### PR TITLE
feat(#123): Implement SECURE 2.0 contribution rules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,15 +12,53 @@
         <maven.compiler.source>25</maven.compiler.source>
         <maven.compiler.target>25</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spring-boot.version>3.4.5</spring-boot.version>
     </properties>
 
-    <dependencies>
-        <!-- Other dependencies ... -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
+    <dependencies>
+        <!-- Spring Boot -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <!-- Spring Boot Configuration Processor -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- SpotBugs Annotations -->
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <version>4.9.3</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Testing -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.10.2</version> <!-- Use the latest version or a property -->
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/github/xmljim/retirement/domain/calculator/IrsContributionRules.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/calculator/IrsContributionRules.java
@@ -1,0 +1,159 @@
+package io.github.xmljim.retirement.domain.calculator;
+
+import java.math.BigDecimal;
+
+import io.github.xmljim.retirement.domain.enums.AccountType;
+import io.github.xmljim.retirement.domain.enums.ContributionType;
+import io.github.xmljim.retirement.domain.value.MatchingPolicy;
+
+/**
+ * Base interface for IRS contribution rule calculators.
+ *
+ * <p>Different implementations handle different versions of IRS rules
+ * (e.g., SECURE Act, SECURE 2.0, future legislation). This interface
+ * provides a common contract for calculating contribution limits and
+ * determining ROTH allocation requirements.
+ *
+ * <p><strong>Important:</strong> All limits calculated by this interface are for
+ * <em>employee contributions only</em>. Employer matching contributions do NOT
+ * count against these limits - they are tracked separately.
+ *
+ * <p>Key SECURE 2.0 rules (effective 2025):
+ * <ul>
+ *   <li>Standard catch-up: Age 50+ can contribute additional $7,500</li>
+ *   <li>Super catch-up: Age 60-63 can contribute additional $11,250</li>
+ *   <li>High earners ($145K+): Catch-up must go to ROTH</li>
+ *   <li>Employer contributions: Always go to Traditional account</li>
+ * </ul>
+ *
+ * @see io.github.xmljim.retirement.domain.calculator.impl.Secure2ContributionRules
+ */
+public interface IrsContributionRules {
+
+    /**
+     * Returns the name/version of the rules.
+     *
+     * @return the rules version (e.g., "SECURE 2.0")
+     */
+    String getRulesVersion();
+
+    /**
+     * Calculates the total annual employee contribution limit for an individual.
+     *
+     * <p>This includes the base limit plus any applicable catch-up contribution.
+     * The limit depends on the person's age and the year.
+     *
+     * <p><strong>Note:</strong> This is the employee contribution limit only.
+     * Employer matching contributions do not count against this limit.
+     *
+     * @param contributionYear the tax year
+     * @param age the person's age during the contribution year
+     * @param accountType the type of account (may affect limits for some account types)
+     * @return the maximum annual employee contribution
+     */
+    BigDecimal calculateAnnualContributionLimit(
+        int contributionYear,
+        int age,
+        AccountType accountType);
+
+    /**
+     * Calculates the catch-up contribution limit if eligible.
+     *
+     * <p>Returns zero if the person is not eligible for catch-up contributions.
+     * For SECURE 2.0:
+     * <ul>
+     *   <li>Age 50-59, 64+: Standard catch-up ($7,500 for 2025)</li>
+     *   <li>Age 60-63 (starting 2025): Super catch-up ($11,250 for 2025)</li>
+     *   <li>Under 50: $0 (not eligible)</li>
+     * </ul>
+     *
+     * @param contributionYear the tax year
+     * @param age the person's age during the contribution year
+     * @param accountType the type of account
+     * @return the catch-up contribution limit
+     */
+    BigDecimal calculateCatchUpLimit(
+        int contributionYear,
+        int age,
+        AccountType accountType);
+
+    /**
+     * Determines if catch-up contributions must go to ROTH.
+     *
+     * <p>Under SECURE 2.0, employees who earned more than $145,000 in the prior
+     * year must make catch-up contributions to a ROTH account.
+     *
+     * @param contributionYear the tax year
+     * @param priorYearIncome the employee's prior year income (W-2 wages)
+     * @return true if catch-up must be ROTH
+     */
+    boolean requiresRothCatchUp(
+        int contributionYear,
+        BigDecimal priorYearIncome);
+
+    /**
+     * Checks if the person is eligible for catch-up contributions.
+     *
+     * @param age the person's age
+     * @return true if eligible for catch-up (age 50+)
+     */
+    boolean isCatchUpEligible(int age);
+
+    /**
+     * Calculates employer match using the specified policy.
+     *
+     * <p><strong>Note:</strong> Employer contributions do NOT count against
+     * the employee's contribution limits. They are tracked separately.
+     *
+     * @param employeeContributionRate the employee's contribution rate
+     * @param policy the employer's matching policy
+     * @return the employer match rate
+     */
+    BigDecimal calculateEmployerMatch(
+        BigDecimal employeeContributionRate,
+        MatchingPolicy policy);
+
+    /**
+     * Determines the target account type for a contribution.
+     *
+     * <p>SECURE 2.0 Rules:
+     * <ul>
+     *   <li>Employer contributions: Always go to Traditional</li>
+     *   <li>Base employee contributions: Follow account default</li>
+     *   <li>Catch-up for high earners ($145K+): Must go to ROTH equivalent</li>
+     *   <li>Catch-up for normal earners: Follow account default</li>
+     * </ul>
+     *
+     * @param contributionType PERSONAL or EMPLOYER
+     * @param isCatchUp true if this is a catch-up contribution
+     * @param priorYearIncome the employee's prior year income
+     * @param contributionYear the tax year
+     * @param accountDefault the account's default type
+     * @return the target AccountType for this contribution
+     */
+    AccountType determineTargetAccountType(
+        ContributionType contributionType,
+        boolean isCatchUp,
+        BigDecimal priorYearIncome,
+        int contributionYear,
+        AccountType accountDefault);
+
+    /**
+     * Calculates the maximum allowed contribution when a ROTH equivalent is not available.
+     *
+     * <p>High earners ($145K+) without a ROTH equivalent account are capped
+     * at the base limit because they cannot make catch-up contributions
+     * to a Traditional account.
+     *
+     * @param year the contribution year
+     * @param age the person's age
+     * @param priorYearIncome the prior year income
+     * @param hasRothEquivalent true if portfolio has a ROTH version of the account
+     * @return the maximum allowed employee contribution
+     */
+    BigDecimal calculateMaxContributionWithoutRoth(
+        int year,
+        int age,
+        BigDecimal priorYearIncome,
+        boolean hasRothEquivalent);
+}

--- a/src/main/java/io/github/xmljim/retirement/domain/calculator/impl/Secure2ContributionRules.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/calculator/impl/Secure2ContributionRules.java
@@ -1,0 +1,222 @@
+package io.github.xmljim.retirement.domain.calculator.impl;
+
+import java.math.BigDecimal;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.github.xmljim.retirement.domain.calculator.IrsContributionRules;
+import io.github.xmljim.retirement.domain.config.IrsContributionLimits;
+import io.github.xmljim.retirement.domain.config.IrsContributionLimits.YearLimits;
+import io.github.xmljim.retirement.domain.enums.AccountType;
+import io.github.xmljim.retirement.domain.enums.ContributionType;
+import io.github.xmljim.retirement.domain.value.MatchingPolicy;
+
+/**
+ * Implementation of SECURE 2.0 contribution rules.
+ *
+ * <p>This implementation handles:
+ * <ul>
+ *   <li>Standard catch-up contributions for age 50+</li>
+ *   <li>Super catch-up contributions for age 60-63 (effective 2025)</li>
+ *   <li>ROTH-only catch-up for high earners ($145K+)</li>
+ *   <li>Employer contribution routing (always to Traditional)</li>
+ * </ul>
+ *
+ * <p><strong>Important:</strong> All contribution limits are for employee
+ * contributions only. Employer matching contributions do NOT count against
+ * these limits.
+ *
+ * <p>ROTH Allocation Rules for High Earners ($145K+ prior year income):
+ * <ul>
+ *   <li>Base contribution (up to base limit): Can go to Traditional</li>
+ *   <li>Catch-up contribution: MUST go to ROTH</li>
+ *   <li>If no ROTH account exists: Capped at base limit (no catch-up)</li>
+ * </ul>
+ */
+@Service
+public class Secure2ContributionRules implements IrsContributionRules {
+
+    private static final String VERSION = "SECURE 2.0";
+    private static final int CATCH_UP_AGE = 50;
+    private static final int SUPER_CATCH_UP_MIN_AGE = 60;
+    private static final int SUPER_CATCH_UP_MAX_AGE = 63;
+    private static final int SUPER_CATCH_UP_EFFECTIVE_YEAR = 2025;
+
+    private final IrsContributionLimits limits;
+
+    /**
+     * Creates a new SECURE 2.0 contribution rules calculator.
+     *
+     * @param limits the IRS contribution limits configuration
+     */
+    @Autowired
+    @SuppressFBWarnings(
+        value = "EI_EXPOSE_REP2",
+        justification = "IrsContributionLimits is a Spring-managed singleton bean"
+    )
+    public Secure2ContributionRules(IrsContributionLimits limits) {
+        this.limits = limits;
+    }
+
+    @Override
+    public String getRulesVersion() {
+        return VERSION;
+    }
+
+    @Override
+    public BigDecimal calculateAnnualContributionLimit(
+            int contributionYear, int age, AccountType accountType) {
+
+        YearLimits yearLimits = limits.getLimitsForYear(contributionYear);
+        BigDecimal baseLimit = yearLimits.baseLimit();
+        BigDecimal catchUpLimit = calculateCatchUpLimit(contributionYear, age, accountType);
+
+        return baseLimit.add(catchUpLimit);
+    }
+
+    @Override
+    public BigDecimal calculateCatchUpLimit(
+            int contributionYear, int age, AccountType accountType) {
+
+        if (!isCatchUpEligible(age)) {
+            return BigDecimal.ZERO;
+        }
+
+        YearLimits yearLimits = limits.getLimitsForYear(contributionYear);
+
+        // Super catch-up for ages 60-63, only starting 2025
+        if (isSuperCatchUpEligible(contributionYear, age)) {
+            return yearLimits.superCatchUpLimit();
+        }
+
+        return yearLimits.catchUpLimit();
+    }
+
+    @Override
+    public boolean requiresRothCatchUp(int contributionYear, BigDecimal priorYearIncome) {
+        if (priorYearIncome == null) {
+            return false;
+        }
+
+        YearLimits yearLimits = limits.getLimitsForYear(contributionYear);
+        return priorYearIncome.compareTo(yearLimits.rothCatchUpIncomeThreshold()) > 0;
+    }
+
+    @Override
+    public boolean isCatchUpEligible(int age) {
+        return age >= CATCH_UP_AGE;
+    }
+
+    /**
+     * Checks if the person is eligible for super catch-up contributions.
+     *
+     * <p>Super catch-up is available for ages 60-63, effective starting in 2025.
+     *
+     * @param contributionYear the tax year
+     * @param age the person's age
+     * @return true if eligible for super catch-up
+     */
+    public boolean isSuperCatchUpEligible(int contributionYear, int age) {
+        return contributionYear >= SUPER_CATCH_UP_EFFECTIVE_YEAR
+            && age >= SUPER_CATCH_UP_MIN_AGE
+            && age <= SUPER_CATCH_UP_MAX_AGE;
+    }
+
+    @Override
+    public BigDecimal calculateEmployerMatch(
+            BigDecimal employeeContributionRate, MatchingPolicy policy) {
+
+        if (policy == null) {
+            return BigDecimal.ZERO;
+        }
+        return policy.calculateEmployerMatch(employeeContributionRate);
+    }
+
+    @Override
+    public AccountType determineTargetAccountType(
+            ContributionType contributionType,
+            boolean isCatchUp,
+            BigDecimal priorYearIncome,
+            int contributionYear,
+            AccountType accountDefault) {
+
+        // Rule 1: Employer contributions ALWAYS go to Traditional
+        if (contributionType == ContributionType.EMPLOYER) {
+            return toTraditionalVariant(accountDefault);
+        }
+
+        // Rule 2: Catch-up contributions for high earners must go to ROTH
+        if (isCatchUp && requiresRothCatchUp(contributionYear, priorYearIncome)) {
+            return toRothVariant(accountDefault);
+        }
+
+        // Rule 3: All other contributions follow account default
+        return accountDefault;
+    }
+
+    @Override
+    public BigDecimal calculateMaxContributionWithoutRoth(
+            int year, int age, BigDecimal priorYearIncome, boolean hasRothEquivalent) {
+
+        YearLimits yearLimits = limits.getLimitsForYear(year);
+        BigDecimal baseLimit = yearLimits.baseLimit();
+
+        // If not catch-up eligible, always just base limit
+        if (!isCatchUpEligible(age)) {
+            return baseLimit;
+        }
+
+        // If has ROTH equivalent, full contribution allowed
+        if (hasRothEquivalent) {
+            return calculateAnnualContributionLimit(year, age, null);
+        }
+
+        // High earners without ROTH: capped at base limit (no catch-up)
+        if (requiresRothCatchUp(year, priorYearIncome)) {
+            return baseLimit;
+        }
+
+        // Normal earners without ROTH: full limit including catch-up
+        return calculateAnnualContributionLimit(year, age, null);
+    }
+
+    /**
+     * Converts an account type to its Traditional variant.
+     *
+     * @param accountType the source account type
+     * @return the Traditional variant
+     */
+    private AccountType toTraditionalVariant(AccountType accountType) {
+        if (accountType == null) {
+            return null;
+        }
+
+        return switch (accountType) {
+            case ROTH_401K, TRADITIONAL_401K -> AccountType.TRADITIONAL_401K;
+            case ROTH_403B, TRADITIONAL_403B -> AccountType.TRADITIONAL_403B;
+            case ROTH_IRA, TRADITIONAL_IRA -> AccountType.TRADITIONAL_IRA;
+            default -> accountType;
+        };
+    }
+
+    /**
+     * Converts an account type to its ROTH variant.
+     *
+     * @param accountType the source account type
+     * @return the ROTH variant
+     */
+    private AccountType toRothVariant(AccountType accountType) {
+        if (accountType == null) {
+            return null;
+        }
+
+        return switch (accountType) {
+            case TRADITIONAL_401K, ROTH_401K -> AccountType.ROTH_401K;
+            case TRADITIONAL_403B, ROTH_403B -> AccountType.ROTH_403B;
+            case TRADITIONAL_IRA, ROTH_IRA -> AccountType.ROTH_IRA;
+            default -> accountType;
+        };
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/domain/config/CalculatorConfig.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/config/CalculatorConfig.java
@@ -1,0 +1,88 @@
+package io.github.xmljim.retirement.domain.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.github.xmljim.retirement.domain.calculator.ContributionCalculator;
+import io.github.xmljim.retirement.domain.calculator.IncomeCalculator;
+import io.github.xmljim.retirement.domain.calculator.InflationCalculator;
+import io.github.xmljim.retirement.domain.calculator.IrsContributionRules;
+import io.github.xmljim.retirement.domain.calculator.ReturnCalculator;
+import io.github.xmljim.retirement.domain.calculator.impl.DefaultContributionCalculator;
+import io.github.xmljim.retirement.domain.calculator.impl.DefaultIncomeCalculator;
+import io.github.xmljim.retirement.domain.calculator.impl.DefaultInflationCalculator;
+import io.github.xmljim.retirement.domain.calculator.impl.DefaultReturnCalculator;
+import io.github.xmljim.retirement.domain.calculator.impl.Secure2ContributionRules;
+
+/**
+ * Spring configuration for calculator beans.
+ *
+ * <p>This configuration provides singleton calculator instances for use
+ * throughout the application. All calculators are stateless and thread-safe.
+ *
+ * <p>Calculator beans available:
+ * <ul>
+ *   <li>{@link IrsContributionRules} - SECURE 2.0 contribution rules</li>
+ *   <li>{@link ContributionCalculator} - Basic contribution rate calculations</li>
+ *   <li>{@link InflationCalculator} - Inflation and COLA calculations</li>
+ *   <li>{@link IncomeCalculator} - Income projections</li>
+ *   <li>{@link ReturnCalculator} - Investment return calculations</li>
+ * </ul>
+ */
+@Configuration
+@EnableConfigurationProperties(IrsContributionLimits.class)
+public class CalculatorConfig {
+
+    /**
+     * Creates the IRS contribution rules bean (SECURE 2.0 implementation).
+     *
+     * @param limits the IRS contribution limits from configuration
+     * @return the contribution rules calculator
+     */
+    @Bean
+    public IrsContributionRules irsContributionRules(IrsContributionLimits limits) {
+        return new Secure2ContributionRules(limits);
+    }
+
+    /**
+     * Creates the contribution calculator bean.
+     *
+     * @return the contribution calculator
+     */
+    @Bean
+    public ContributionCalculator contributionCalculator() {
+        return new DefaultContributionCalculator();
+    }
+
+    /**
+     * Creates the inflation calculator bean.
+     *
+     * @return the inflation calculator
+     */
+    @Bean
+    public InflationCalculator inflationCalculator() {
+        return new DefaultInflationCalculator();
+    }
+
+    /**
+     * Creates the income calculator bean.
+     *
+     * @param inflationCalculator the inflation calculator dependency
+     * @return the income calculator
+     */
+    @Bean
+    public IncomeCalculator incomeCalculator(InflationCalculator inflationCalculator) {
+        return new DefaultIncomeCalculator(inflationCalculator);
+    }
+
+    /**
+     * Creates the return calculator bean.
+     *
+     * @return the return calculator
+     */
+    @Bean
+    public ReturnCalculator returnCalculator() {
+        return new DefaultReturnCalculator();
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/domain/config/IrsContributionLimits.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/config/IrsContributionLimits.java
@@ -1,0 +1,244 @@
+package io.github.xmljim.retirement.domain.config;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * IRS contribution limits loaded from external YAML configuration.
+ *
+ * <p>This class provides access to IRS retirement contribution limits
+ * including base limits, catch-up contributions, and ROTH allocation thresholds.
+ * Limits are organized by year and can be extrapolated for future years.
+ *
+ * <p>Configuration is loaded from {@code application.yml} under the
+ * {@code irs.contribution} prefix.
+ *
+ * <p>Example configuration:
+ * <pre>
+ * irs:
+ *   contribution:
+ *     default-annual-increase-rate: 0.02
+ *     limits:
+ *       2025:
+ *         base-limit: 23500
+ *         catch-up-limit: 7500
+ *         super-catch-up-limit: 11250
+ *         roth-catch-up-income-threshold: 145000
+ * </pre>
+ */
+@ConfigurationProperties(prefix = "irs.contribution")
+@Validated
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP",
+    justification = "Spring @ConfigurationProperties requires mutable access for binding"
+)
+public class IrsContributionLimits {
+
+    private static final int SCALE = 2;
+    private static final RoundingMode ROUNDING_MODE = RoundingMode.HALF_UP;
+
+    private Map<Integer, YearLimits> limits = new HashMap<>();
+    private BigDecimal defaultAnnualIncreaseRate = new BigDecimal("0.02");
+    private Map<Integer, IraLimits> iraLimits = new HashMap<>();
+
+    /**
+     * Contribution limits for a specific year.
+     *
+     * @param baseLimit the base contribution limit (e.g., $23,500)
+     * @param catchUpLimit the standard catch-up limit for age 50+ (e.g., $7,500)
+     * @param superCatchUpLimit the super catch-up limit for age 60-63 (e.g., $11,250)
+     * @param rothCatchUpIncomeThreshold income threshold requiring ROTH catch-up (e.g., $145,000)
+     */
+    public record YearLimits(
+        BigDecimal baseLimit,
+        BigDecimal catchUpLimit,
+        BigDecimal superCatchUpLimit,
+        BigDecimal rothCatchUpIncomeThreshold
+    ) {
+        /**
+         * Creates YearLimits with default values for missing fields.
+         */
+        public YearLimits {
+            if (baseLimit == null) {
+                baseLimit = BigDecimal.ZERO;
+            }
+            if (catchUpLimit == null) {
+                catchUpLimit = BigDecimal.ZERO;
+            }
+            if (superCatchUpLimit == null) {
+                superCatchUpLimit = BigDecimal.ZERO;
+            }
+            if (rothCatchUpIncomeThreshold == null) {
+                rothCatchUpIncomeThreshold = BigDecimal.ZERO;
+            }
+        }
+    }
+
+    /**
+     * IRA contribution limits for a specific year.
+     *
+     * @param baseLimit the base IRA contribution limit
+     * @param catchUpLimit the catch-up limit for age 50+
+     */
+    public record IraLimits(
+        BigDecimal baseLimit,
+        BigDecimal catchUpLimit
+    ) {
+        /**
+         * Creates IraLimits with default values for missing fields.
+         */
+        public IraLimits {
+            if (baseLimit == null) {
+                baseLimit = BigDecimal.ZERO;
+            }
+            if (catchUpLimit == null) {
+                catchUpLimit = BigDecimal.ZERO;
+            }
+        }
+    }
+
+    /**
+     * Returns the limits for a specific year.
+     *
+     * <p>If the year is not in the configuration, extrapolates from the
+     * most recent known year using the default annual increase rate.
+     *
+     * @param year the contribution year
+     * @return the limits for that year
+     */
+    public YearLimits getLimitsForYear(int year) {
+        if (limits.containsKey(year)) {
+            return limits.get(year);
+        }
+
+        // Find the most recent year and extrapolate
+        NavigableMap<Integer, YearLimits> sortedLimits = new TreeMap<>(limits);
+        if (sortedLimits.isEmpty()) {
+            return new YearLimits(BigDecimal.ZERO, BigDecimal.ZERO,
+                BigDecimal.ZERO, BigDecimal.ZERO);
+        }
+
+        Map.Entry<Integer, YearLimits> latestEntry = sortedLimits.lastEntry();
+        int latestYear = latestEntry.getKey();
+        YearLimits latestLimits = latestEntry.getValue();
+
+        if (year < latestYear) {
+            // For past years not in config, return the earliest known
+            Map.Entry<Integer, YearLimits> earliestEntry = sortedLimits.firstEntry();
+            return earliestEntry.getValue();
+        }
+
+        // Extrapolate forward
+        int yearsAhead = year - latestYear;
+        BigDecimal multiplier = BigDecimal.ONE.add(defaultAnnualIncreaseRate)
+            .pow(yearsAhead);
+
+        return new YearLimits(
+            latestLimits.baseLimit().multiply(multiplier).setScale(SCALE, ROUNDING_MODE),
+            latestLimits.catchUpLimit().multiply(multiplier).setScale(SCALE, ROUNDING_MODE),
+            latestLimits.superCatchUpLimit().multiply(multiplier).setScale(SCALE, ROUNDING_MODE),
+            latestLimits.rothCatchUpIncomeThreshold().multiply(multiplier)
+                .setScale(SCALE, ROUNDING_MODE)
+        );
+    }
+
+    /**
+     * Returns the IRA limits for a specific year.
+     *
+     * @param year the contribution year
+     * @return the IRA limits for that year
+     */
+    public IraLimits getIraLimitsForYear(int year) {
+        if (iraLimits.containsKey(year)) {
+            return iraLimits.get(year);
+        }
+
+        // Find the most recent year
+        NavigableMap<Integer, IraLimits> sortedLimits = new TreeMap<>(iraLimits);
+        if (sortedLimits.isEmpty()) {
+            return new IraLimits(BigDecimal.ZERO, BigDecimal.ZERO);
+        }
+
+        Map.Entry<Integer, IraLimits> latestEntry = sortedLimits.lastEntry();
+        int latestYear = latestEntry.getKey();
+        IraLimits latestLimits = latestEntry.getValue();
+
+        if (year <= latestYear) {
+            Map.Entry<Integer, IraLimits> floorEntry = sortedLimits.floorEntry(year);
+            return floorEntry != null ? floorEntry.getValue() : latestLimits;
+        }
+
+        // Extrapolate forward
+        int yearsAhead = year - latestYear;
+        BigDecimal multiplier = BigDecimal.ONE.add(defaultAnnualIncreaseRate)
+            .pow(yearsAhead);
+
+        return new IraLimits(
+            latestLimits.baseLimit().multiply(multiplier).setScale(SCALE, ROUNDING_MODE),
+            latestLimits.catchUpLimit().multiply(multiplier).setScale(SCALE, ROUNDING_MODE)
+        );
+    }
+
+    /**
+     * Returns the configured limits map.
+     *
+     * @return map of year to limits
+     */
+    public Map<Integer, YearLimits> getLimits() {
+        return limits;
+    }
+
+    /**
+     * Sets the limits map (used by Spring for configuration binding).
+     *
+     * @param limits the limits map
+     */
+    public void setLimits(Map<Integer, YearLimits> limits) {
+        this.limits = limits;
+    }
+
+    /**
+     * Returns the default annual increase rate for extrapolation.
+     *
+     * @return the increase rate as a decimal
+     */
+    public BigDecimal getDefaultAnnualIncreaseRate() {
+        return defaultAnnualIncreaseRate;
+    }
+
+    /**
+     * Sets the default annual increase rate.
+     *
+     * @param rate the increase rate as a decimal
+     */
+    public void setDefaultAnnualIncreaseRate(BigDecimal rate) {
+        this.defaultAnnualIncreaseRate = rate;
+    }
+
+    /**
+     * Returns the IRA limits map.
+     *
+     * @return map of year to IRA limits
+     */
+    public Map<Integer, IraLimits> getIraLimits() {
+        return iraLimits;
+    }
+
+    /**
+     * Sets the IRA limits map.
+     *
+     * @param iraLimits the IRA limits map
+     */
+    public void setIraLimits(Map<Integer, IraLimits> iraLimits) {
+        this.iraLimits = iraLimits;
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/domain/config/package-info.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/config/package-info.java
@@ -1,0 +1,15 @@
+/**
+ * Configuration classes for the retirement domain.
+ *
+ * <p>This package contains configuration classes for loading external
+ * configuration, including:
+ * <ul>
+ *   <li>{@link io.github.xmljim.retirement.domain.config.IrsContributionLimits} -
+ *       IRS contribution limits loaded from YAML configuration</li>
+ *   <li>Spring {@code @Configuration} classes for bean definitions</li>
+ * </ul>
+ *
+ * <p>Configuration is loaded using Spring's {@code @ConfigurationProperties}
+ * mechanism from {@code application.yml}.
+ */
+package io.github.xmljim.retirement.domain.config;

--- a/src/main/java/io/github/xmljim/retirement/domain/value/ContributionConfig.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/value/ContributionConfig.java
@@ -5,6 +5,7 @@ import java.time.Month;
 import java.util.Objects;
 
 import io.github.xmljim.retirement.domain.annotation.Generated;
+import io.github.xmljim.retirement.domain.enums.AccountType;
 import io.github.xmljim.retirement.domain.enums.ContributionType;
 import io.github.xmljim.retirement.domain.exception.MissingRequiredFieldException;
 import io.github.xmljim.retirement.domain.exception.ValidationException;
@@ -16,6 +17,15 @@ import io.github.xmljim.retirement.domain.exception.ValidationException;
  * contributions, including the base rate, annual increment, and the month
  * when the increment is applied.
  *
+ * <p>Additional SECURE 2.0 support:
+ * <ul>
+ *   <li>{@code targetAccountType} - Optional override for ROTH routing. When set,
+ *       contributions will be directed to this account type instead of the account's
+ *       default. Used for high earner catch-up contributions that must go to ROTH.</li>
+ *   <li>{@code matchingPolicy} - For employer contribution configs, defines the
+ *       matching rules (simple, tiered, or none).</li>
+ * </ul>
+ *
  * <p>This is an immutable value object. Use the {@link Builder} to create instances.
  */
 public final class ContributionConfig {
@@ -24,12 +34,16 @@ public final class ContributionConfig {
     private final BigDecimal contributionRate;
     private final BigDecimal incrementRate;
     private final Month incrementMonth;
+    private final AccountType targetAccountType;
+    private final MatchingPolicy matchingPolicy;
 
     private ContributionConfig(Builder builder) {
         this.contributionType = builder.contributionType;
         this.contributionRate = builder.contributionRate;
         this.incrementRate = builder.incrementRate;
         this.incrementMonth = builder.incrementMonth;
+        this.targetAccountType = builder.targetAccountType;
+        this.matchingPolicy = builder.matchingPolicy;
     }
 
     /**
@@ -69,6 +83,31 @@ public final class ContributionConfig {
      */
     public Month getIncrementMonth() {
         return incrementMonth;
+    }
+
+    /**
+     * Returns the target account type for ROTH routing.
+     *
+     * <p>When set, contributions will be directed to this account type instead
+     * of the account's default. This is used for SECURE 2.0 high earner catch-up
+     * contributions that must go to ROTH.
+     *
+     * @return the target account type, or null if using account default
+     */
+    public AccountType getTargetAccountType() {
+        return targetAccountType;
+    }
+
+    /**
+     * Returns the matching policy for employer contributions.
+     *
+     * <p>For employer contribution configs, this defines how the employer
+     * calculates the match (simple, tiered, or none).
+     *
+     * @return the matching policy, or null if not an employer contribution
+     */
+    public MatchingPolicy getMatchingPolicy() {
+        return matchingPolicy;
     }
 
     /**
@@ -119,13 +158,16 @@ public final class ContributionConfig {
         return contributionType == that.contributionType
             && contributionRate.compareTo(that.contributionRate) == 0
             && incrementRate.compareTo(that.incrementRate) == 0
-            && incrementMonth == that.incrementMonth;
+            && incrementMonth == that.incrementMonth
+            && targetAccountType == that.targetAccountType
+            && Objects.equals(matchingPolicy, that.matchingPolicy);
     }
 
     @Generated
     @Override
     public int hashCode() {
-        return Objects.hash(contributionType, contributionRate, incrementRate, incrementMonth);
+        return Objects.hash(contributionType, contributionRate, incrementRate, incrementMonth,
+            targetAccountType, matchingPolicy);
     }
 
     @Generated
@@ -136,6 +178,8 @@ public final class ContributionConfig {
             ", rate=" + contributionRate +
             ", increment=" + incrementRate +
             ", month=" + incrementMonth +
+            ", targetAccountType=" + targetAccountType +
+            ", matchingPolicy=" + matchingPolicy +
             '}';
     }
 
@@ -147,6 +191,8 @@ public final class ContributionConfig {
         private BigDecimal contributionRate = BigDecimal.ZERO;
         private BigDecimal incrementRate = BigDecimal.ZERO;
         private Month incrementMonth = Month.JANUARY;
+        private AccountType targetAccountType;
+        private MatchingPolicy matchingPolicy;
 
         /**
          * Sets the contribution type.
@@ -209,6 +255,35 @@ public final class ContributionConfig {
          */
         public Builder incrementMonth(Month month) {
             this.incrementMonth = month;
+            return this;
+        }
+
+        /**
+         * Sets the target account type for ROTH routing.
+         *
+         * <p>When set, contributions will be directed to this account type instead
+         * of the account's default. This is used for SECURE 2.0 high earner catch-up
+         * contributions that must go to ROTH.
+         *
+         * @param accountType the target account type
+         * @return this builder
+         */
+        public Builder targetAccountType(AccountType accountType) {
+            this.targetAccountType = accountType;
+            return this;
+        }
+
+        /**
+         * Sets the matching policy for employer contributions.
+         *
+         * <p>For employer contribution configs, this defines how the employer
+         * calculates the match (simple, tiered, or none).
+         *
+         * @param policy the matching policy
+         * @return this builder
+         */
+        public Builder matchingPolicy(MatchingPolicy policy) {
+            this.matchingPolicy = policy;
             return this;
         }
 

--- a/src/main/java/io/github/xmljim/retirement/domain/value/MatchTier.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/value/MatchTier.java
@@ -1,0 +1,63 @@
+package io.github.xmljim.retirement.domain.value;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/**
+ * A single tier in a tiered employer matching policy.
+ *
+ * <p>Each tier defines a contribution threshold and the match rate that applies
+ * up to that threshold. Tiers are cumulative - a tiered policy applies each tier
+ * in sequence until the employee contribution is exhausted.
+ *
+ * <p>Example: 100% match on first 3%, 50% match on next 2%
+ * <pre>
+ * Tier 1: threshold=0.03, matchRate=1.0  (100% match on contributions up to 3%)
+ * Tier 2: threshold=0.05, matchRate=0.5  (50% match on contributions from 3% to 5%)
+ * </pre>
+ *
+ * <p>For an employee contributing 6%:
+ * <ul>
+ *   <li>Tier 1: 3% * 100% = 3% employer match</li>
+ *   <li>Tier 2: 2% * 50% = 1% employer match</li>
+ *   <li>Total employer match: 4%</li>
+ * </ul>
+ *
+ * @param contributionThreshold the cumulative contribution percentage threshold
+ *                              (e.g., 0.03 for 3%)
+ * @param matchRate the match rate for this tier (e.g., 1.0 for 100% match)
+ */
+public record MatchTier(
+    BigDecimal contributionThreshold,
+    BigDecimal matchRate
+) {
+    /**
+     * Creates a new MatchTier with validation.
+     *
+     * @param contributionThreshold the contribution threshold
+     * @param matchRate the match rate
+     */
+    public MatchTier {
+        Objects.requireNonNull(contributionThreshold, "Contribution threshold cannot be null");
+        Objects.requireNonNull(matchRate, "Match rate cannot be null");
+
+        if (contributionThreshold.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException(
+                "Contribution threshold cannot be negative: " + contributionThreshold);
+        }
+        if (matchRate.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("Match rate cannot be negative: " + matchRate);
+        }
+    }
+
+    /**
+     * Creates a MatchTier from double values for convenience.
+     *
+     * @param threshold the contribution threshold as a decimal
+     * @param rate the match rate as a decimal
+     * @return a new MatchTier
+     */
+    public static MatchTier of(double threshold, double rate) {
+        return new MatchTier(BigDecimal.valueOf(threshold), BigDecimal.valueOf(rate));
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/domain/value/MatchingPolicy.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/value/MatchingPolicy.java
@@ -1,0 +1,110 @@
+package io.github.xmljim.retirement.domain.value;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * Defines an employer matching contribution policy.
+ *
+ * <p>Different employers offer different matching structures:
+ * <ul>
+ *   <li><strong>Simple match</strong>: A fixed percentage match up to a cap
+ *       (e.g., 50% match up to 6% of salary)</li>
+ *   <li><strong>Tiered match</strong>: Different match rates at different levels
+ *       (e.g., 100% on first 3%, 50% on next 2%)</li>
+ *   <li><strong>No match</strong>: Employer does not match contributions</li>
+ * </ul>
+ *
+ * <p>Use the static factory methods to create policies:
+ * <pre>
+ * // 50% match up to 6%
+ * MatchingPolicy simple = MatchingPolicy.simple(0.50, 0.06);
+ *
+ * // 100% on first 3%, 50% on next 2%
+ * MatchingPolicy tiered = MatchingPolicy.tiered(List.of(
+ *     MatchTier.of(0.03, 1.0),
+ *     MatchTier.of(0.05, 0.5)
+ * ));
+ *
+ * // No employer match
+ * MatchingPolicy none = MatchingPolicy.none();
+ * </pre>
+ */
+public interface MatchingPolicy {
+
+    /**
+     * Calculates the employer match for a given employee contribution rate.
+     *
+     * @param employeeContributionRate the employee's contribution as a decimal
+     *                                  (e.g., 0.06 for 6%)
+     * @return the employer match as a decimal (e.g., 0.03 for 3%)
+     */
+    BigDecimal calculateEmployerMatch(BigDecimal employeeContributionRate);
+
+    /**
+     * Indicates whether this policy allows ROTH matching.
+     *
+     * <p>Under SECURE 2.0, employers can now offer ROTH matching contributions.
+     * However, not all employers have implemented this feature.
+     *
+     * @return true if the employer supports ROTH matching
+     */
+    boolean allowsRothMatch();
+
+    /**
+     * Returns a description of the matching policy.
+     *
+     * @return a human-readable description
+     */
+    String getDescription();
+
+    /**
+     * Creates a simple matching policy with a fixed match rate up to a cap.
+     *
+     * <p>Example: 50% match up to 6% of salary
+     * <ul>
+     *   <li>Employee contributes 4% → Employer matches 2%</li>
+     *   <li>Employee contributes 6% → Employer matches 3%</li>
+     *   <li>Employee contributes 10% → Employer matches 3% (capped at 6%)</li>
+     * </ul>
+     *
+     * @param matchRate the match rate as a decimal (e.g., 0.50 for 50%)
+     * @param maxMatchPercent the maximum employee contribution that will be matched
+     * @return a simple matching policy
+     */
+    static MatchingPolicy simple(BigDecimal matchRate, BigDecimal maxMatchPercent) {
+        return new SimpleMatchingPolicy(matchRate, maxMatchPercent, false);
+    }
+
+    /**
+     * Creates a simple matching policy with a fixed match rate up to a cap.
+     *
+     * @param matchRate the match rate as a decimal
+     * @param maxMatchPercent the maximum contribution that will be matched
+     * @return a simple matching policy
+     */
+    static MatchingPolicy simple(double matchRate, double maxMatchPercent) {
+        return simple(BigDecimal.valueOf(matchRate), BigDecimal.valueOf(maxMatchPercent));
+    }
+
+    /**
+     * Creates a tiered matching policy with different rates at different levels.
+     *
+     * <p>Tiers must be ordered by threshold (lowest to highest).
+     *
+     * @param tiers the list of match tiers
+     * @return a tiered matching policy
+     */
+    static MatchingPolicy tiered(List<MatchTier> tiers) {
+        return new TieredMatchingPolicy(tiers, false);
+    }
+
+    /**
+     * Creates a policy with no employer matching.
+     *
+     * @return a no-match policy
+     */
+    static MatchingPolicy none() {
+        return NoMatchingPolicy.INSTANCE;
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/domain/value/NoMatchingPolicy.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/value/NoMatchingPolicy.java
@@ -1,0 +1,41 @@
+package io.github.xmljim.retirement.domain.value;
+
+import java.math.BigDecimal;
+
+/**
+ * A matching policy representing no employer match.
+ *
+ * <p>This is a singleton implementation used when an employer does not
+ * offer any matching contributions.
+ */
+public final class NoMatchingPolicy implements MatchingPolicy {
+
+    /**
+     * Singleton instance.
+     */
+    static final NoMatchingPolicy INSTANCE = new NoMatchingPolicy();
+
+    private NoMatchingPolicy() {
+        // Private constructor for singleton
+    }
+
+    @Override
+    public BigDecimal calculateEmployerMatch(BigDecimal employeeContributionRate) {
+        return BigDecimal.ZERO;
+    }
+
+    @Override
+    public boolean allowsRothMatch() {
+        return false;
+    }
+
+    @Override
+    public String getDescription() {
+        return "No employer match";
+    }
+
+    @Override
+    public String toString() {
+        return "NoMatchingPolicy{}";
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/domain/value/SimpleMatchingPolicy.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/value/SimpleMatchingPolicy.java
@@ -1,0 +1,107 @@
+package io.github.xmljim.retirement.domain.value;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Objects;
+
+/**
+ * A simple employer matching policy with a fixed match rate up to a cap.
+ *
+ * <p>This is the most common type of employer matching policy. The employer
+ * matches a fixed percentage of employee contributions up to a specified
+ * percentage of salary.
+ *
+ * <p>Example: 50% match up to 6% of salary
+ * <ul>
+ *   <li>Employee contributes 4% → Employer matches 2%</li>
+ *   <li>Employee contributes 6% → Employer matches 3%</li>
+ *   <li>Employee contributes 10% → Employer matches 3% (capped at 6%)</li>
+ * </ul>
+ */
+public final class SimpleMatchingPolicy implements MatchingPolicy {
+
+    private static final int SCALE = 6;
+    private static final RoundingMode ROUNDING_MODE = RoundingMode.HALF_UP;
+
+    private final BigDecimal matchRate;
+    private final BigDecimal maxMatchPercent;
+    private final boolean allowsRothMatch;
+
+    /**
+     * Creates a simple matching policy.
+     *
+     * @param matchRate the match rate as a decimal (e.g., 0.50 for 50%)
+     * @param maxMatchPercent the maximum employee contribution that will be matched
+     * @param allowsRothMatch whether ROTH matching is allowed
+     */
+    public SimpleMatchingPolicy(BigDecimal matchRate, BigDecimal maxMatchPercent,
+                                boolean allowsRothMatch) {
+        Objects.requireNonNull(matchRate, "Match rate cannot be null");
+        Objects.requireNonNull(maxMatchPercent, "Max match percent cannot be null");
+
+        if (matchRate.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("Match rate cannot be negative: " + matchRate);
+        }
+        if (maxMatchPercent.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException(
+                "Max match percent cannot be negative: " + maxMatchPercent);
+        }
+
+        this.matchRate = matchRate;
+        this.maxMatchPercent = maxMatchPercent;
+        this.allowsRothMatch = allowsRothMatch;
+    }
+
+    @Override
+    public BigDecimal calculateEmployerMatch(BigDecimal employeeContributionRate) {
+        if (employeeContributionRate == null
+                || employeeContributionRate.compareTo(BigDecimal.ZERO) <= 0) {
+            return BigDecimal.ZERO;
+        }
+
+        // Cap the employee contribution at the maximum matchable amount
+        BigDecimal matchableContribution = employeeContributionRate.min(maxMatchPercent);
+
+        // Apply the match rate
+        return matchableContribution.multiply(matchRate).setScale(SCALE, ROUNDING_MODE);
+    }
+
+    @Override
+    public boolean allowsRothMatch() {
+        return allowsRothMatch;
+    }
+
+    @Override
+    public String getDescription() {
+        return String.format("%.0f%% match up to %.0f%% of salary",
+            matchRate.multiply(BigDecimal.valueOf(100)),
+            maxMatchPercent.multiply(BigDecimal.valueOf(100)));
+    }
+
+    /**
+     * Returns the match rate.
+     *
+     * @return the match rate as a decimal
+     */
+    public BigDecimal getMatchRate() {
+        return matchRate;
+    }
+
+    /**
+     * Returns the maximum employee contribution that will be matched.
+     *
+     * @return the max match percent as a decimal
+     */
+    public BigDecimal getMaxMatchPercent() {
+        return maxMatchPercent;
+    }
+
+    @Override
+    public String toString() {
+        return "SimpleMatchingPolicy{" +
+            "matchRate=" + matchRate +
+            ", maxMatchPercent=" + maxMatchPercent +
+            ", allowsRothMatch=" + allowsRothMatch +
+            '}';
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/domain/value/TieredMatchingPolicy.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/value/TieredMatchingPolicy.java
@@ -1,0 +1,136 @@
+package io.github.xmljim.retirement.domain.value;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * A tiered employer matching policy with different rates at different levels.
+ *
+ * <p>This policy applies match rates progressively across tiers. Each tier
+ * defines a cumulative contribution threshold and the match rate that applies
+ * to contributions within that tier.
+ *
+ * <p>Example: 100% match on first 3%, 50% match on next 2%
+ * <pre>
+ * Tiers:
+ *   - threshold=0.03, matchRate=1.0  (100% match on 0% to 3%)
+ *   - threshold=0.05, matchRate=0.5  (50% match on 3% to 5%)
+ *
+ * For 6% employee contribution:
+ *   - Tier 1: 3% * 100% = 3%
+ *   - Tier 2: 2% * 50%  = 1%
+ *   - Total match: 4%
+ * </pre>
+ */
+public final class TieredMatchingPolicy implements MatchingPolicy {
+
+    private static final int SCALE = 6;
+    private static final RoundingMode ROUNDING_MODE = RoundingMode.HALF_UP;
+
+    private final List<MatchTier> tiers;
+    private final boolean allowsRothMatch;
+
+    /**
+     * Creates a tiered matching policy.
+     *
+     * @param tiers the list of match tiers (will be sorted by threshold)
+     * @param allowsRothMatch whether ROTH matching is allowed
+     */
+    public TieredMatchingPolicy(List<MatchTier> tiers, boolean allowsRothMatch) {
+        Objects.requireNonNull(tiers, "Tiers cannot be null");
+
+        if (tiers.isEmpty()) {
+            throw new IllegalArgumentException("At least one tier must be provided");
+        }
+
+        // Sort tiers by threshold (lowest to highest)
+        this.tiers = tiers.stream()
+            .sorted(Comparator.comparing(MatchTier::contributionThreshold))
+            .collect(Collectors.toCollection(ArrayList::new));
+
+        this.allowsRothMatch = allowsRothMatch;
+    }
+
+    @Override
+    public BigDecimal calculateEmployerMatch(BigDecimal employeeContributionRate) {
+        if (employeeContributionRate == null
+                || employeeContributionRate.compareTo(BigDecimal.ZERO) <= 0) {
+            return BigDecimal.ZERO;
+        }
+
+        BigDecimal totalMatch = BigDecimal.ZERO;
+        BigDecimal previousThreshold = BigDecimal.ZERO;
+        BigDecimal remainingContribution = employeeContributionRate;
+
+        for (MatchTier tier : tiers) {
+            if (remainingContribution.compareTo(BigDecimal.ZERO) <= 0) {
+                break;
+            }
+
+            // Calculate the contribution amount in this tier
+            BigDecimal tierWidth = tier.contributionThreshold().subtract(previousThreshold);
+            BigDecimal contributionInTier = remainingContribution.min(tierWidth);
+
+            // Apply the tier's match rate
+            BigDecimal tierMatch = contributionInTier.multiply(tier.matchRate());
+            totalMatch = totalMatch.add(tierMatch);
+
+            // Move to next tier
+            remainingContribution = remainingContribution.subtract(contributionInTier);
+            previousThreshold = tier.contributionThreshold();
+        }
+
+        return totalMatch.setScale(SCALE, ROUNDING_MODE);
+    }
+
+    @Override
+    public boolean allowsRothMatch() {
+        return allowsRothMatch;
+    }
+
+    @Override
+    public String getDescription() {
+        StringBuilder sb = new StringBuilder("Tiered match: ");
+        BigDecimal previousThreshold = BigDecimal.ZERO;
+
+        for (int i = 0; i < tiers.size(); i++) {
+            MatchTier tier = tiers.get(i);
+            if (i > 0) {
+                sb.append(", ");
+            }
+
+            BigDecimal tierStart = previousThreshold.multiply(BigDecimal.valueOf(100));
+            BigDecimal tierEnd = tier.contributionThreshold().multiply(BigDecimal.valueOf(100));
+            BigDecimal matchPct = tier.matchRate().multiply(BigDecimal.valueOf(100));
+
+            sb.append(String.format("%.0f%% match on %.0f%%-%.0f%%",
+                matchPct, tierStart, tierEnd));
+
+            previousThreshold = tier.contributionThreshold();
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Returns the list of tiers.
+     *
+     * @return unmodifiable list of tiers
+     */
+    public List<MatchTier> getTiers() {
+        return List.copyOf(tiers);
+    }
+
+    @Override
+    public String toString() {
+        return "TieredMatchingPolicy{" +
+            "tiers=" + tiers +
+            ", allowsRothMatch=" + allowsRothMatch +
+            '}';
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/domain/value/WorkingIncome.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/value/WorkingIncome.java
@@ -13,15 +13,21 @@ import io.github.xmljim.retirement.domain.exception.ValidationException;
  * rate that applies during the accumulation phase.
  *
  * <p>This is an immutable value object. Use the {@link Builder} to create instances.
+ *
+ * <p>The {@code priorYearIncome} field is used for SECURE 2.0 ROTH catch-up
+ * contribution rules. Employees who earned more than $145,000 in the prior
+ * year must make catch-up contributions to a ROTH account.
  */
 public final class WorkingIncome {
 
     private final BigDecimal annualSalary;
     private final BigDecimal colaRate;
+    private final BigDecimal priorYearIncome;
 
     private WorkingIncome(Builder builder) {
         this.annualSalary = builder.annualSalary;
         this.colaRate = builder.colaRate;
+        this.priorYearIncome = builder.priorYearIncome;
     }
 
     /**
@@ -51,6 +57,19 @@ public final class WorkingIncome {
      */
     public BigDecimal getColaRate() {
         return colaRate;
+    }
+
+    /**
+     * Returns the prior year income for SECURE 2.0 ROTH catch-up rules.
+     *
+     * <p>Under SECURE 2.0, employees who earned more than $145,000 in the prior
+     * year must make catch-up contributions to a ROTH account. This field stores
+     * that prior year income for the calculation.
+     *
+     * @return the prior year income, or null if not specified
+     */
+    public BigDecimal getPriorYearIncome() {
+        return priorYearIncome;
     }
 
     /**
@@ -87,13 +106,14 @@ public final class WorkingIncome {
         }
         WorkingIncome that = (WorkingIncome) o;
         return annualSalary.compareTo(that.annualSalary) == 0
-            && colaRate.compareTo(that.colaRate) == 0;
+            && colaRate.compareTo(that.colaRate) == 0
+            && Objects.equals(priorYearIncome, that.priorYearIncome);
     }
 
     @Generated
     @Override
     public int hashCode() {
-        return Objects.hash(annualSalary, colaRate);
+        return Objects.hash(annualSalary, colaRate, priorYearIncome);
     }
 
     @Generated
@@ -102,6 +122,7 @@ public final class WorkingIncome {
         return "WorkingIncome{" +
             "annualSalary=" + annualSalary +
             ", colaRate=" + colaRate +
+            ", priorYearIncome=" + priorYearIncome +
             '}';
     }
 
@@ -111,6 +132,7 @@ public final class WorkingIncome {
     public static class Builder {
         private BigDecimal annualSalary = BigDecimal.ZERO;
         private BigDecimal colaRate = BigDecimal.ZERO;
+        private BigDecimal priorYearIncome;
 
         /**
          * Sets the annual salary amount.
@@ -152,6 +174,27 @@ public final class WorkingIncome {
          */
         public Builder colaRate(double rate) {
             return colaRate(BigDecimal.valueOf(rate));
+        }
+
+        /**
+         * Sets the prior year income for SECURE 2.0 ROTH catch-up rules.
+         *
+         * @param income the prior year income
+         * @return this builder
+         */
+        public Builder priorYearIncome(BigDecimal income) {
+            this.priorYearIncome = income;
+            return this;
+        }
+
+        /**
+         * Sets the prior year income for SECURE 2.0 ROTH catch-up rules.
+         *
+         * @param income the prior year income
+         * @return this builder
+         */
+        public Builder priorYearIncome(double income) {
+            return priorYearIncome(BigDecimal.valueOf(income));
         }
 
         /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,37 @@
+# IRS Contribution Limits Configuration
+# SECURE 2.0 Act limits for 401(k), 403(b), and 457(b) plans
+
+irs:
+  contribution:
+    # Default annual increase rate for extrapolating future years
+    default-annual-increase-rate: 0.02
+
+    # 401(k)/403(b)/457(b) limits by year
+    limits:
+      2024:
+        base-limit: 23000
+        catch-up-limit: 7500
+        super-catch-up-limit: 0  # Not effective until 2025
+        roth-catch-up-income-threshold: 145000
+      2025:
+        base-limit: 23500
+        catch-up-limit: 7500
+        super-catch-up-limit: 11250  # Age 60-63 super catch-up
+        roth-catch-up-income-threshold: 145000
+      2026:
+        base-limit: 24500
+        catch-up-limit: 7500
+        super-catch-up-limit: 11625
+        roth-catch-up-income-threshold: 150000  # Estimated increase
+
+    # IRA limits (separate from employer-sponsored plans)
+    ira-limits:
+      2024:
+        base-limit: 7000
+        catch-up-limit: 1000
+      2025:
+        base-limit: 7000
+        catch-up-limit: 1000
+      2026:
+        base-limit: 7500
+        catch-up-limit: 1000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,3 +35,19 @@ irs:
       2026:
         base-limit: 7500
         catch-up-limit: 1000
+
+    # HSA limits (requires HDHP coverage)
+    # Catch-up available at age 55 (not 50 like retirement accounts)
+    hsa-limits:
+      2024:
+        individual-limit: 4150
+        family-limit: 8300
+        catch-up-limit: 1000
+      2025:
+        individual-limit: 4300
+        family-limit: 8550
+        catch-up-limit: 1000
+      2026:
+        individual-limit: 4400  # Estimated
+        family-limit: 8750      # Estimated
+        catch-up-limit: 1000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,53 +1,66 @@
 # IRS Contribution Limits Configuration
 # SECURE 2.0 Act limits for 401(k), 403(b), and 457(b) plans
+#
+# Sources:
+# - IRS News Release IR-2024-285 (Nov 2024): 2025 limits
+# - IRS News Release IR-2023-203 (Nov 2023): 2024 limits
+# - IRS Notice 2023-62: ROTH catch-up delayed to 2026
+#
+# SECURE 2.0 Key Provisions:
+# - Super catch-up (ages 60-63): Effective 2025, higher catch-up limit
+# - ROTH-only catch-up for high earners (>$145K): Delayed until 2026
 
 irs:
   contribution:
     # Default annual increase rate for extrapolating future years
+    # Based on historical ~2-3% COLA adjustments
     default-annual-increase-rate: 0.02
 
     # 401(k)/403(b)/457(b) limits by year
+    # Annual additions limit (employer+employee): $69,000 (2024), $70,000 (2025)
     limits:
       2024:
-        base-limit: 23000
-        catch-up-limit: 7500
+        base-limit: 23000        # IRS confirmed
+        catch-up-limit: 7500     # IRS confirmed (age 50+)
         super-catch-up-limit: 0  # Not effective until 2025
-        roth-catch-up-income-threshold: 145000
+        roth-catch-up-income-threshold: 145000  # Delayed until 2026
       2025:
-        base-limit: 23500
-        catch-up-limit: 7500
-        super-catch-up-limit: 11250  # Age 60-63 super catch-up
-        roth-catch-up-income-threshold: 145000
+        base-limit: 23500        # IRS confirmed
+        catch-up-limit: 7500     # IRS confirmed (age 50+)
+        super-catch-up-limit: 11250  # IRS confirmed (ages 60-63)
+        roth-catch-up-income-threshold: 145000  # Delayed until 2026
       2026:
-        base-limit: 24500
-        catch-up-limit: 7500
-        super-catch-up-limit: 11625
-        roth-catch-up-income-threshold: 150000  # Estimated increase
+        base-limit: 24000        # Estimated ($500 increase)
+        catch-up-limit: 7500     # Typically flat
+        super-catch-up-limit: 11250  # Typically flat initially
+        roth-catch-up-income-threshold: 145000  # Enforcement begins 2026
 
     # IRA limits (separate from employer-sponsored plans)
+    # Note: IRA catch-up ($1,000) is NOT indexed for inflation
     ira-limits:
       2024:
-        base-limit: 7000
-        catch-up-limit: 1000
+        base-limit: 7000         # IRS confirmed
+        catch-up-limit: 1000     # IRS confirmed (age 50+, not indexed)
       2025:
-        base-limit: 7000
-        catch-up-limit: 1000
+        base-limit: 7000         # IRS confirmed (unchanged)
+        catch-up-limit: 1000     # IRS confirmed (age 50+, not indexed)
       2026:
-        base-limit: 7500
-        catch-up-limit: 1000
+        base-limit: 7000         # Estimated (likely unchanged)
+        catch-up-limit: 1000     # Not indexed for inflation
 
     # HSA limits (requires HDHP coverage)
-    # Catch-up available at age 55 (not 50 like retirement accounts)
+    # Catch-up: Age 55+ (not 50), $1,000 flat (not indexed)
+    # Source: IRS Rev. Proc. 2023-23 (2024), Rev. Proc. 2024-25 (2025)
     hsa-limits:
       2024:
-        individual-limit: 4150
-        family-limit: 8300
-        catch-up-limit: 1000
+        individual-limit: 4150   # IRS confirmed
+        family-limit: 8300       # IRS confirmed
+        catch-up-limit: 1000     # IRS confirmed (age 55+, not indexed)
       2025:
-        individual-limit: 4300
-        family-limit: 8550
-        catch-up-limit: 1000
+        individual-limit: 4300   # IRS confirmed
+        family-limit: 8550       # IRS confirmed
+        catch-up-limit: 1000     # IRS confirmed (age 55+, not indexed)
       2026:
-        individual-limit: 4400  # Estimated
-        family-limit: 8750      # Estimated
-        catch-up-limit: 1000
+        individual-limit: 4400   # Estimated
+        family-limit: 8750       # Estimated
+        catch-up-limit: 1000     # Not indexed for inflation

--- a/src/test/java/io/github/xmljim/retirement/domain/calculator/impl/Secure2ContributionRulesTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/calculator/impl/Secure2ContributionRulesTest.java
@@ -199,6 +199,33 @@ class Secure2ContributionRulesTest {
         }
 
         @Test
+        @DisplayName("Employer contribution to 403b goes to Traditional 403b")
+        void employerTo403bGoesToTraditional403b() {
+            AccountType result = rules.determineTargetAccountType(
+                ContributionType.EMPLOYER, false, new BigDecimal("100000"),
+                2025, AccountType.ROTH_403B);
+            assertEquals(AccountType.TRADITIONAL_403B, result);
+        }
+
+        @Test
+        @DisplayName("Employer contribution to IRA goes to Traditional IRA")
+        void employerToIraGoesToTraditionalIra() {
+            AccountType result = rules.determineTargetAccountType(
+                ContributionType.EMPLOYER, false, new BigDecimal("100000"),
+                2025, AccountType.ROTH_IRA);
+            assertEquals(AccountType.TRADITIONAL_IRA, result);
+        }
+
+        @Test
+        @DisplayName("Employer contribution to Traditional stays Traditional")
+        void employerToTraditionalStaysTraditional() {
+            AccountType result = rules.determineTargetAccountType(
+                ContributionType.EMPLOYER, false, new BigDecimal("100000"),
+                2025, AccountType.TRADITIONAL_401K);
+            assertEquals(AccountType.TRADITIONAL_401K, result);
+        }
+
+        @Test
         @DisplayName("Personal base contribution follows account default")
         void personalBaseFollowsDefault() {
             AccountType result = rules.determineTargetAccountType(
@@ -217,12 +244,57 @@ class Secure2ContributionRulesTest {
         }
 
         @Test
+        @DisplayName("Catch-up for high earner 403b goes to ROTH 403b")
+        void catchUpHighEarner403bGoesToRoth403b() {
+            AccountType result = rules.determineTargetAccountType(
+                ContributionType.PERSONAL, true, new BigDecimal("150000"),
+                2025, AccountType.TRADITIONAL_403B);
+            assertEquals(AccountType.ROTH_403B, result);
+        }
+
+        @Test
+        @DisplayName("Catch-up for high earner IRA goes to ROTH IRA")
+        void catchUpHighEarnerIraGoesToRothIra() {
+            AccountType result = rules.determineTargetAccountType(
+                ContributionType.PERSONAL, true, new BigDecimal("150000"),
+                2025, AccountType.TRADITIONAL_IRA);
+            assertEquals(AccountType.ROTH_IRA, result);
+        }
+
+        @Test
+        @DisplayName("Catch-up for high earner ROTH stays ROTH")
+        void catchUpHighEarnerRothStaysRoth() {
+            AccountType result = rules.determineTargetAccountType(
+                ContributionType.PERSONAL, true, new BigDecimal("150000"),
+                2025, AccountType.ROTH_401K);
+            assertEquals(AccountType.ROTH_401K, result);
+        }
+
+        @Test
         @DisplayName("Catch-up for normal earner follows default")
         void catchUpNormalEarnerFollowsDefault() {
             AccountType result = rules.determineTargetAccountType(
                 ContributionType.PERSONAL, true, new BigDecimal("100000"),
                 2025, AccountType.TRADITIONAL_401K);
             assertEquals(AccountType.TRADITIONAL_401K, result);
+        }
+
+        @Test
+        @DisplayName("Null account type returns null")
+        void nullAccountTypeReturnsNull() {
+            AccountType result = rules.determineTargetAccountType(
+                ContributionType.EMPLOYER, false, new BigDecimal("100000"),
+                2025, null);
+            assertEquals(null, result);
+        }
+
+        @Test
+        @DisplayName("Other account types pass through unchanged")
+        void otherAccountTypesPassThrough() {
+            AccountType result = rules.determineTargetAccountType(
+                ContributionType.EMPLOYER, false, new BigDecimal("100000"),
+                2025, AccountType.TAXABLE_BROKERAGE);
+            assertEquals(AccountType.TAXABLE_BROKERAGE, result);
         }
     }
 

--- a/src/test/java/io/github/xmljim/retirement/domain/calculator/impl/Secure2ContributionRulesTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/calculator/impl/Secure2ContributionRulesTest.java
@@ -1,0 +1,285 @@
+package io.github.xmljim.retirement.domain.calculator.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.github.xmljim.retirement.domain.config.IrsContributionLimits;
+import io.github.xmljim.retirement.domain.enums.AccountType;
+import io.github.xmljim.retirement.domain.enums.ContributionType;
+import io.github.xmljim.retirement.domain.value.MatchingPolicy;
+
+@DisplayName("Secure2ContributionRules Tests")
+class Secure2ContributionRulesTest {
+
+    private Secure2ContributionRules rules;
+    private IrsContributionLimits limits;
+
+    @BeforeEach
+    void setUp() {
+        limits = createTestLimits();
+        rules = new Secure2ContributionRules(limits);
+    }
+
+    private IrsContributionLimits createTestLimits() {
+        IrsContributionLimits testLimits = new IrsContributionLimits();
+        testLimits.getLimits().put(2024, new IrsContributionLimits.YearLimits(
+            new BigDecimal("23000"), new BigDecimal("7500"),
+            BigDecimal.ZERO, new BigDecimal("145000")));
+        testLimits.getLimits().put(2025, new IrsContributionLimits.YearLimits(
+            new BigDecimal("23500"), new BigDecimal("7500"),
+            new BigDecimal("11250"), new BigDecimal("145000")));
+        testLimits.getLimits().put(2026, new IrsContributionLimits.YearLimits(
+            new BigDecimal("24500"), new BigDecimal("7500"),
+            new BigDecimal("11625"), new BigDecimal("150000")));
+        return testLimits;
+    }
+
+    @Nested
+    @DisplayName("Rules Version")
+    class RulesVersionTests {
+        @Test
+        @DisplayName("Should return SECURE 2.0 version")
+        void returnsSecure2Version() {
+            assertEquals("SECURE 2.0", rules.getRulesVersion());
+        }
+    }
+
+    @Nested
+    @DisplayName("Annual Contribution Limits")
+    class AnnualContributionLimitTests {
+
+        @Test
+        @DisplayName("Age 49: Base limit only ($23,500 for 2025)")
+        void age49BaseOnly() {
+            BigDecimal limit = rules.calculateAnnualContributionLimit(2025, 49, null);
+            assertEquals(0, new BigDecimal("23500").compareTo(limit));
+        }
+
+        @Test
+        @DisplayName("Age 50-59: Base + standard catch-up ($31,000 for 2025)")
+        void age50StandardCatchUp() {
+            BigDecimal limit = rules.calculateAnnualContributionLimit(2025, 55, null);
+            assertEquals(0, new BigDecimal("31000").compareTo(limit));
+        }
+
+        @Test
+        @DisplayName("Age 60-63: Base + super catch-up ($34,750 for 2025)")
+        void age60SuperCatchUp() {
+            BigDecimal limit = rules.calculateAnnualContributionLimit(2025, 61, null);
+            assertEquals(0, new BigDecimal("34750").compareTo(limit));
+        }
+
+        @Test
+        @DisplayName("Age 64+: Base + standard catch-up (super ends at 63)")
+        void age64StandardCatchUp() {
+            BigDecimal limit = rules.calculateAnnualContributionLimit(2025, 64, null);
+            assertEquals(0, new BigDecimal("31000").compareTo(limit));
+        }
+
+        @Test
+        @DisplayName("Age 60 in 2024: Standard catch-up (super starts 2025)")
+        void age60In2024NoSuperCatchUp() {
+            BigDecimal limit = rules.calculateAnnualContributionLimit(2024, 60, null);
+            assertEquals(0, new BigDecimal("30500").compareTo(limit));
+        }
+    }
+
+    @Nested
+    @DisplayName("Catch-Up Eligibility")
+    class CatchUpEligibilityTests {
+
+        @Test
+        @DisplayName("Age 49 not eligible")
+        void age49NotEligible() {
+            assertFalse(rules.isCatchUpEligible(49));
+        }
+
+        @Test
+        @DisplayName("Age 50 eligible")
+        void age50Eligible() {
+            assertTrue(rules.isCatchUpEligible(50));
+        }
+
+        @Test
+        @DisplayName("Age 65 eligible")
+        void age65Eligible() {
+            assertTrue(rules.isCatchUpEligible(65));
+        }
+    }
+
+    @Nested
+    @DisplayName("Super Catch-Up Eligibility")
+    class SuperCatchUpEligibilityTests {
+
+        @Test
+        @DisplayName("Age 59 not eligible")
+        void age59NotEligible() {
+            assertFalse(rules.isSuperCatchUpEligible(2025, 59));
+        }
+
+        @Test
+        @DisplayName("Age 60 in 2025 eligible")
+        void age60In2025Eligible() {
+            assertTrue(rules.isSuperCatchUpEligible(2025, 60));
+        }
+
+        @Test
+        @DisplayName("Age 63 in 2025 eligible")
+        void age63In2025Eligible() {
+            assertTrue(rules.isSuperCatchUpEligible(2025, 63));
+        }
+
+        @Test
+        @DisplayName("Age 64 not eligible")
+        void age64NotEligible() {
+            assertFalse(rules.isSuperCatchUpEligible(2025, 64));
+        }
+
+        @Test
+        @DisplayName("Age 60 in 2024 not eligible (before effective year)")
+        void age60In2024NotEligible() {
+            assertFalse(rules.isSuperCatchUpEligible(2024, 60));
+        }
+    }
+
+    @Nested
+    @DisplayName("ROTH Catch-Up Requirements")
+    class RothCatchUpTests {
+
+        @Test
+        @DisplayName("Income $145,000 does not require ROTH")
+        void income145KNoRothRequired() {
+            assertFalse(rules.requiresRothCatchUp(2025, new BigDecimal("145000")));
+        }
+
+        @Test
+        @DisplayName("Income $145,001 requires ROTH")
+        void income145001RequiresRoth() {
+            assertTrue(rules.requiresRothCatchUp(2025, new BigDecimal("145001")));
+        }
+
+        @Test
+        @DisplayName("Income $150,000 requires ROTH in 2025")
+        void income150KRequiresRothIn2025() {
+            assertTrue(rules.requiresRothCatchUp(2025, new BigDecimal("150000")));
+        }
+
+        @Test
+        @DisplayName("Income $150,000 does not require ROTH in 2026 (threshold raised)")
+        void income150KNoRothIn2026() {
+            assertFalse(rules.requiresRothCatchUp(2026, new BigDecimal("150000")));
+        }
+
+        @Test
+        @DisplayName("Null income does not require ROTH")
+        void nullIncomeNoRothRequired() {
+            assertFalse(rules.requiresRothCatchUp(2025, null));
+        }
+    }
+
+    @Nested
+    @DisplayName("Target Account Type Determination")
+    class TargetAccountTypeTests {
+
+        @Test
+        @DisplayName("Employer contribution always goes to Traditional")
+        void employerAlwaysTraditional() {
+            AccountType result = rules.determineTargetAccountType(
+                ContributionType.EMPLOYER, false, new BigDecimal("100000"),
+                2025, AccountType.ROTH_401K);
+            assertEquals(AccountType.TRADITIONAL_401K, result);
+        }
+
+        @Test
+        @DisplayName("Personal base contribution follows account default")
+        void personalBaseFollowsDefault() {
+            AccountType result = rules.determineTargetAccountType(
+                ContributionType.PERSONAL, false, new BigDecimal("150000"),
+                2025, AccountType.TRADITIONAL_401K);
+            assertEquals(AccountType.TRADITIONAL_401K, result);
+        }
+
+        @Test
+        @DisplayName("Catch-up for high earner goes to ROTH")
+        void catchUpHighEarnerGoesToRoth() {
+            AccountType result = rules.determineTargetAccountType(
+                ContributionType.PERSONAL, true, new BigDecimal("150000"),
+                2025, AccountType.TRADITIONAL_401K);
+            assertEquals(AccountType.ROTH_401K, result);
+        }
+
+        @Test
+        @DisplayName("Catch-up for normal earner follows default")
+        void catchUpNormalEarnerFollowsDefault() {
+            AccountType result = rules.determineTargetAccountType(
+                ContributionType.PERSONAL, true, new BigDecimal("100000"),
+                2025, AccountType.TRADITIONAL_401K);
+            assertEquals(AccountType.TRADITIONAL_401K, result);
+        }
+    }
+
+    @Nested
+    @DisplayName("Max Contribution Without ROTH")
+    class MaxContributionWithoutRothTests {
+
+        @Test
+        @DisplayName("Age 49 always base limit")
+        void age49AlwaysBase() {
+            BigDecimal max = rules.calculateMaxContributionWithoutRoth(
+                2025, 49, new BigDecimal("150000"), false);
+            assertEquals(0, new BigDecimal("23500").compareTo(max));
+        }
+
+        @Test
+        @DisplayName("High earner without ROTH capped at base")
+        void highEarnerNoRothCappedAtBase() {
+            BigDecimal max = rules.calculateMaxContributionWithoutRoth(
+                2025, 55, new BigDecimal("150000"), false);
+            assertEquals(0, new BigDecimal("23500").compareTo(max));
+        }
+
+        @Test
+        @DisplayName("High earner with ROTH gets full limit")
+        void highEarnerWithRothFullLimit() {
+            BigDecimal max = rules.calculateMaxContributionWithoutRoth(
+                2025, 55, new BigDecimal("150000"), true);
+            assertEquals(0, new BigDecimal("31000").compareTo(max));
+        }
+
+        @Test
+        @DisplayName("Normal earner without ROTH gets full limit")
+        void normalEarnerNoRothFullLimit() {
+            BigDecimal max = rules.calculateMaxContributionWithoutRoth(
+                2025, 55, new BigDecimal("100000"), false);
+            assertEquals(0, new BigDecimal("31000").compareTo(max));
+        }
+    }
+
+    @Nested
+    @DisplayName("Employer Match Calculation")
+    class EmployerMatchTests {
+
+        @Test
+        @DisplayName("Calculates match using policy")
+        void calculatesMatchUsingPolicy() {
+            MatchingPolicy policy = MatchingPolicy.simple(0.50, 0.06);
+            BigDecimal match = rules.calculateEmployerMatch(new BigDecimal("0.10"), policy);
+            assertEquals(0, new BigDecimal("0.03").compareTo(match.stripTrailingZeros()));
+        }
+
+        @Test
+        @DisplayName("Returns zero for null policy")
+        void returnsZeroForNullPolicy() {
+            BigDecimal match = rules.calculateEmployerMatch(new BigDecimal("0.10"), null);
+            assertEquals(0, BigDecimal.ZERO.compareTo(match));
+        }
+    }
+}

--- a/src/test/java/io/github/xmljim/retirement/domain/calculator/impl/Secure2ContributionRulesTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/calculator/impl/Secure2ContributionRulesTest.java
@@ -37,8 +37,8 @@ class Secure2ContributionRulesTest {
             new BigDecimal("23500"), new BigDecimal("7500"),
             new BigDecimal("11250"), new BigDecimal("145000")));
         testLimits.getLimits().put(2026, new IrsContributionLimits.YearLimits(
-            new BigDecimal("24500"), new BigDecimal("7500"),
-            new BigDecimal("11625"), new BigDecimal("150000")));
+            new BigDecimal("24000"), new BigDecimal("7500"),
+            new BigDecimal("11250"), new BigDecimal("145000")));
         return testLimits;
     }
 
@@ -173,9 +173,15 @@ class Secure2ContributionRulesTest {
         }
 
         @Test
-        @DisplayName("Income $150,000 does not require ROTH in 2026 (threshold raised)")
-        void income150KNoRothIn2026() {
-            assertFalse(rules.requiresRothCatchUp(2026, new BigDecimal("150000")));
+        @DisplayName("Income $145,000 does not require ROTH in 2026")
+        void income145KNoRothIn2026() {
+            assertFalse(rules.requiresRothCatchUp(2026, new BigDecimal("145000")));
+        }
+
+        @Test
+        @DisplayName("Income $145,001 requires ROTH in 2026")
+        void income145001RequiresRothIn2026() {
+            assertTrue(rules.requiresRothCatchUp(2026, new BigDecimal("145001")));
         }
 
         @Test

--- a/src/test/java/io/github/xmljim/retirement/domain/config/IrsContributionLimitsTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/config/IrsContributionLimitsTest.java
@@ -41,10 +41,10 @@ class IrsContributionLimitsTest {
             new BigDecimal("145000")
         ));
         yearLimits.put(2026, new YearLimits(
-            new BigDecimal("24500"),
+            new BigDecimal("24000"),
             new BigDecimal("7500"),
-            new BigDecimal("11625"),
-            new BigDecimal("150000")
+            new BigDecimal("11250"),
+            new BigDecimal("145000")
         ));
         limits.setLimits(yearLimits);
 
@@ -113,12 +113,12 @@ class IrsContributionLimitsTest {
             YearLimits result = limits.getLimitsForYear(2030);
 
             assertNotNull(result);
-            // Base limit: 24500 * (1.02)^4 = 26,519.59 → rounds to $26,500
-            assertEquals(0, new BigDecimal("26500").compareTo(result.baseLimit()));
+            // Base limit: 24000 * (1.02)^4 = 25,977.67 → rounds to $26,000
+            assertEquals(0, new BigDecimal("26000").compareTo(result.baseLimit()));
             // Catch-up: 7500 * (1.02)^4 = 8118.24 → rounds to $8,000
             assertEquals(0, new BigDecimal("8000").compareTo(result.catchUpLimit()));
-            // Income threshold: 150000 * (1.02)^4 = 162364.82 → rounds to $160,000
-            assertEquals(0, new BigDecimal("160000").compareTo(result.rothCatchUpIncomeThreshold()));
+            // Income threshold: 145000 * (1.02)^4 = 156,952.66 → rounds to $155,000
+            assertEquals(0, new BigDecimal("155000").compareTo(result.rothCatchUpIncomeThreshold()));
         }
 
         @Test

--- a/src/test/java/io/github/xmljim/retirement/domain/config/IrsContributionLimitsTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/config/IrsContributionLimitsTest.java
@@ -88,15 +88,18 @@ class IrsContributionLimitsTest {
         }
 
         @Test
-        @DisplayName("Should extrapolate limits for future year")
+        @DisplayName("Should extrapolate limits for future year with IRS-style rounding")
         void extrapolatesLimitsForFutureYear() {
             // 2030 is 4 years after 2026
             YearLimits result = limits.getLimitsForYear(2030);
 
             assertNotNull(result);
-            // Base limit: 24500 * (1.02)^4 ≈ 26523.22
-            assertTrue(result.baseLimit().compareTo(new BigDecimal("26000")) > 0);
-            assertTrue(result.baseLimit().compareTo(new BigDecimal("27000")) < 0);
+            // Base limit: 24500 * (1.02)^4 = 26,519.59 → rounds to $26,500
+            assertEquals(0, new BigDecimal("26500").compareTo(result.baseLimit()));
+            // Catch-up: 7500 * (1.02)^4 = 8118.24 → rounds to $8,000
+            assertEquals(0, new BigDecimal("8000").compareTo(result.catchUpLimit()));
+            // Income threshold: 150000 * (1.02)^4 = 162364.82 → rounds to $160,000
+            assertEquals(0, new BigDecimal("160000").compareTo(result.rothCatchUpIncomeThreshold()));
         }
 
         @Test

--- a/src/test/java/io/github/xmljim/retirement/domain/config/IrsContributionLimitsTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/config/IrsContributionLimitsTest.java
@@ -1,0 +1,183 @@
+package io.github.xmljim.retirement.domain.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.github.xmljim.retirement.domain.config.IrsContributionLimits.IraLimits;
+import io.github.xmljim.retirement.domain.config.IrsContributionLimits.YearLimits;
+
+@DisplayName("IrsContributionLimits Tests")
+class IrsContributionLimitsTest {
+
+    private IrsContributionLimits limits;
+
+    @BeforeEach
+    void setUp() {
+        limits = new IrsContributionLimits();
+
+        // Set up test data
+        Map<Integer, YearLimits> yearLimits = new HashMap<>();
+        yearLimits.put(2024, new YearLimits(
+            new BigDecimal("23000"),
+            new BigDecimal("7500"),
+            BigDecimal.ZERO,
+            new BigDecimal("145000")
+        ));
+        yearLimits.put(2025, new YearLimits(
+            new BigDecimal("23500"),
+            new BigDecimal("7500"),
+            new BigDecimal("11250"),
+            new BigDecimal("145000")
+        ));
+        yearLimits.put(2026, new YearLimits(
+            new BigDecimal("24500"),
+            new BigDecimal("7500"),
+            new BigDecimal("11625"),
+            new BigDecimal("150000")
+        ));
+        limits.setLimits(yearLimits);
+
+        Map<Integer, IraLimits> iraLimits = new HashMap<>();
+        iraLimits.put(2024, new IraLimits(
+            new BigDecimal("7000"),
+            new BigDecimal("1000")
+        ));
+        iraLimits.put(2025, new IraLimits(
+            new BigDecimal("7000"),
+            new BigDecimal("1000")
+        ));
+        limits.setIraLimits(iraLimits);
+
+        limits.setDefaultAnnualIncreaseRate(new BigDecimal("0.02"));
+    }
+
+    @Nested
+    @DisplayName("getLimitsForYear")
+    class GetLimitsForYearTests {
+
+        @Test
+        @DisplayName("Should return exact limits for configured year")
+        void returnsExactLimitsForConfiguredYear() {
+            YearLimits result = limits.getLimitsForYear(2025);
+
+            assertNotNull(result);
+            assertEquals(0, new BigDecimal("23500").compareTo(result.baseLimit()));
+            assertEquals(0, new BigDecimal("7500").compareTo(result.catchUpLimit()));
+            assertEquals(0, new BigDecimal("11250").compareTo(result.superCatchUpLimit()));
+            assertEquals(0, new BigDecimal("145000").compareTo(result.rothCatchUpIncomeThreshold()));
+        }
+
+        @Test
+        @DisplayName("Should return 2024 limits with zero super catch-up")
+        void returns2024LimitsWithZeroSuperCatchUp() {
+            YearLimits result = limits.getLimitsForYear(2024);
+
+            assertNotNull(result);
+            assertEquals(0, new BigDecimal("23000").compareTo(result.baseLimit()));
+            assertEquals(0, BigDecimal.ZERO.compareTo(result.superCatchUpLimit()));
+        }
+
+        @Test
+        @DisplayName("Should extrapolate limits for future year")
+        void extrapolatesLimitsForFutureYear() {
+            // 2030 is 4 years after 2026
+            YearLimits result = limits.getLimitsForYear(2030);
+
+            assertNotNull(result);
+            // Base limit: 24500 * (1.02)^4 ≈ 26523.22
+            assertTrue(result.baseLimit().compareTo(new BigDecimal("26000")) > 0);
+            assertTrue(result.baseLimit().compareTo(new BigDecimal("27000")) < 0);
+        }
+
+        @Test
+        @DisplayName("Should return earliest year for past year not in config")
+        void returnsEarliestYearForPastYear() {
+            YearLimits result = limits.getLimitsForYear(2020);
+
+            assertNotNull(result);
+            // Should return 2024 limits (earliest configured)
+            assertEquals(0, new BigDecimal("23000").compareTo(result.baseLimit()));
+        }
+
+        @Test
+        @DisplayName("Should return zero limits when no years configured")
+        void returnsZeroLimitsWhenEmpty() {
+            IrsContributionLimits emptyLimits = new IrsContributionLimits();
+            emptyLimits.setLimits(new HashMap<>());
+
+            YearLimits result = emptyLimits.getLimitsForYear(2025);
+
+            assertNotNull(result);
+            assertEquals(0, BigDecimal.ZERO.compareTo(result.baseLimit()));
+        }
+    }
+
+    @Nested
+    @DisplayName("getIraLimitsForYear")
+    class GetIraLimitsForYearTests {
+
+        @Test
+        @DisplayName("Should return exact IRA limits for configured year")
+        void returnsExactIraLimitsForConfiguredYear() {
+            IraLimits result = limits.getIraLimitsForYear(2025);
+
+            assertNotNull(result);
+            assertEquals(0, new BigDecimal("7000").compareTo(result.baseLimit()));
+            assertEquals(0, new BigDecimal("1000").compareTo(result.catchUpLimit()));
+        }
+
+        @Test
+        @DisplayName("Should extrapolate IRA limits for future year")
+        void extrapolatesIraLimitsForFutureYear() {
+            IraLimits result = limits.getIraLimitsForYear(2030);
+
+            assertNotNull(result);
+            // Should be more than 2025 base limit of 7000
+            assertTrue(result.baseLimit().compareTo(new BigDecimal("7000")) > 0);
+        }
+    }
+
+    @Nested
+    @DisplayName("YearLimits Record")
+    class YearLimitsTests {
+
+        @Test
+        @DisplayName("Should handle null values with defaults")
+        void handlesNullValuesWithDefaults() {
+            YearLimits result = new YearLimits(null, null, null, null);
+
+            assertEquals(0, BigDecimal.ZERO.compareTo(result.baseLimit()));
+            assertEquals(0, BigDecimal.ZERO.compareTo(result.catchUpLimit()));
+            assertEquals(0, BigDecimal.ZERO.compareTo(result.superCatchUpLimit()));
+            assertEquals(0, BigDecimal.ZERO.compareTo(result.rothCatchUpIncomeThreshold()));
+        }
+    }
+
+    @Nested
+    @DisplayName("Configuration Properties")
+    class ConfigurationPropertiesTests {
+
+        @Test
+        @DisplayName("Should return default annual increase rate")
+        void returnsDefaultAnnualIncreaseRate() {
+            assertEquals(0, new BigDecimal("0.02").compareTo(limits.getDefaultAnnualIncreaseRate()));
+        }
+
+        @Test
+        @DisplayName("Should allow setting annual increase rate")
+        void allowsSettingAnnualIncreaseRate() {
+            limits.setDefaultAnnualIncreaseRate(new BigDecimal("0.03"));
+            assertEquals(0, new BigDecimal("0.03").compareTo(limits.getDefaultAnnualIncreaseRate()));
+        }
+    }
+}

--- a/src/test/java/io/github/xmljim/retirement/domain/value/ContributionConfigTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/value/ContributionConfigTest.java
@@ -2,6 +2,7 @@ package io.github.xmljim.retirement.domain.value;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.math.BigDecimal;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import io.github.xmljim.retirement.domain.enums.AccountType;
 import io.github.xmljim.retirement.domain.enums.ContributionType;
 import io.github.xmljim.retirement.domain.exception.MissingRequiredFieldException;
 import io.github.xmljim.retirement.domain.exception.ValidationException;
@@ -106,6 +108,101 @@ class ContributionConfigTest {
                     .contributionRate(0.10)
                     .incrementRate(-0.01)
                     .build());
+        }
+    }
+
+    @Nested
+    @DisplayName("Target Account Type Tests")
+    class TargetAccountTypeTests {
+
+        @Test
+        @DisplayName("Should set and get target account type")
+        void setAndGetTargetAccountType() {
+            ContributionConfig config = ContributionConfig.builder()
+                .contributionType(ContributionType.PERSONAL)
+                .contributionRate(0.10)
+                .targetAccountType(AccountType.ROTH_401K)
+                .build();
+
+            assertEquals(AccountType.ROTH_401K, config.getTargetAccountType());
+        }
+
+        @Test
+        @DisplayName("Should allow null target account type")
+        void allowNullTargetAccountType() {
+            ContributionConfig config = ContributionConfig.builder()
+                .contributionType(ContributionType.PERSONAL)
+                .contributionRate(0.10)
+                .build();
+
+            assertNull(config.getTargetAccountType());
+        }
+
+        @Test
+        @DisplayName("Should include target account type in equals")
+        void includesInEquals() {
+            ContributionConfig c1 = ContributionConfig.builder()
+                .contributionType(ContributionType.PERSONAL)
+                .contributionRate(0.10)
+                .targetAccountType(AccountType.ROTH_401K)
+                .build();
+
+            ContributionConfig c2 = ContributionConfig.builder()
+                .contributionType(ContributionType.PERSONAL)
+                .contributionRate(0.10)
+                .targetAccountType(AccountType.ROTH_401K)
+                .build();
+
+            ContributionConfig c3 = ContributionConfig.builder()
+                .contributionType(ContributionType.PERSONAL)
+                .contributionRate(0.10)
+                .targetAccountType(AccountType.TRADITIONAL_401K)
+                .build();
+
+            assertEquals(c1, c2);
+            assertNotEquals(c1, c3);
+        }
+    }
+
+    @Nested
+    @DisplayName("Matching Policy Tests")
+    class MatchingPolicyTests {
+
+        @Test
+        @DisplayName("Should set and get matching policy")
+        void setAndGetMatchingPolicy() {
+            MatchingPolicy policy = MatchingPolicy.simple(0.50, 0.06);
+            ContributionConfig config = ContributionConfig.builder()
+                .contributionType(ContributionType.EMPLOYER)
+                .contributionRate(0.06)
+                .matchingPolicy(policy)
+                .build();
+
+            assertEquals(policy, config.getMatchingPolicy());
+        }
+
+        @Test
+        @DisplayName("Should allow null matching policy")
+        void allowNullMatchingPolicy() {
+            ContributionConfig config = ContributionConfig.builder()
+                .contributionType(ContributionType.EMPLOYER)
+                .contributionRate(0.06)
+                .build();
+
+            assertNull(config.getMatchingPolicy());
+        }
+
+        @Test
+        @DisplayName("Should include matching policy in toString")
+        void includesInToString() {
+            MatchingPolicy policy = MatchingPolicy.simple(0.50, 0.06);
+            ContributionConfig config = ContributionConfig.builder()
+                .contributionType(ContributionType.EMPLOYER)
+                .matchingPolicy(policy)
+                .build();
+
+            String result = config.toString();
+            assertEquals(true, result.contains("matchingPolicy="));
         }
     }
 

--- a/src/test/java/io/github/xmljim/retirement/domain/value/MatchingPolicyTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/value/MatchingPolicyTest.java
@@ -1,0 +1,215 @@
+package io.github.xmljim.retirement.domain.value;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("MatchingPolicy Tests")
+class MatchingPolicyTest {
+
+    @Nested
+    @DisplayName("SimpleMatchingPolicy")
+    class SimpleMatchingPolicyTests {
+
+        @Test
+        @DisplayName("Should calculate 50% match up to 6%")
+        void calculates50PercentMatchUpTo6Percent() {
+            MatchingPolicy policy = MatchingPolicy.simple(0.50, 0.06);
+
+            // Employee contributes 4% → 2% match
+            BigDecimal result = policy.calculateEmployerMatch(new BigDecimal("0.04"));
+            assertEquals(0, new BigDecimal("0.02").compareTo(result.stripTrailingZeros()));
+        }
+
+        @Test
+        @DisplayName("Should cap match at maximum matchable percentage")
+        void capsMatchAtMaximumMatchablePercentage() {
+            MatchingPolicy policy = MatchingPolicy.simple(0.50, 0.06);
+
+            // Employee contributes 10% → 3% match (capped at 6% * 50%)
+            BigDecimal result = policy.calculateEmployerMatch(new BigDecimal("0.10"));
+            assertEquals(0, new BigDecimal("0.03").compareTo(result.stripTrailingZeros()));
+        }
+
+        @Test
+        @DisplayName("Should return zero for null contribution")
+        void returnsZeroForNullContribution() {
+            MatchingPolicy policy = MatchingPolicy.simple(0.50, 0.06);
+
+            BigDecimal result = policy.calculateEmployerMatch(null);
+            assertEquals(0, BigDecimal.ZERO.compareTo(result));
+        }
+
+        @Test
+        @DisplayName("Should return zero for zero contribution")
+        void returnsZeroForZeroContribution() {
+            MatchingPolicy policy = MatchingPolicy.simple(0.50, 0.06);
+
+            BigDecimal result = policy.calculateEmployerMatch(BigDecimal.ZERO);
+            assertEquals(0, BigDecimal.ZERO.compareTo(result));
+        }
+
+        @Test
+        @DisplayName("Should throw for negative match rate")
+        void throwsForNegativeMatchRate() {
+            assertThrows(IllegalArgumentException.class, () ->
+                MatchingPolicy.simple(-0.50, 0.06));
+        }
+
+        @Test
+        @DisplayName("Should return description")
+        void returnsDescription() {
+            MatchingPolicy policy = MatchingPolicy.simple(0.50, 0.06);
+
+            assertNotNull(policy.getDescription());
+            assertTrue(policy.getDescription().contains("50%"));
+            assertTrue(policy.getDescription().contains("6%"));
+        }
+    }
+
+    @Nested
+    @DisplayName("TieredMatchingPolicy")
+    class TieredMatchingPolicyTests {
+
+        @Test
+        @DisplayName("Should calculate tiered match: 100% on first 3%, 50% on next 2%")
+        void calculatesTieredMatch() {
+            // 100% match on first 3%, 50% match on contributions from 3% to 5%
+            MatchingPolicy policy = MatchingPolicy.tiered(List.of(
+                MatchTier.of(0.03, 1.0),
+                MatchTier.of(0.05, 0.5)
+            ));
+
+            // Employee contributes 6%
+            // Tier 1: 3% * 100% = 3%
+            // Tier 2: 2% * 50% = 1%
+            // Total: 4%
+            BigDecimal result = policy.calculateEmployerMatch(new BigDecimal("0.06"));
+            assertEquals(0, new BigDecimal("0.04").compareTo(result.stripTrailingZeros()));
+        }
+
+        @Test
+        @DisplayName("Should handle contribution within first tier only")
+        void handlesContributionWithinFirstTierOnly() {
+            MatchingPolicy policy = MatchingPolicy.tiered(List.of(
+                MatchTier.of(0.03, 1.0),
+                MatchTier.of(0.05, 0.5)
+            ));
+
+            // Employee contributes 2% → 2% match (within first tier)
+            BigDecimal result = policy.calculateEmployerMatch(new BigDecimal("0.02"));
+            assertEquals(0, new BigDecimal("0.02").compareTo(result.stripTrailingZeros()));
+        }
+
+        @Test
+        @DisplayName("Should handle contribution exactly at tier boundary")
+        void handlesContributionExactlyAtTierBoundary() {
+            MatchingPolicy policy = MatchingPolicy.tiered(List.of(
+                MatchTier.of(0.03, 1.0),
+                MatchTier.of(0.05, 0.5)
+            ));
+
+            // Employee contributes exactly 3% → 3% match
+            BigDecimal result = policy.calculateEmployerMatch(new BigDecimal("0.03"));
+            assertEquals(0, new BigDecimal("0.03").compareTo(result.stripTrailingZeros()));
+        }
+
+        @Test
+        @DisplayName("Should return zero for null contribution")
+        void returnsZeroForNullContribution() {
+            MatchingPolicy policy = MatchingPolicy.tiered(List.of(
+                MatchTier.of(0.03, 1.0)
+            ));
+
+            BigDecimal result = policy.calculateEmployerMatch(null);
+            assertEquals(0, BigDecimal.ZERO.compareTo(result));
+        }
+
+        @Test
+        @DisplayName("Should throw for empty tier list")
+        void throwsForEmptyTierList() {
+            assertThrows(IllegalArgumentException.class, () ->
+                MatchingPolicy.tiered(List.of()));
+        }
+
+        @Test
+        @DisplayName("Should sort tiers by threshold")
+        void sortsTiersByThreshold() {
+            // Provide tiers out of order - should still work correctly
+            MatchingPolicy policy = MatchingPolicy.tiered(List.of(
+                MatchTier.of(0.05, 0.5),
+                MatchTier.of(0.03, 1.0)
+            ));
+
+            // Should calculate correctly despite out-of-order input
+            BigDecimal result = policy.calculateEmployerMatch(new BigDecimal("0.06"));
+            assertEquals(0, new BigDecimal("0.04").compareTo(result.stripTrailingZeros()));
+        }
+    }
+
+    @Nested
+    @DisplayName("NoMatchingPolicy")
+    class NoMatchingPolicyTests {
+
+        @Test
+        @DisplayName("Should return zero for any contribution")
+        void returnsZeroForAnyContribution() {
+            MatchingPolicy policy = MatchingPolicy.none();
+
+            BigDecimal result = policy.calculateEmployerMatch(new BigDecimal("0.10"));
+            assertEquals(0, BigDecimal.ZERO.compareTo(result));
+        }
+
+        @Test
+        @DisplayName("Should not allow ROTH match")
+        void doesNotAllowRothMatch() {
+            MatchingPolicy policy = MatchingPolicy.none();
+
+            assertFalse(policy.allowsRothMatch());
+        }
+    }
+
+    @Nested
+    @DisplayName("MatchTier Record")
+    class MatchTierTests {
+
+        @Test
+        @DisplayName("Should create valid tier")
+        void createsValidTier() {
+            MatchTier tier = MatchTier.of(0.03, 1.0);
+
+            assertEquals(0, new BigDecimal("0.03").compareTo(tier.contributionThreshold()));
+            assertEquals(0, new BigDecimal("1.0").compareTo(tier.matchRate()));
+        }
+
+        @Test
+        @DisplayName("Should throw for null threshold")
+        void throwsForNullThreshold() {
+            assertThrows(NullPointerException.class, () ->
+                new MatchTier(null, BigDecimal.ONE));
+        }
+
+        @Test
+        @DisplayName("Should throw for negative threshold")
+        void throwsForNegativeThreshold() {
+            assertThrows(IllegalArgumentException.class, () ->
+                MatchTier.of(-0.03, 1.0));
+        }
+
+        @Test
+        @DisplayName("Should throw for negative match rate")
+        void throwsForNegativeMatchRate() {
+            assertThrows(IllegalArgumentException.class, () ->
+                MatchTier.of(0.03, -1.0));
+        }
+    }
+}

--- a/src/test/java/io/github/xmljim/retirement/domain/value/WorkingIncomeTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/value/WorkingIncomeTest.java
@@ -2,6 +2,7 @@ package io.github.xmljim.retirement.domain.value;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.math.BigDecimal;
@@ -79,6 +80,71 @@ class WorkingIncomeTest {
                 WorkingIncome.builder()
                     .annualSalary(-100000.00)
                     .build());
+        }
+    }
+
+    @Nested
+    @DisplayName("Prior Year Income Tests")
+    class PriorYearIncomeTests {
+
+        @Test
+        @DisplayName("Should set and get prior year income")
+        void setAndGetPriorYearIncome() {
+            WorkingIncome income = WorkingIncome.builder()
+                .annualSalary(100000.00)
+                .colaRate(0.02)
+                .priorYearIncome(150000.00)
+                .build();
+
+            assertEquals(0, new BigDecimal("150000").compareTo(income.getPriorYearIncome()));
+        }
+
+        @Test
+        @DisplayName("Should allow null prior year income")
+        void allowNullPriorYearIncome() {
+            WorkingIncome income = WorkingIncome.builder()
+                .annualSalary(100000.00)
+                .colaRate(0.02)
+                .build();
+
+            assertNull(income.getPriorYearIncome());
+        }
+
+        @Test
+        @DisplayName("Should include prior year income in equals")
+        void includesInEquals() {
+            WorkingIncome w1 = WorkingIncome.builder()
+                .annualSalary(100000.00)
+                .colaRate(0.02)
+                .priorYearIncome(150000.00)
+                .build();
+
+            WorkingIncome w2 = WorkingIncome.builder()
+                .annualSalary(100000.00)
+                .colaRate(0.02)
+                .priorYearIncome(150000.00)
+                .build();
+
+            WorkingIncome w3 = WorkingIncome.builder()
+                .annualSalary(100000.00)
+                .colaRate(0.02)
+                .priorYearIncome(100000.00)
+                .build();
+
+            assertEquals(w1, w2);
+            assertNotEquals(w1, w3);
+        }
+
+        @Test
+        @DisplayName("Should include prior year income in toString")
+        void includesInToString() {
+            WorkingIncome income = WorkingIncome.builder()
+                .annualSalary(100000.00)
+                .priorYearIncome(150000.00)
+                .build();
+
+            String result = income.toString();
+            assertEquals(true, result.contains("priorYearIncome=150000"));
         }
     }
 


### PR DESCRIPTION
## Summary

Implements comprehensive IRS SECURE 2.0 retirement contribution rules including:

- **IrsContributionLimits**: Spring `@ConfigurationProperties` for YAML-based IRS limits with year-based extrapolation using IRS-style rounding ($500/$5000 increments)
- **IrsContributionRules**: Base interface for contribution rule calculators (extensible for future legislation)
- **Secure2ContributionRules**: Full SECURE 2.0 implementation:
  - Age-based catch-up contributions (50+)
  - Super catch-up for ages 60-63 (effective 2025)
  - ROTH-only catch-up for high earners ($145K+ prior year income)
  - Employer match calculations
  - Target account type determination (employer → Traditional, high earner catch-up → ROTH)
- **MatchingPolicy**: Interface with Simple, Tiered, and None implementations for employer matching
- **CalculatorConfig**: Spring configuration for calculator beans

### Modified Models
- `WorkingIncome`: Added `priorYearIncome` field for ROTH threshold determination
- `ContributionConfig`: Added `targetAccountType` and `matchingPolicy` fields

### Key ROTH Allocation Rules (SECURE 2.0)
| Contribution Type | Prior Year Income > $145K | Allocation |
|-------------------|---------------------------|------------|
| Base personal | Any | Account default |
| Catch-up (50+) | ≤ $145K | Account default |
| Catch-up (50+) | > $145K | **ROTH only** |
| Employer match | Any | **Always Traditional** |

Closes #123

## Test Plan

- [x] IrsContributionLimitsTest - YAML loading, extrapolation with IRS-style rounding
- [x] Secure2ContributionRulesTest - All age/income/account type scenarios
- [x] MatchingPolicyTest - Simple, tiered, and no-match policies
- [x] WorkingIncomeTest - priorYearIncome field
- [x] ContributionConfigTest - targetAccountType and matchingPolicy fields
- [x] Full build passes (checkstyle, PMD, SpotBugs, 80% coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)