### PR TITLE
feat(#14): Redesign Transaction with complete balance calculations

### DIFF
--- a/src/main/java/io/github/xmljim/retirement/domain/enums/TransactionType.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/enums/TransactionType.java
@@ -1,0 +1,51 @@
+package io.github.xmljim.retirement.domain.enums;
+
+/**
+ * Types of transactions in a retirement portfolio simulation.
+ *
+ * <p>Indicates the primary activity for a given transaction period:
+ * <ul>
+ *   <li>CONTRIBUTION - Accumulation phase (adding to accounts)</li>
+ *   <li>WITHDRAWAL - Distribution phase (drawing from accounts)</li>
+ * </ul>
+ */
+public enum TransactionType {
+
+    /**
+     * Contribution transaction during accumulation phase.
+     * May include personal contributions, employer matches, and investment returns.
+     */
+    CONTRIBUTION("Contribution", "Adding funds to account"),
+
+    /**
+     * Withdrawal transaction during distribution phase.
+     * May include withdrawals and investment returns.
+     */
+    WITHDRAWAL("Withdrawal", "Drawing funds from account");
+
+    private final String displayName;
+    private final String description;
+
+    TransactionType(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+
+    /**
+     * Returns the human-readable display name.
+     *
+     * @return the display name
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * Returns a brief description of the transaction type.
+     *
+     * @return the description
+     */
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/domain/model/Transaction.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/model/Transaction.java
@@ -1,0 +1,457 @@
+package io.github.xmljim.retirement.domain.model;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.YearMonth;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import io.github.xmljim.retirement.domain.annotation.Generated;
+import io.github.xmljim.retirement.domain.enums.AccountType;
+import io.github.xmljim.retirement.domain.enums.TransactionType;
+import io.github.xmljim.retirement.domain.exception.MissingRequiredFieldException;
+
+/**
+ * Represents a monthly transaction in a retirement portfolio simulation.
+ *
+ * <p>A Transaction captures all financial activity for an account during
+ * a single month, including:
+ * <ul>
+ *   <li>Starting balance (from previous transaction or initial balance)</li>
+ *   <li>Personal and employer contributions</li>
+ *   <li>Investment returns for the period</li>
+ *   <li>Withdrawals</li>
+ *   <li>Ending balance (calculated)</li>
+ * </ul>
+ *
+ * <p>Transactions support chaining where each transaction's end balance
+ * becomes the next transaction's start balance. Use the {@link Builder}
+ * to create instances.
+ *
+ * <p>Balance calculation:
+ * <pre>
+ * endBalance = startBalance + personalContribution + employerContribution
+ *            + investmentReturn - withdrawal
+ * </pre>
+ */
+public final class Transaction {
+
+    private static final int DOLLAR_SCALE = 2;
+    private static final RoundingMode ROUNDING_MODE = RoundingMode.HALF_UP;
+
+    private final String id;
+    private final String accountId;
+    private final AccountType accountType;
+    private final YearMonth period;
+    private final TransactionType transactionType;
+
+    private final BigDecimal startBalance;
+    private final BigDecimal personalContribution;
+    private final BigDecimal employerContribution;
+    private final BigDecimal investmentReturn;
+    private final BigDecimal withdrawal;
+    private final BigDecimal endBalance;
+
+    private final Transaction previous;
+
+    private Transaction(Builder builder) {
+        this.id = builder.id != null ? builder.id : UUID.randomUUID().toString();
+        this.accountId = builder.accountId;
+        this.accountType = builder.accountType;
+        this.period = builder.period;
+        this.transactionType = builder.transactionType;
+        this.startBalance = scale(builder.startBalance);
+        this.personalContribution = scale(builder.personalContribution);
+        this.employerContribution = scale(builder.employerContribution);
+        this.investmentReturn = scale(builder.investmentReturn);
+        this.withdrawal = scale(builder.withdrawal);
+        this.endBalance = calculateEndBalance();
+        this.previous = builder.previous;
+    }
+
+    private BigDecimal scale(BigDecimal value) {
+        return value != null ? value.setScale(DOLLAR_SCALE, ROUNDING_MODE) : BigDecimal.ZERO;
+    }
+
+    private BigDecimal calculateEndBalance() {
+        return startBalance
+            .add(personalContribution)
+            .add(employerContribution)
+            .add(investmentReturn)
+            .subtract(withdrawal)
+            .setScale(DOLLAR_SCALE, ROUNDING_MODE);
+    }
+
+    /**
+     * Returns the unique transaction identifier.
+     *
+     * @return the transaction ID
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Returns the account identifier this transaction belongs to.
+     *
+     * @return the account ID
+     */
+    public String getAccountId() {
+        return accountId;
+    }
+
+    /**
+     * Returns the account type.
+     *
+     * @return the account type
+     */
+    public AccountType getAccountType() {
+        return accountType;
+    }
+
+    /**
+     * Returns the month this transaction covers.
+     *
+     * @return the transaction period as YearMonth
+     */
+    public YearMonth getPeriod() {
+        return period;
+    }
+
+    /**
+     * Returns the transaction type (CONTRIBUTION or WITHDRAWAL).
+     *
+     * @return the transaction type
+     */
+    public TransactionType getTransactionType() {
+        return transactionType;
+    }
+
+    /**
+     * Returns the balance at the start of this period.
+     *
+     * @return the starting balance
+     */
+    public BigDecimal getStartBalance() {
+        return startBalance;
+    }
+
+    /**
+     * Returns the personal (employee) contribution amount.
+     *
+     * @return the personal contribution
+     */
+    public BigDecimal getPersonalContribution() {
+        return personalContribution;
+    }
+
+    /**
+     * Returns the employer contribution/match amount.
+     *
+     * @return the employer contribution
+     */
+    public BigDecimal getEmployerContribution() {
+        return employerContribution;
+    }
+
+    /**
+     * Returns the total contribution (personal + employer).
+     *
+     * @return the total contribution
+     */
+    public BigDecimal getTotalContribution() {
+        return personalContribution.add(employerContribution);
+    }
+
+    /**
+     * Returns the investment return for this period.
+     *
+     * @return the investment return amount
+     */
+    public BigDecimal getInvestmentReturn() {
+        return investmentReturn;
+    }
+
+    /**
+     * Returns the withdrawal amount for this period.
+     *
+     * @return the withdrawal amount
+     */
+    public BigDecimal getWithdrawal() {
+        return withdrawal;
+    }
+
+    /**
+     * Returns the balance at the end of this period.
+     *
+     * <p>Calculated as: startBalance + contributions + investmentReturn - withdrawal
+     *
+     * @return the ending balance
+     */
+    public BigDecimal getEndBalance() {
+        return endBalance;
+    }
+
+    /**
+     * Returns the previous transaction in the chain, if any.
+     *
+     * @return Optional containing the previous transaction
+     */
+    public Optional<Transaction> getPrevious() {
+        return Optional.ofNullable(previous);
+    }
+
+    /**
+     * Returns true if this is the first transaction in the chain.
+     *
+     * @return true if no previous transaction exists
+     */
+    public boolean isFirst() {
+        return previous == null;
+    }
+
+    /**
+     * Returns the net change in balance for this period.
+     *
+     * @return endBalance - startBalance
+     */
+    public BigDecimal getNetChange() {
+        return endBalance.subtract(startBalance);
+    }
+
+    /**
+     * Creates a new builder for Transaction.
+     *
+     * @return a new builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Creates a builder for the next transaction in the chain.
+     *
+     * <p>The new transaction will:
+     * <ul>
+     *   <li>Use this transaction's end balance as start balance</li>
+     *   <li>Link to this transaction as previous</li>
+     *   <li>Inherit account ID and type</li>
+     * </ul>
+     *
+     * @param nextPeriod the period for the next transaction
+     * @return a builder pre-configured for chaining
+     */
+    public Builder nextTransaction(YearMonth nextPeriod) {
+        return new Builder()
+            .accountId(this.accountId)
+            .accountType(this.accountType)
+            .period(nextPeriod)
+            .startBalance(this.endBalance)
+            .previous(this);
+    }
+
+    @Generated
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Transaction that = (Transaction) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Generated
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Generated
+    @Override
+    public String toString() {
+        return "Transaction{" +
+            "id='" + id + '\'' +
+            ", accountId='" + accountId + '\'' +
+            ", period=" + period +
+            ", type=" + transactionType +
+            ", start=" + startBalance +
+            ", end=" + endBalance +
+            '}';
+    }
+
+    /**
+     * Builder for creating Transaction instances.
+     */
+    public static class Builder {
+
+        private String id;
+        private String accountId;
+        private AccountType accountType;
+        private YearMonth period;
+        private TransactionType transactionType;
+        private BigDecimal startBalance = BigDecimal.ZERO;
+        private BigDecimal personalContribution = BigDecimal.ZERO;
+        private BigDecimal employerContribution = BigDecimal.ZERO;
+        private BigDecimal investmentReturn = BigDecimal.ZERO;
+        private BigDecimal withdrawal = BigDecimal.ZERO;
+        private Transaction previous;
+
+        /**
+         * Sets the transaction ID. If not set, a UUID will be generated.
+         *
+         * @param id the transaction ID
+         * @return this builder
+         */
+        public Builder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        /**
+         * Sets the account ID.
+         *
+         * @param accountId the account ID
+         * @return this builder
+         */
+        public Builder accountId(String accountId) {
+            this.accountId = accountId;
+            return this;
+        }
+
+        /**
+         * Sets the account type.
+         *
+         * @param accountType the account type
+         * @return this builder
+         */
+        public Builder accountType(AccountType accountType) {
+            this.accountType = accountType;
+            return this;
+        }
+
+        /**
+         * Configures from an InvestmentAccount.
+         *
+         * @param account the investment account
+         * @return this builder
+         */
+        public Builder forAccount(InvestmentAccount account) {
+            this.accountId = account.getId();
+            this.accountType = account.getAccountType();
+            if (this.startBalance.compareTo(BigDecimal.ZERO) == 0) {
+                this.startBalance = account.getBalance();
+            }
+            return this;
+        }
+
+        /**
+         * Sets the transaction period.
+         *
+         * @param period the year-month
+         * @return this builder
+         */
+        public Builder period(YearMonth period) {
+            this.period = period;
+            return this;
+        }
+
+        /**
+         * Sets the transaction type.
+         *
+         * @param transactionType the transaction type
+         * @return this builder
+         */
+        public Builder transactionType(TransactionType transactionType) {
+            this.transactionType = transactionType;
+            return this;
+        }
+
+        /**
+         * Sets the starting balance.
+         *
+         * @param startBalance the start balance
+         * @return this builder
+         */
+        public Builder startBalance(BigDecimal startBalance) {
+            this.startBalance = startBalance;
+            return this;
+        }
+
+        /**
+         * Sets the personal contribution.
+         *
+         * @param personalContribution the personal contribution
+         * @return this builder
+         */
+        public Builder personalContribution(BigDecimal personalContribution) {
+            this.personalContribution = personalContribution;
+            return this;
+        }
+
+        /**
+         * Sets the employer contribution.
+         *
+         * @param employerContribution the employer contribution
+         * @return this builder
+         */
+        public Builder employerContribution(BigDecimal employerContribution) {
+            this.employerContribution = employerContribution;
+            return this;
+        }
+
+        /**
+         * Sets the investment return.
+         *
+         * @param investmentReturn the investment return
+         * @return this builder
+         */
+        public Builder investmentReturn(BigDecimal investmentReturn) {
+            this.investmentReturn = investmentReturn;
+            return this;
+        }
+
+        /**
+         * Sets the withdrawal amount.
+         *
+         * @param withdrawal the withdrawal amount
+         * @return this builder
+         */
+        public Builder withdrawal(BigDecimal withdrawal) {
+            this.withdrawal = withdrawal;
+            return this;
+        }
+
+        /**
+         * Sets the previous transaction for chaining.
+         *
+         * @param previous the previous transaction
+         * @return this builder
+         */
+        public Builder previous(Transaction previous) {
+            this.previous = previous;
+            return this;
+        }
+
+        /**
+         * Builds the Transaction instance.
+         *
+         * @return a new Transaction
+         * @throws MissingRequiredFieldException if required fields are missing
+         */
+        public Transaction build() {
+            validate();
+            return new Transaction(this);
+        }
+
+        private void validate() {
+            MissingRequiredFieldException.requireNonNull(accountId, "accountId");
+            MissingRequiredFieldException.requireNonNull(accountType, "accountType");
+            MissingRequiredFieldException.requireNonNull(period, "period");
+            MissingRequiredFieldException.requireNonNull(transactionType, "transactionType");
+        }
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/model/TransactionType.java
+++ b/src/main/java/io/github/xmljim/retirement/model/TransactionType.java
@@ -1,5 +1,12 @@
 package io.github.xmljim.retirement.model;
 
+/**
+ * Types of transactions in a retirement portfolio simulation.
+ *
+ * @deprecated Use {@link io.github.xmljim.retirement.domain.enums.TransactionType} instead.
+ *             This class will be removed in a future version.
+ */
+@Deprecated
 public enum TransactionType {
 
     CONTRIBUTION,

--- a/src/test/java/io/github/xmljim/retirement/domain/model/TransactionTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/model/TransactionTest.java
@@ -1,0 +1,355 @@
+package io.github.xmljim.retirement.domain.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.time.YearMonth;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.github.xmljim.retirement.domain.enums.AccountType;
+import io.github.xmljim.retirement.domain.enums.TransactionType;
+import io.github.xmljim.retirement.domain.exception.MissingRequiredFieldException;
+import io.github.xmljim.retirement.domain.value.AssetAllocation;
+
+@DisplayName("Transaction Tests")
+class TransactionTest {
+
+    private static final String ACCOUNT_ID = "test-account-1";
+    private static final YearMonth JAN_2025 = YearMonth.of(2025, 1);
+    private static final YearMonth FEB_2025 = YearMonth.of(2025, 2);
+
+    private InvestmentAccount createTestAccount(double balance) {
+        return InvestmentAccount.builder()
+            .name("Test 401k")
+            .accountType(AccountType.TRADITIONAL_401K)
+            .balance(balance)
+            .allocation(AssetAllocation.balanced())
+            .preRetirementReturnRate(0.07)
+            .build();
+    }
+
+    @Nested
+    @DisplayName("Balance Calculations")
+    class BalanceCalculationTests {
+
+        @Test
+        @DisplayName("Should calculate end balance with contributions only")
+        void contributionsOnly() {
+            Transaction tx = Transaction.builder()
+                .accountId(ACCOUNT_ID)
+                .accountType(AccountType.TRADITIONAL_401K)
+                .period(JAN_2025)
+                .transactionType(TransactionType.CONTRIBUTION)
+                .startBalance(new BigDecimal("100000"))
+                .personalContribution(new BigDecimal("500"))
+                .employerContribution(new BigDecimal("150"))
+                .build();
+
+            // 100000 + 500 + 150 = 100650
+            assertEquals(0, new BigDecimal("100650.00").compareTo(tx.getEndBalance()));
+        }
+
+        @Test
+        @DisplayName("Should calculate end balance with all components")
+        void allComponents() {
+            Transaction tx = Transaction.builder()
+                .accountId(ACCOUNT_ID)
+                .accountType(AccountType.TRADITIONAL_401K)
+                .period(JAN_2025)
+                .transactionType(TransactionType.CONTRIBUTION)
+                .startBalance(new BigDecimal("100000"))
+                .personalContribution(new BigDecimal("500"))
+                .employerContribution(new BigDecimal("150"))
+                .investmentReturn(new BigDecimal("583.33"))
+                .build();
+
+            // 100000 + 500 + 150 + 583.33 = 101233.33
+            assertEquals(0, new BigDecimal("101233.33").compareTo(tx.getEndBalance()));
+        }
+
+        @Test
+        @DisplayName("Should calculate end balance with withdrawal")
+        void withWithdrawal() {
+            Transaction tx = Transaction.builder()
+                .accountId(ACCOUNT_ID)
+                .accountType(AccountType.TRADITIONAL_401K)
+                .period(JAN_2025)
+                .transactionType(TransactionType.WITHDRAWAL)
+                .startBalance(new BigDecimal("500000"))
+                .investmentReturn(new BigDecimal("2083.33"))
+                .withdrawal(new BigDecimal("3000"))
+                .build();
+
+            // 500000 + 2083.33 - 3000 = 499083.33
+            assertEquals(0, new BigDecimal("499083.33").compareTo(tx.getEndBalance()));
+        }
+
+        @Test
+        @DisplayName("Should calculate total contribution")
+        void totalContribution() {
+            Transaction tx = Transaction.builder()
+                .accountId(ACCOUNT_ID)
+                .accountType(AccountType.TRADITIONAL_401K)
+                .period(JAN_2025)
+                .transactionType(TransactionType.CONTRIBUTION)
+                .startBalance(new BigDecimal("100000"))
+                .personalContribution(new BigDecimal("500"))
+                .employerContribution(new BigDecimal("150"))
+                .build();
+
+            assertEquals(0, new BigDecimal("650.00").compareTo(tx.getTotalContribution()));
+        }
+
+        @Test
+        @DisplayName("Should calculate net change")
+        void netChange() {
+            Transaction tx = Transaction.builder()
+                .accountId(ACCOUNT_ID)
+                .accountType(AccountType.TRADITIONAL_401K)
+                .period(JAN_2025)
+                .transactionType(TransactionType.CONTRIBUTION)
+                .startBalance(new BigDecimal("100000"))
+                .personalContribution(new BigDecimal("500"))
+                .employerContribution(new BigDecimal("150"))
+                .investmentReturn(new BigDecimal("583.33"))
+                .build();
+
+            // Net change = 101233.33 - 100000 = 1233.33
+            assertEquals(0, new BigDecimal("1233.33").compareTo(tx.getNetChange()));
+        }
+
+        @Test
+        @DisplayName("Should handle zero values gracefully")
+        void zeroValues() {
+            Transaction tx = Transaction.builder()
+                .accountId(ACCOUNT_ID)
+                .accountType(AccountType.TRADITIONAL_401K)
+                .period(JAN_2025)
+                .transactionType(TransactionType.CONTRIBUTION)
+                .startBalance(new BigDecimal("100000"))
+                .build();
+
+            assertEquals(0, new BigDecimal("100000.00").compareTo(tx.getEndBalance()));
+            assertEquals(0, BigDecimal.ZERO.compareTo(tx.getPersonalContribution()));
+        }
+    }
+
+    @Nested
+    @DisplayName("Transaction Chaining")
+    class TransactionChainingTests {
+
+        @Test
+        @DisplayName("Should chain transactions with end balance becoming start balance")
+        void chainTransactions() {
+            Transaction first = Transaction.builder()
+                .accountId(ACCOUNT_ID)
+                .accountType(AccountType.TRADITIONAL_401K)
+                .period(JAN_2025)
+                .transactionType(TransactionType.CONTRIBUTION)
+                .startBalance(new BigDecimal("100000"))
+                .personalContribution(new BigDecimal("500"))
+                .investmentReturn(new BigDecimal("583.33"))
+                .build();
+
+            Transaction second = first.nextTransaction(FEB_2025)
+                .transactionType(TransactionType.CONTRIBUTION)
+                .personalContribution(new BigDecimal("500"))
+                .investmentReturn(new BigDecimal("590.00"))
+                .build();
+
+            // First end balance should be second start balance
+            assertEquals(0, first.getEndBalance().compareTo(second.getStartBalance()));
+            assertTrue(second.getPrevious().isPresent());
+            assertEquals(first.getId(), second.getPrevious().get().getId());
+        }
+
+        @Test
+        @DisplayName("Should identify first transaction in chain")
+        void firstTransaction() {
+            Transaction first = Transaction.builder()
+                .accountId(ACCOUNT_ID)
+                .accountType(AccountType.TRADITIONAL_401K)
+                .period(JAN_2025)
+                .transactionType(TransactionType.CONTRIBUTION)
+                .startBalance(new BigDecimal("100000"))
+                .build();
+
+            assertTrue(first.isFirst());
+            assertFalse(first.getPrevious().isPresent());
+        }
+
+        @Test
+        @DisplayName("Should maintain chain through multiple transactions")
+        void multipleChained() {
+            Transaction t1 = Transaction.builder()
+                .accountId(ACCOUNT_ID)
+                .accountType(AccountType.TRADITIONAL_401K)
+                .period(YearMonth.of(2025, 1))
+                .transactionType(TransactionType.CONTRIBUTION)
+                .startBalance(new BigDecimal("100000"))
+                .personalContribution(new BigDecimal("500"))
+                .build();
+
+            Transaction t2 = t1.nextTransaction(YearMonth.of(2025, 2))
+                .transactionType(TransactionType.CONTRIBUTION)
+                .personalContribution(new BigDecimal("500"))
+                .build();
+
+            Transaction t3 = t2.nextTransaction(YearMonth.of(2025, 3))
+                .transactionType(TransactionType.CONTRIBUTION)
+                .personalContribution(new BigDecimal("500"))
+                .build();
+
+            // Verify chain integrity
+            assertEquals(0, new BigDecimal("101500.00").compareTo(t3.getEndBalance()));
+            assertFalse(t3.isFirst());
+            assertTrue(t3.getPrevious().isPresent());
+            assertEquals(t2.getId(), t3.getPrevious().get().getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("Builder with InvestmentAccount")
+    class BuilderWithAccountTests {
+
+        @Test
+        @DisplayName("Should configure from InvestmentAccount")
+        void forAccount() {
+            InvestmentAccount account = createTestAccount(100000);
+
+            Transaction tx = Transaction.builder()
+                .forAccount(account)
+                .period(JAN_2025)
+                .transactionType(TransactionType.CONTRIBUTION)
+                .personalContribution(new BigDecimal("500"))
+                .build();
+
+            assertEquals(account.getId(), tx.getAccountId());
+            assertEquals(account.getAccountType(), tx.getAccountType());
+            assertEquals(0, account.getBalance().compareTo(tx.getStartBalance()));
+        }
+
+        @Test
+        @DisplayName("Should not override explicit start balance")
+        void explicitStartBalance() {
+            InvestmentAccount account = createTestAccount(100000);
+
+            Transaction tx = Transaction.builder()
+                .startBalance(new BigDecimal("50000"))
+                .forAccount(account)
+                .period(JAN_2025)
+                .transactionType(TransactionType.CONTRIBUTION)
+                .build();
+
+            // Explicit start balance should be preserved
+            assertEquals(0, new BigDecimal("50000.00").compareTo(tx.getStartBalance()));
+        }
+    }
+
+    @Nested
+    @DisplayName("Validation")
+    class ValidationTests {
+
+        @Test
+        @DisplayName("Should throw for missing accountId")
+        void missingAccountId() {
+            assertThrows(MissingRequiredFieldException.class, () ->
+                Transaction.builder()
+                    .accountType(AccountType.TRADITIONAL_401K)
+                    .period(JAN_2025)
+                    .transactionType(TransactionType.CONTRIBUTION)
+                    .build());
+        }
+
+        @Test
+        @DisplayName("Should throw for missing accountType")
+        void missingAccountType() {
+            assertThrows(MissingRequiredFieldException.class, () ->
+                Transaction.builder()
+                    .accountId(ACCOUNT_ID)
+                    .period(JAN_2025)
+                    .transactionType(TransactionType.CONTRIBUTION)
+                    .build());
+        }
+
+        @Test
+        @DisplayName("Should throw for missing period")
+        void missingPeriod() {
+            assertThrows(MissingRequiredFieldException.class, () ->
+                Transaction.builder()
+                    .accountId(ACCOUNT_ID)
+                    .accountType(AccountType.TRADITIONAL_401K)
+                    .transactionType(TransactionType.CONTRIBUTION)
+                    .build());
+        }
+
+        @Test
+        @DisplayName("Should throw for missing transactionType")
+        void missingTransactionType() {
+            assertThrows(MissingRequiredFieldException.class, () ->
+                Transaction.builder()
+                    .accountId(ACCOUNT_ID)
+                    .accountType(AccountType.TRADITIONAL_401K)
+                    .period(JAN_2025)
+                    .build());
+        }
+    }
+
+    @Nested
+    @DisplayName("Properties")
+    class PropertyTests {
+
+        @Test
+        @DisplayName("Should generate ID if not provided")
+        void generatesId() {
+            Transaction tx = Transaction.builder()
+                .accountId(ACCOUNT_ID)
+                .accountType(AccountType.TRADITIONAL_401K)
+                .period(JAN_2025)
+                .transactionType(TransactionType.CONTRIBUTION)
+                .build();
+
+            assertNotNull(tx.getId());
+            assertFalse(tx.getId().isEmpty());
+        }
+
+        @Test
+        @DisplayName("Should use provided ID")
+        void usesProvidedId() {
+            String customId = "custom-tx-id";
+            Transaction tx = Transaction.builder()
+                .id(customId)
+                .accountId(ACCOUNT_ID)
+                .accountType(AccountType.TRADITIONAL_401K)
+                .period(JAN_2025)
+                .transactionType(TransactionType.CONTRIBUTION)
+                .build();
+
+            assertEquals(customId, tx.getId());
+        }
+
+        @Test
+        @DisplayName("Should scale amounts to 2 decimal places")
+        void scalesAmounts() {
+            Transaction tx = Transaction.builder()
+                .accountId(ACCOUNT_ID)
+                .accountType(AccountType.TRADITIONAL_401K)
+                .period(JAN_2025)
+                .transactionType(TransactionType.CONTRIBUTION)
+                .startBalance(new BigDecimal("100000.999"))
+                .personalContribution(new BigDecimal("500.555"))
+                .build();
+
+            assertEquals(2, tx.getStartBalance().scale());
+            assertEquals(2, tx.getPersonalContribution().scale());
+            assertEquals(2, tx.getEndBalance().scale());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `TransactionType` enum in `domain/enums` (CONTRIBUTION, WITHDRAWAL)
- Add new `Transaction` class in `domain/model` with complete balance tracking
- Support transaction chaining via `previous` reference and `nextTransaction()` builder
- Auto-calculate end balance: `start + personal + employer + returns - withdrawal`
- Builder pattern with `forAccount()` integration for InvestmentAccount

## Key Features
- Immutable design
- Proper 2 decimal place scaling
- Helper methods: `getTotalContribution()`, `getNetChange()`, `isFirst()`
- Chain builder: `tx.nextTransaction(nextPeriod)` inherits account info and uses end balance

## Test Plan
- [x] Balance calculations with contributions only
- [x] Balance calculations with all components
- [x] Balance calculations with withdrawals
- [x] Transaction chaining (end balance → start balance)
- [x] Multiple chained transactions
- [x] Builder with InvestmentAccount integration
- [x] Validation for required fields
- [x] Amount scaling to 2 decimal places
- [x] Checkstyle passes

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)