### PR TITLE
feat(domain): add Portfolio model for investment account aggregation

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -79,7 +79,7 @@
       <!-- Indentation -->
       <indentOptions>
         <option name="INDENT_SIZE" value="4" />
-        <option name="CONTINUATION_INDENT_SIZE" value="8" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
         <option name="TAB_SIZE" value="4" />
         <option name="USE_TAB_CHARACTER" value="false" />
         <option name="SMART_TABS" value="false" />

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.zip

--- a/mvnw
+++ b/mvnw
@@ -1,0 +1,295 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.4
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -1,0 +1,189 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.4
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+
+$MAVEN_M2_PATH = "$HOME/.m2"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_M2_PATH = "$env:MAVEN_USER_HOME"
+}
+
+if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
+    New-Item -Path $MAVEN_M2_PATH -ItemType Directory | Out-Null
+}
+
+$MAVEN_WRAPPER_DISTS = $null
+if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+} else {
+  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+}
+
+$MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.SHA256]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+$actualDistributionDir = ""
+
+# First try the expected directory name (for regular distributions)
+$expectedPath = Join-Path "$TMP_DOWNLOAD_DIR" "$distributionUrlNameMain"
+$expectedMvnPath = Join-Path "$expectedPath" "bin/$MVN_CMD"
+if ((Test-Path -Path $expectedPath -PathType Container) -and (Test-Path -Path $expectedMvnPath -PathType Leaf)) {
+  $actualDistributionDir = $distributionUrlNameMain
+}
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if (!$actualDistributionDir) {
+  Get-ChildItem -Path "$TMP_DOWNLOAD_DIR" -Directory | ForEach-Object {
+    $testPath = Join-Path $_.FullName "bin/$MVN_CMD"
+    if (Test-Path -Path $testPath -PathType Leaf) {
+      $actualDistributionDir = $_.Name
+    }
+  }
+}
+
+if (!$actualDistributionDir) {
+  Write-Error "Could not find Maven distribution directory in extracted archive"
+}
+
+Write-Verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$actualDistributionDir" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/src/main/java/io/github/xmljim/retirement/domain/model/InvestmentAccount.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/model/InvestmentAccount.java
@@ -225,11 +225,11 @@ public final class InvestmentAccount {
      */
     public Builder toBuilder() {
         Builder builder = new Builder()
-                .id(this.id)
-                .name(this.name)
-                .accountType(this.accountType)
-                .balance(this.balance)
-                .allocation(this.allocation);
+            .id(this.id)
+            .name(this.name)
+            .accountType(this.accountType)
+            .balance(this.balance)
+            .allocation(this.allocation);
 
         if (useAllocationBasedReturn) {
             builder.useAllocationBasedReturn();

--- a/src/main/java/io/github/xmljim/retirement/domain/model/PersonProfile.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/model/PersonProfile.java
@@ -180,13 +180,13 @@ public final class PersonProfile {
      */
     public Builder toBuilder() {
         return new Builder()
-                .id(this.id)
-                .name(this.name)
-                .dateOfBirth(this.dateOfBirth)
-                .retirementDate(this.retirementDate)
-                .lifeExpectancy(this.lifeExpectancy)
-                .socialSecurityStartDate(this.socialSecurityStartDate)
-                .spouse(this.spouse);
+            .id(this.id)
+            .name(this.name)
+            .dateOfBirth(this.dateOfBirth)
+            .retirementDate(this.retirementDate)
+            .lifeExpectancy(this.lifeExpectancy)
+            .socialSecurityStartDate(this.socialSecurityStartDate)
+            .spouse(this.spouse);
     }
 
     @Override

--- a/src/main/java/io/github/xmljim/retirement/domain/model/Portfolio.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/model/Portfolio.java
@@ -1,0 +1,452 @@
+package io.github.xmljim.retirement.domain.model;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import io.github.xmljim.retirement.domain.enums.AccountType;
+import io.github.xmljim.retirement.domain.value.AssetAllocation;
+
+/**
+ * Represents a portfolio containing multiple investment accounts.
+ *
+ * <p>A Portfolio is owned by a {@link PersonProfile} and contains a collection
+ * of {@link InvestmentAccount} objects. It provides aggregation methods for
+ * calculating total balances, balances by account type or tax treatment,
+ * and overall asset allocation across all accounts.
+ *
+ * <p>Use the {@link Builder} to create instances:
+ * <pre>{@code
+ * Portfolio portfolio = Portfolio.builder()
+ *     .owner(personProfile)
+ *     .addAccount(account401k)
+ *     .addAccount(rothIra)
+ *     .build();
+ * }</pre>
+ */
+public final class Portfolio {
+
+    private static final int SCALE = 6;
+
+    private final String id;
+    private final PersonProfile owner;
+    private final List<InvestmentAccount> accounts;
+
+    private Portfolio(Builder builder) {
+        this.id = builder.id != null ? builder.id : UUID.randomUUID().toString();
+        this.owner = builder.owner;
+        this.accounts = Collections.unmodifiableList(new ArrayList<>(builder.accounts));
+    }
+
+    /**
+     * Returns the unique identifier for this portfolio.
+     *
+     * @return the portfolio ID
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Returns the owner of this portfolio.
+     *
+     * @return the owner's PersonProfile
+     */
+    public PersonProfile getOwner() {
+        return owner;
+    }
+
+    /**
+     * Returns an unmodifiable list of accounts in this portfolio.
+     *
+     * @return the list of investment accounts
+     */
+    public List<InvestmentAccount> getAccounts() {
+        return accounts;
+    }
+
+    /**
+     * Returns the number of accounts in this portfolio.
+     *
+     * @return the account count
+     */
+    public int getAccountCount() {
+        return accounts.size();
+    }
+
+    /**
+     * Indicates whether this portfolio has any accounts.
+     *
+     * @return true if the portfolio has at least one account
+     */
+    public boolean hasAccounts() {
+        return !accounts.isEmpty();
+    }
+
+    /**
+     * Finds an account by its ID.
+     *
+     * @param accountId the account ID to find
+     * @return an Optional containing the account, or empty if not found
+     */
+    public Optional<InvestmentAccount> findAccountById(String accountId) {
+        return accounts.stream()
+                .filter(a -> a.getId().equals(accountId))
+                .findFirst();
+    }
+
+    /**
+     * Returns all accounts of a specific type.
+     *
+     * @param accountType the account type to filter by
+     * @return list of accounts matching the type
+     */
+    public List<InvestmentAccount> getAccountsByType(AccountType accountType) {
+        return accounts.stream()
+                .filter(a -> a.getAccountType() == accountType)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns all accounts with a specific tax treatment.
+     *
+     * @param taxTreatment the tax treatment to filter by
+     * @return list of accounts matching the tax treatment
+     */
+    public List<InvestmentAccount> getAccountsByTaxTreatment(AccountType.TaxTreatment taxTreatment) {
+        return accounts.stream()
+                .filter(a -> a.getTaxTreatment() == taxTreatment)
+                .collect(Collectors.toList());
+    }
+
+    // ==================== Balance Aggregation ====================
+
+    /**
+     * Calculates the total balance across all accounts.
+     *
+     * @return the total portfolio balance
+     */
+    public BigDecimal getTotalBalance() {
+        return accounts.stream()
+                .map(InvestmentAccount::getBalance)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    /**
+     * Calculates the total balance for accounts of a specific type.
+     *
+     * @param accountType the account type to sum
+     * @return the total balance for that account type
+     */
+    public BigDecimal getBalanceByType(AccountType accountType) {
+        return accounts.stream()
+                .filter(a -> a.getAccountType() == accountType)
+                .map(InvestmentAccount::getBalance)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    /**
+     * Calculates the total balance grouped by account type.
+     *
+     * @return a map of account type to total balance
+     */
+    public Map<AccountType, BigDecimal> getBalancesByType() {
+        return accounts.stream()
+                .collect(Collectors.groupingBy(
+                        InvestmentAccount::getAccountType,
+                        Collectors.reducing(
+                                BigDecimal.ZERO,
+                                InvestmentAccount::getBalance,
+                                BigDecimal::add
+                        )
+                ));
+    }
+
+    /**
+     * Calculates the total balance for accounts with a specific tax treatment.
+     *
+     * @param taxTreatment the tax treatment to sum
+     * @return the total balance for that tax treatment
+     */
+    public BigDecimal getBalanceByTaxTreatment(AccountType.TaxTreatment taxTreatment) {
+        return accounts.stream()
+                .filter(a -> a.getTaxTreatment() == taxTreatment)
+                .map(InvestmentAccount::getBalance)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    /**
+     * Calculates the total balance grouped by tax treatment.
+     *
+     * @return a map of tax treatment to total balance
+     */
+    public Map<AccountType.TaxTreatment, BigDecimal> getBalancesByTaxTreatment() {
+        return accounts.stream()
+                .collect(Collectors.groupingBy(
+                        InvestmentAccount::getTaxTreatment,
+                        Collectors.reducing(
+                                BigDecimal.ZERO,
+                                InvestmentAccount::getBalance,
+                                BigDecimal::add
+                        )
+                ));
+    }
+
+    // ==================== Allocation Methods ====================
+
+    /**
+     * Calculates the overall asset allocation weighted by account balances.
+     *
+     * <p>Each account's allocation is weighted by its balance relative to
+     * the total portfolio balance.
+     *
+     * @return the weighted average asset allocation, or a zero allocation if empty
+     */
+    public AssetAllocation getOverallAllocation() {
+        BigDecimal totalBalance = getTotalBalance();
+
+        if (totalBalance.compareTo(BigDecimal.ZERO) == 0) {
+            return AssetAllocation.of(0, 0, 100);
+        }
+
+        BigDecimal weightedStocks = BigDecimal.ZERO;
+        BigDecimal weightedBonds = BigDecimal.ZERO;
+        BigDecimal weightedCash = BigDecimal.ZERO;
+
+        for (InvestmentAccount account : accounts) {
+            BigDecimal weight = account.getBalance()
+                    .divide(totalBalance, SCALE, RoundingMode.HALF_UP);
+
+            weightedStocks = weightedStocks.add(
+                    account.getAllocation().getStocksPercentage().multiply(weight));
+            weightedBonds = weightedBonds.add(
+                    account.getAllocation().getBondsPercentage().multiply(weight));
+            weightedCash = weightedCash.add(
+                    account.getAllocation().getCashPercentage().multiply(weight));
+        }
+
+        // Round to ensure they sum to 100
+        double stocks = weightedStocks.setScale(2, RoundingMode.HALF_UP).doubleValue();
+        double bonds = weightedBonds.setScale(2, RoundingMode.HALF_UP).doubleValue();
+        double cash = 100.0 - stocks - bonds;
+
+        return AssetAllocation.of(stocks, bonds, Math.max(0, cash));
+    }
+
+    /**
+     * Calculates the blended pre-retirement return rate weighted by balances.
+     *
+     * @return the weighted average pre-retirement return rate
+     */
+    public BigDecimal getBlendedPreRetirementReturnRate() {
+        return calculateBlendedReturnRate(true);
+    }
+
+    /**
+     * Calculates the blended post-retirement return rate weighted by balances.
+     *
+     * @return the weighted average post-retirement return rate
+     */
+    public BigDecimal getBlendedPostRetirementReturnRate() {
+        return calculateBlendedReturnRate(false);
+    }
+
+    private BigDecimal calculateBlendedReturnRate(boolean preRetirement) {
+        BigDecimal totalBalance = getTotalBalance();
+
+        if (totalBalance.compareTo(BigDecimal.ZERO) == 0) {
+            return BigDecimal.ZERO;
+        }
+
+        BigDecimal weightedReturn = BigDecimal.ZERO;
+
+        for (InvestmentAccount account : accounts) {
+            BigDecimal weight = account.getBalance()
+                    .divide(totalBalance, SCALE, RoundingMode.HALF_UP);
+
+            BigDecimal accountReturn = preRetirement
+                    ? account.getPreRetirementReturnRate()
+                    : account.getPostRetirementReturnRate();
+
+            weightedReturn = weightedReturn.add(accountReturn.multiply(weight));
+        }
+
+        return weightedReturn.setScale(SCALE, RoundingMode.HALF_UP);
+    }
+
+    // ==================== Portfolio Modification ====================
+
+    /**
+     * Creates a new portfolio with an additional account.
+     *
+     * @param account the account to add
+     * @return a new Portfolio with the account added
+     * @throws IllegalArgumentException if account ID already exists
+     */
+    public Portfolio withAccount(InvestmentAccount account) {
+        return toBuilder().addAccount(account).build();
+    }
+
+    /**
+     * Creates a new portfolio without the specified account.
+     *
+     * @param accountId the ID of the account to remove
+     * @return a new Portfolio without the account
+     */
+    public Portfolio withoutAccount(String accountId) {
+        List<InvestmentAccount> filtered = accounts.stream()
+                .filter(a -> !a.getId().equals(accountId))
+                .collect(Collectors.toList());
+
+        return toBuilder()
+                .clearAccounts()
+                .addAccounts(filtered)
+                .build();
+    }
+
+    /**
+     * Creates a new builder for Portfolio.
+     *
+     * @return a new builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Creates a builder initialized with values from this portfolio.
+     *
+     * @return a new builder with copied values
+     */
+    public Builder toBuilder() {
+        return new Builder()
+                .id(this.id)
+                .owner(this.owner)
+                .addAccounts(this.accounts);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Portfolio portfolio = (Portfolio) o;
+        return Objects.equals(id, portfolio.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public String toString() {
+        return "Portfolio{" +
+                "id='" + id + '\'' +
+                ", owner=" + owner.getName() +
+                ", accounts=" + accounts.size() +
+                ", totalBalance=" + getTotalBalance() +
+                '}';
+    }
+
+    /**
+     * Builder for creating Portfolio instances.
+     */
+    public static class Builder {
+        private String id;
+        private PersonProfile owner;
+        private final List<InvestmentAccount> accounts = new ArrayList<>();
+        private final Set<String> accountIds = new HashSet<>();
+
+        /**
+         * Sets the portfolio ID.
+         *
+         * @param id the portfolio ID
+         * @return this builder
+         */
+        public Builder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        /**
+         * Sets the portfolio owner.
+         *
+         * @param owner the owner's PersonProfile
+         * @return this builder
+         */
+        public Builder owner(PersonProfile owner) {
+            this.owner = owner;
+            return this;
+        }
+
+        /**
+         * Adds an investment account to the portfolio.
+         *
+         * @param account the account to add
+         * @return this builder
+         * @throws IllegalArgumentException if account ID already exists
+         */
+        public Builder addAccount(InvestmentAccount account) {
+            Objects.requireNonNull(account, "Account cannot be null");
+
+            if (accountIds.contains(account.getId())) {
+                throw new IllegalArgumentException(
+                        "Duplicate account ID: " + account.getId());
+            }
+
+            accounts.add(account);
+            accountIds.add(account.getId());
+            return this;
+        }
+
+        /**
+         * Adds multiple investment accounts to the portfolio.
+         *
+         * @param accounts the accounts to add
+         * @return this builder
+         */
+        public Builder addAccounts(List<InvestmentAccount> accounts) {
+            accounts.forEach(this::addAccount);
+            return this;
+        }
+
+        /**
+         * Clears all accounts from the builder.
+         *
+         * @return this builder
+         */
+        public Builder clearAccounts() {
+            this.accounts.clear();
+            this.accountIds.clear();
+            return this;
+        }
+
+        /**
+         * Builds the Portfolio instance.
+         *
+         * @return a new Portfolio
+         * @throws NullPointerException if owner is not set
+         */
+        public Portfolio build() {
+            validate();
+            return new Portfolio(this);
+        }
+
+        private void validate() {
+            Objects.requireNonNull(owner, "Owner is required");
+        }
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/domain/model/Portfolio.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/model/Portfolio.java
@@ -100,8 +100,8 @@ public final class Portfolio {
      */
     public Optional<InvestmentAccount> findAccountById(String accountId) {
         return accounts.stream()
-                .filter(a -> a.getId().equals(accountId))
-                .findFirst();
+            .filter(a -> a.getId().equals(accountId))
+            .findFirst();
     }
 
     /**
@@ -112,8 +112,8 @@ public final class Portfolio {
      */
     public List<InvestmentAccount> getAccountsByType(AccountType accountType) {
         return accounts.stream()
-                .filter(a -> a.getAccountType() == accountType)
-                .collect(Collectors.toList());
+            .filter(a -> a.getAccountType() == accountType)
+            .collect(Collectors.toList());
     }
 
     /**
@@ -124,8 +124,8 @@ public final class Portfolio {
      */
     public List<InvestmentAccount> getAccountsByTaxTreatment(AccountType.TaxTreatment taxTreatment) {
         return accounts.stream()
-                .filter(a -> a.getTaxTreatment() == taxTreatment)
-                .collect(Collectors.toList());
+            .filter(a -> a.getTaxTreatment() == taxTreatment)
+            .collect(Collectors.toList());
     }
 
     // ==================== Balance Aggregation ====================
@@ -137,8 +137,8 @@ public final class Portfolio {
      */
     public BigDecimal getTotalBalance() {
         return accounts.stream()
-                .map(InvestmentAccount::getBalance)
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
+            .map(InvestmentAccount::getBalance)
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
     }
 
     /**
@@ -149,9 +149,9 @@ public final class Portfolio {
      */
     public BigDecimal getBalanceByType(AccountType accountType) {
         return accounts.stream()
-                .filter(a -> a.getAccountType() == accountType)
-                .map(InvestmentAccount::getBalance)
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
+            .filter(a -> a.getAccountType() == accountType)
+            .map(InvestmentAccount::getBalance)
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
     }
 
     /**
@@ -161,14 +161,14 @@ public final class Portfolio {
      */
     public Map<AccountType, BigDecimal> getBalancesByType() {
         return accounts.stream()
-                .collect(Collectors.groupingBy(
-                        InvestmentAccount::getAccountType,
-                        Collectors.reducing(
-                                BigDecimal.ZERO,
-                                InvestmentAccount::getBalance,
-                                BigDecimal::add
-                        )
-                ));
+            .collect(Collectors.groupingBy(
+                InvestmentAccount::getAccountType,
+                Collectors.reducing(
+                    BigDecimal.ZERO,
+                    InvestmentAccount::getBalance,
+                    BigDecimal::add
+                )
+            ));
     }
 
     /**
@@ -179,9 +179,9 @@ public final class Portfolio {
      */
     public BigDecimal getBalanceByTaxTreatment(AccountType.TaxTreatment taxTreatment) {
         return accounts.stream()
-                .filter(a -> a.getTaxTreatment() == taxTreatment)
-                .map(InvestmentAccount::getBalance)
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
+            .filter(a -> a.getTaxTreatment() == taxTreatment)
+            .map(InvestmentAccount::getBalance)
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
     }
 
     /**
@@ -191,14 +191,14 @@ public final class Portfolio {
      */
     public Map<AccountType.TaxTreatment, BigDecimal> getBalancesByTaxTreatment() {
         return accounts.stream()
-                .collect(Collectors.groupingBy(
-                        InvestmentAccount::getTaxTreatment,
-                        Collectors.reducing(
-                                BigDecimal.ZERO,
-                                InvestmentAccount::getBalance,
-                                BigDecimal::add
-                        )
-                ));
+            .collect(Collectors.groupingBy(
+                InvestmentAccount::getTaxTreatment,
+                Collectors.reducing(
+                    BigDecimal.ZERO,
+                    InvestmentAccount::getBalance,
+                    BigDecimal::add
+                )
+            ));
     }
 
     // ==================== Allocation Methods ====================
@@ -314,13 +314,13 @@ public final class Portfolio {
      */
     public Portfolio withoutAccount(String accountId) {
         List<InvestmentAccount> filtered = accounts.stream()
-                .filter(a -> !a.getId().equals(accountId))
-                .collect(Collectors.toList());
+            .filter(a -> !a.getId().equals(accountId))
+            .collect(Collectors.toList());
 
         return toBuilder()
-                .clearAccounts()
-                .addAccounts(filtered)
-                .build();
+            .clearAccounts()
+            .addAccounts(filtered)
+            .build();
     }
 
     /**
@@ -339,9 +339,9 @@ public final class Portfolio {
      */
     public Builder toBuilder() {
         return new Builder()
-                .id(this.id)
-                .owner(this.owner)
-                .addAccounts(this.accounts);
+            .id(this.id)
+            .owner(this.owner)
+            .addAccounts(this.accounts);
     }
 
     @Override

--- a/src/main/java/io/github/xmljim/retirement/domain/value/AssetAllocation.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/value/AssetAllocation.java
@@ -51,10 +51,10 @@ public final class AssetAllocation {
      */
     public static AssetAllocation of(double stocks, double bonds, double cash) {
         return builder()
-                .stocks(stocks)
-                .bonds(bonds)
-                .cash(cash)
-                .build();
+            .stocks(stocks)
+            .bonds(bonds)
+            .cash(cash)
+            .build();
     }
 
     /**
@@ -91,9 +91,9 @@ public final class AssetAllocation {
      */
     public static AssetAllocation balanced() {
         return new AssetAllocation(
-                new BigDecimal("60"),
-                new BigDecimal("40"),
-                BigDecimal.ZERO
+            new BigDecimal("60"),
+            new BigDecimal("40"),
+            BigDecimal.ZERO
         );
     }
 
@@ -144,14 +144,14 @@ public final class AssetAllocation {
     public BigDecimal calculateBlendedReturn(BigDecimal stockReturn, BigDecimal bondReturn,
                                              BigDecimal cashReturn) {
         BigDecimal stockContribution = stocksPercentage
-                .multiply(stockReturn)
-                .divide(HUNDRED, SCALE, RoundingMode.HALF_UP);
+            .multiply(stockReturn)
+            .divide(HUNDRED, SCALE, RoundingMode.HALF_UP);
         BigDecimal bondContribution = bondsPercentage
-                .multiply(bondReturn)
-                .divide(HUNDRED, SCALE, RoundingMode.HALF_UP);
+            .multiply(bondReturn)
+            .divide(HUNDRED, SCALE, RoundingMode.HALF_UP);
         BigDecimal cashContribution = cashPercentage
-                .multiply(cashReturn)
-                .divide(HUNDRED, SCALE, RoundingMode.HALF_UP);
+            .multiply(cashReturn)
+            .divide(HUNDRED, SCALE, RoundingMode.HALF_UP);
 
         return stockContribution.add(bondContribution).add(cashContribution);
     }

--- a/src/test/java/io/github/xmljim/retirement/domain/model/PortfolioTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/model/PortfolioTest.java
@@ -1,0 +1,246 @@
+package io.github.xmljim.retirement.domain.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.github.xmljim.retirement.domain.enums.AccountType;
+import io.github.xmljim.retirement.domain.value.AssetAllocation;
+
+@DisplayName("Portfolio Tests")
+class PortfolioTest {
+
+    private PersonProfile owner;
+    private InvestmentAccount account401k;
+    private InvestmentAccount rothIra;
+    private InvestmentAccount taxable;
+
+    @BeforeEach
+    void setUp() {
+        owner = PersonProfile.builder()
+                .name("John Doe")
+                .dateOfBirth(LocalDate.of(1970, 5, 15))
+                .retirementDate(LocalDate.of(2035, 1, 1))
+                .build();
+
+        account401k = InvestmentAccount.builder()
+                .name("Company 401(k)")
+                .accountType(AccountType.TRADITIONAL_401K)
+                .balance(new BigDecimal("200000"))
+                .allocation(AssetAllocation.of(70, 25, 5))
+                .preRetirementReturnRate(0.07)
+                .build();
+
+        rothIra = InvestmentAccount.builder()
+                .name("Roth IRA")
+                .accountType(AccountType.ROTH_IRA)
+                .balance(new BigDecimal("100000"))
+                .allocation(AssetAllocation.of(80, 15, 5))
+                .preRetirementReturnRate(0.08)
+                .build();
+
+        taxable = InvestmentAccount.builder()
+                .name("Brokerage")
+                .accountType(AccountType.TAXABLE_BROKERAGE)
+                .balance(new BigDecimal("50000"))
+                .allocation(AssetAllocation.of(60, 30, 10))
+                .preRetirementReturnRate(0.06)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("Builder Tests")
+    class BuilderTests {
+
+        @Test
+        @DisplayName("Should create portfolio with owner and accounts")
+        void createWithOwnerAndAccounts() {
+            Portfolio portfolio = Portfolio.builder()
+                    .owner(owner)
+                    .addAccount(account401k)
+                    .addAccount(rothIra)
+                    .build();
+
+            assertEquals(owner, portfolio.getOwner());
+            assertEquals(2, portfolio.getAccountCount());
+            assertNotNull(portfolio.getId());
+        }
+
+        @Test
+        @DisplayName("Should throw exception when owner is missing")
+        void missingOwner() {
+            assertThrows(NullPointerException.class, () ->
+                    Portfolio.builder().addAccount(account401k).build());
+        }
+
+        @Test
+        @DisplayName("Should throw exception for duplicate account ID")
+        void duplicateAccountId() {
+            assertThrows(IllegalArgumentException.class, () ->
+                    Portfolio.builder()
+                            .owner(owner)
+                            .addAccount(account401k)
+                            .addAccount(account401k)
+                            .build());
+        }
+
+        @Test
+        @DisplayName("Should allow empty portfolio")
+        void emptyPortfolio() {
+            Portfolio portfolio = Portfolio.builder().owner(owner).build();
+            assertFalse(portfolio.hasAccounts());
+            assertEquals(0, portfolio.getAccountCount());
+        }
+    }
+
+    @Nested
+    @DisplayName("Balance Aggregation Tests")
+    class BalanceTests {
+
+        @Test
+        @DisplayName("Should calculate total balance")
+        void totalBalance() {
+            Portfolio portfolio = createFullPortfolio();
+            assertEquals(0, new BigDecimal("350000").compareTo(portfolio.getTotalBalance()));
+        }
+
+        @Test
+        @DisplayName("Should calculate balance by account type")
+        void balanceByType() {
+            Portfolio portfolio = createFullPortfolio();
+            assertEquals(0, new BigDecimal("200000")
+                    .compareTo(portfolio.getBalanceByType(AccountType.TRADITIONAL_401K)));
+        }
+
+        @Test
+        @DisplayName("Should calculate balances by tax treatment")
+        void balancesByTaxTreatment() {
+            Portfolio portfolio = createFullPortfolio();
+            Map<AccountType.TaxTreatment, BigDecimal> balances = portfolio.getBalancesByTaxTreatment();
+
+            assertEquals(0, new BigDecimal("200000")
+                    .compareTo(balances.get(AccountType.TaxTreatment.PRE_TAX)));
+            assertEquals(0, new BigDecimal("100000")
+                    .compareTo(balances.get(AccountType.TaxTreatment.ROTH)));
+            assertEquals(0, new BigDecimal("50000")
+                    .compareTo(balances.get(AccountType.TaxTreatment.TAXABLE)));
+        }
+    }
+
+    @Nested
+    @DisplayName("Allocation Tests")
+    class AllocationTests {
+
+        @Test
+        @DisplayName("Should calculate weighted overall allocation")
+        void overallAllocation() {
+            Portfolio portfolio = createFullPortfolio();
+            AssetAllocation overall = portfolio.getOverallAllocation();
+
+            // Weighted: (200k*70 + 100k*80 + 50k*60) / 350k = 71.43% stocks
+            assertTrue(overall.getStocksPercentage().doubleValue() > 70);
+            assertTrue(overall.getStocksPercentage().doubleValue() < 73);
+        }
+
+        @Test
+        @DisplayName("Should calculate blended return rate")
+        void blendedReturnRate() {
+            Portfolio portfolio = createFullPortfolio();
+            BigDecimal blended = portfolio.getBlendedPreRetirementReturnRate();
+
+            // Weighted: (200k*0.07 + 100k*0.08 + 50k*0.06) / 350k ≈ 0.0714
+            assertTrue(blended.doubleValue() > 0.07);
+            assertTrue(blended.doubleValue() < 0.075);
+        }
+    }
+
+    @Nested
+    @DisplayName("Account Lookup Tests")
+    class LookupTests {
+
+        @Test
+        @DisplayName("Should find account by ID")
+        void findById() {
+            Portfolio portfolio = createFullPortfolio();
+            assertTrue(portfolio.findAccountById(account401k.getId()).isPresent());
+            assertFalse(portfolio.findAccountById("non-existent").isPresent());
+        }
+
+        @Test
+        @DisplayName("Should filter accounts by type")
+        void filterByType() {
+            Portfolio portfolio = createFullPortfolio();
+            assertEquals(1, portfolio.getAccountsByType(AccountType.ROTH_IRA).size());
+        }
+    }
+
+    @Nested
+    @DisplayName("Modification Tests")
+    class ModificationTests {
+
+        @Test
+        @DisplayName("Should create new portfolio with added account")
+        void withAccount() {
+            Portfolio original = Portfolio.builder().owner(owner).addAccount(account401k).build();
+            Portfolio updated = original.withAccount(rothIra);
+
+            assertEquals(1, original.getAccountCount());
+            assertEquals(2, updated.getAccountCount());
+        }
+
+        @Test
+        @DisplayName("Should create new portfolio without account")
+        void withoutAccount() {
+            Portfolio original = createFullPortfolio();
+            Portfolio updated = original.withoutAccount(taxable.getId());
+
+            assertEquals(3, original.getAccountCount());
+            assertEquals(2, updated.getAccountCount());
+        }
+    }
+
+    @Nested
+    @DisplayName("Equals and HashCode Tests")
+    class EqualsTests {
+
+        @Test
+        @DisplayName("Portfolios with same ID should be equal")
+        void sameIdEquals() {
+            Portfolio p1 = Portfolio.builder().id("same-id").owner(owner).build();
+            Portfolio p2 = Portfolio.builder().id("same-id").owner(owner).addAccount(account401k).build();
+
+            assertEquals(p1, p2);
+            assertEquals(p1.hashCode(), p2.hashCode());
+        }
+
+        @Test
+        @DisplayName("Portfolios with different IDs should not be equal")
+        void differentIdNotEquals() {
+            Portfolio p1 = Portfolio.builder().owner(owner).build();
+            Portfolio p2 = Portfolio.builder().owner(owner).build();
+
+            assertNotEquals(p1, p2);
+        }
+    }
+
+    private Portfolio createFullPortfolio() {
+        return Portfolio.builder()
+                .owner(owner)
+                .addAccount(account401k)
+                .addAccount(rothIra)
+                .addAccount(taxable)
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary

Implements the Portfolio domain model (#5) as a container for multiple investment accounts.

## Related Issues

- Fixes #5 - Create Portfolio domain model

## Changes Made

### Portfolio Model
- Owner reference to PersonProfile
- Collection of InvestmentAccount objects
- Add/remove account methods (immutable - returns new instance)
- Find account by ID, filter by type or tax treatment

### Balance Aggregation
- Total balance across all accounts
- Balance by account type
- Balance by tax treatment (pre-tax, Roth, taxable)
- Map-based groupings for reporting

### Allocation Methods
- Weighted overall asset allocation across accounts
- Blended pre-retirement return rate
- Blended post-retirement return rate

### Validation
- No duplicate account IDs
- Owner required

## Testing

- [x] Builder tests
- [x] Balance aggregation tests
- [x] Allocation calculation tests
- [x] Account lookup tests
- [x] Modification (immutability) tests
- [x] Equals/hashCode tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)