### PR TITLE
feat(#133): Extract CompoundingFunction interface for flexible interest calculations

### DIFF
--- a/src/main/java/io/github/xmljim/retirement/domain/calculator/CompoundingFunction.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/calculator/CompoundingFunction.java
@@ -1,0 +1,61 @@
+package io.github.xmljim.retirement.domain.calculator;
+
+import java.math.BigDecimal;
+
+/**
+ * Functional interface for compounding interest calculations.
+ *
+ * <p>Different financial instruments use different compounding formulas:
+ * <ul>
+ *   <li><b>Annual</b>: Investments typically use true annual compounding</li>
+ *   <li><b>Monthly</b>: Savings accounts often compound monthly</li>
+ *   <li><b>Daily</b>: Credit cards and some loans compound daily</li>
+ *   <li><b>Continuous</b>: Theoretical maximum compounding frequency</li>
+ * </ul>
+ *
+ * <p>This interface follows the Strategy Pattern, allowing different
+ * compounding strategies to be plugged into calculators.
+ *
+ * <p>Standard implementations are available in {@link CompoundingFunctions}.
+ *
+ * @see CompoundingFunctions
+ */
+@FunctionalInterface
+public interface CompoundingFunction {
+
+    /**
+     * Calculates the ending balance after applying compound interest.
+     *
+     * <p>The interpretation of {@code periods} depends on the implementation:
+     * <ul>
+     *   <li>ANNUAL compounding: periods are months (compounds annually)</li>
+     *   <li>MONTHLY compounding: periods are months</li>
+     *   <li>DAILY compounding: periods are days</li>
+     *   <li>CONTINUOUS compounding: periods are months</li>
+     * </ul>
+     *
+     * @param principal the starting balance (must be non-negative)
+     * @param annualRate the annual interest rate as decimal (0.10 for 10%)
+     * @param periods the number of periods (interpretation depends on implementation)
+     * @return the ending balance after compounding
+     */
+    BigDecimal compound(BigDecimal principal, BigDecimal annualRate, int periods);
+
+    /**
+     * Returns the name of this compounding function.
+     *
+     * @return a descriptive name
+     */
+    default String getName() {
+        return "Custom";
+    }
+
+    /**
+     * Returns the formula description for documentation purposes.
+     *
+     * @return the mathematical formula
+     */
+    default String getFormula() {
+        return "Custom compounding formula";
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/domain/calculator/CompoundingFunctions.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/calculator/CompoundingFunctions.java
@@ -1,0 +1,222 @@
+package io.github.xmljim.retirement.domain.calculator;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import io.github.xmljim.retirement.domain.calculator.impl.MathUtils;
+
+/**
+ * Standard compounding function implementations.
+ *
+ * <p>Provides commonly used compounding strategies:
+ * <ul>
+ *   <li>{@link #ANNUAL} - True annual compounding (for investments)</li>
+ *   <li>{@link #MONTHLY} - Discrete monthly compounding (for savings)</li>
+ *   <li>{@link #DAILY} - Daily compounding (for credit cards)</li>
+ *   <li>{@link #CONTINUOUS} - Continuous compounding (theoretical maximum)</li>
+ * </ul>
+ *
+ * <p>Usage example:
+ * <pre>{@code
+ * BigDecimal result = CompoundingFunctions.ANNUAL.compound(
+ *     new BigDecimal("10000"),  // principal
+ *     new BigDecimal("0.10"),   // 10% annual rate
+ *     24                        // 24 months
+ * );
+ * // result = 10000 * (1.10)^(24/12) = 10000 * 1.21 = 12100
+ * }</pre>
+ */
+public final class CompoundingFunctions {
+
+    private static final int SCALE = 10;
+    private static final RoundingMode ROUNDING_MODE = RoundingMode.HALF_UP;
+    private static final int MONTHS_PER_YEAR = 12;
+    private static final int DAYS_PER_YEAR = 365;
+
+    private CompoundingFunctions() {
+        // Prevent instantiation
+    }
+
+    /**
+     * True annual compounding.
+     *
+     * <p>Formula: {@code principal * (1 + annualRate)^(months/12)}
+     *
+     * <p>This is the standard for investment growth calculations where
+     * the annual rate represents the expected yearly return, compounded
+     * once per year but prorated for partial years.
+     *
+     * <p>Example: $100 at 10% annual rate for 6 months:
+     * <pre>
+     * 100 * (1.10)^(6/12) = 100 * (1.10)^0.5 = 104.88
+     * </pre>
+     */
+    public static final CompoundingFunction ANNUAL = new CompoundingFunction() {
+        @Override
+        public BigDecimal compound(BigDecimal principal, BigDecimal annualRate, int periods) {
+            if (principal == null || principal.compareTo(BigDecimal.ZERO) == 0) {
+                return principal != null ? principal : BigDecimal.ZERO;
+            }
+            if (annualRate == null || annualRate.compareTo(BigDecimal.ZERO) == 0) {
+                return principal;
+            }
+            if (periods <= 0) {
+                return principal;
+            }
+
+            // principal * (1 + annualRate)^(months/12)
+            BigDecimal base = BigDecimal.ONE.add(annualRate);
+            double exponent = periods / (double) MONTHS_PER_YEAR;
+            BigDecimal factor = MathUtils.pow(base, exponent, SCALE, ROUNDING_MODE);
+
+            return principal.multiply(factor).setScale(SCALE, ROUNDING_MODE);
+        }
+
+        @Override
+        public String getName() {
+            return "Annual";
+        }
+
+        @Override
+        public String getFormula() {
+            return "principal * (1 + annualRate)^(months/12)";
+        }
+    };
+
+    /**
+     * Discrete monthly compounding.
+     *
+     * <p>Formula: {@code principal * (1 + annualRate/12)^months}
+     *
+     * <p>Common for savings accounts and CDs where interest is credited
+     * monthly at 1/12th of the annual rate.
+     *
+     * <p>Example: $100 at 12% annual rate for 6 months:
+     * <pre>
+     * 100 * (1 + 0.12/12)^6 = 100 * (1.01)^6 = 106.15
+     * </pre>
+     */
+    public static final CompoundingFunction MONTHLY = new CompoundingFunction() {
+        @Override
+        public BigDecimal compound(BigDecimal principal, BigDecimal annualRate, int periods) {
+            if (principal == null || principal.compareTo(BigDecimal.ZERO) == 0) {
+                return principal != null ? principal : BigDecimal.ZERO;
+            }
+            if (annualRate == null || annualRate.compareTo(BigDecimal.ZERO) == 0) {
+                return principal;
+            }
+            if (periods <= 0) {
+                return principal;
+            }
+
+            // principal * (1 + annualRate/12)^months
+            BigDecimal monthlyRate = annualRate.divide(
+                BigDecimal.valueOf(MONTHS_PER_YEAR), SCALE, ROUNDING_MODE);
+            BigDecimal base = BigDecimal.ONE.add(monthlyRate);
+            BigDecimal factor = MathUtils.pow(base, periods, SCALE, ROUNDING_MODE);
+
+            return principal.multiply(factor).setScale(SCALE, ROUNDING_MODE);
+        }
+
+        @Override
+        public String getName() {
+            return "Monthly";
+        }
+
+        @Override
+        public String getFormula() {
+            return "principal * (1 + annualRate/12)^months";
+        }
+    };
+
+    /**
+     * Daily compounding.
+     *
+     * <p>Formula: {@code principal * (1 + annualRate/365)^days}
+     *
+     * <p>Common for credit cards and some loans. Note that this function
+     * expects the period parameter to be in days, not months.
+     *
+     * <p>Example: $100 at 18% annual rate for 30 days:
+     * <pre>
+     * 100 * (1 + 0.18/365)^30 = 100 * 1.01485 = 101.49
+     * </pre>
+     */
+    public static final CompoundingFunction DAILY = new CompoundingFunction() {
+        @Override
+        public BigDecimal compound(BigDecimal principal, BigDecimal annualRate, int periods) {
+            if (principal == null || principal.compareTo(BigDecimal.ZERO) == 0) {
+                return principal != null ? principal : BigDecimal.ZERO;
+            }
+            if (annualRate == null || annualRate.compareTo(BigDecimal.ZERO) == 0) {
+                return principal;
+            }
+            if (periods <= 0) {
+                return principal;
+            }
+
+            // principal * (1 + annualRate/365)^days
+            BigDecimal dailyRate = annualRate.divide(
+                BigDecimal.valueOf(DAYS_PER_YEAR), SCALE, ROUNDING_MODE);
+            BigDecimal base = BigDecimal.ONE.add(dailyRate);
+            BigDecimal factor = MathUtils.pow(base, periods, SCALE, ROUNDING_MODE);
+
+            return principal.multiply(factor).setScale(SCALE, ROUNDING_MODE);
+        }
+
+        @Override
+        public String getName() {
+            return "Daily";
+        }
+
+        @Override
+        public String getFormula() {
+            return "principal * (1 + annualRate/365)^days";
+        }
+    };
+
+    /**
+     * Continuous compounding.
+     *
+     * <p>Formula: {@code principal * e^(annualRate * years)}
+     *
+     * <p>Theoretical maximum compounding frequency. Periods are months
+     * which are converted to years for the calculation.
+     *
+     * <p>Example: $100 at 10% annual rate for 12 months (1 year):
+     * <pre>
+     * 100 * e^(0.10 * 1) = 100 * 1.1052 = 110.52
+     * </pre>
+     */
+    public static final CompoundingFunction CONTINUOUS = new CompoundingFunction() {
+        @Override
+        public BigDecimal compound(BigDecimal principal, BigDecimal annualRate, int periods) {
+            if (principal == null || principal.compareTo(BigDecimal.ZERO) == 0) {
+                return principal != null ? principal : BigDecimal.ZERO;
+            }
+            if (annualRate == null || annualRate.compareTo(BigDecimal.ZERO) == 0) {
+                return principal;
+            }
+            if (periods <= 0) {
+                return principal;
+            }
+
+            // principal * e^(annualRate * years)
+            double years = periods / (double) MONTHS_PER_YEAR;
+            double exponent = annualRate.doubleValue() * years;
+            double factor = Math.exp(exponent);
+
+            return principal.multiply(BigDecimal.valueOf(factor)).setScale(SCALE, ROUNDING_MODE);
+        }
+
+        @Override
+        public String getName() {
+            return "Continuous";
+        }
+
+        @Override
+        public String getFormula() {
+            return "principal * e^(annualRate * years)";
+        }
+    };
+}

--- a/src/main/java/io/github/xmljim/retirement/domain/calculator/ReturnCalculator.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/calculator/ReturnCalculator.java
@@ -63,7 +63,7 @@ public interface ReturnCalculator {
     /**
      * Calculates the growth of an account balance over a period.
      *
-     * <p>Uses true annual compounding formula:
+     * <p>Uses true annual compounding formula by default:
      * <pre>
      * endBalance = balance * (1 + annualRate)^(months/12)
      * </pre>
@@ -81,6 +81,24 @@ public interface ReturnCalculator {
      * @throws CalculationException if balance is negative or months is negative
      */
     BigDecimal calculateAccountGrowth(BigDecimal balance, BigDecimal annualReturnRate, int months);
+
+    /**
+     * Calculates the growth of an account balance using a specific compounding function.
+     *
+     * <p>This method allows custom compounding strategies to be used instead of
+     * the default true annual compounding.
+     *
+     * @param balance the current account balance (must be non-negative)
+     * @param annualReturnRate the annual return rate as a decimal (e.g., 0.10 for 10%)
+     * @param periods the number of periods (interpretation depends on compounding function)
+     * @param compounding the compounding function to use
+     * @return the ending balance after growth
+     * @throws MissingRequiredFieldException if balance or compounding is null
+     * @throws CalculationException if balance is negative or periods is negative
+     * @see CompoundingFunctions
+     */
+    BigDecimal calculateAccountGrowth(BigDecimal balance, BigDecimal annualReturnRate,
+                                      int periods, CompoundingFunction compounding);
 
     /**
      * Converts an annual return rate to a monthly return rate.

--- a/src/main/java/io/github/xmljim/retirement/domain/calculator/impl/MathUtils.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/calculator/impl/MathUtils.java
@@ -10,7 +10,7 @@ import java.math.RoundingMode;
  * <p>This class provides high-precision BigDecimal arithmetic operations
  * that are commonly needed across calculator implementations.
  */
-final class MathUtils {
+public final class MathUtils {
 
     private static final int DEFAULT_SCALE = 10;
     private static final RoundingMode DEFAULT_ROUNDING = RoundingMode.HALF_UP;
@@ -31,7 +31,7 @@ final class MathUtils {
      * @param roundingMode the rounding mode to use
      * @return base^exponent
      */
-    static BigDecimal pow(BigDecimal base, int exponent, int scale, RoundingMode roundingMode) {
+    public static BigDecimal pow(BigDecimal base, int exponent, int scale, RoundingMode roundingMode) {
         if (exponent == 0) {
             return BigDecimal.ONE;
         }
@@ -64,7 +64,7 @@ final class MathUtils {
      * @param exponent the exponent (must be non-negative)
      * @return base^exponent
      */
-    static BigDecimal pow(BigDecimal base, int exponent) {
+    public static BigDecimal pow(BigDecimal base, int exponent) {
         return pow(base, exponent, DEFAULT_SCALE, DEFAULT_ROUNDING);
     }
 
@@ -85,7 +85,7 @@ final class MathUtils {
      * @param roundingMode the rounding mode to use
      * @return base^exponent as a BigDecimal
      */
-    static BigDecimal pow(BigDecimal base, double exponent, int scale, RoundingMode roundingMode) {
+    public static BigDecimal pow(BigDecimal base, double exponent, int scale, RoundingMode roundingMode) {
         if (exponent == 0.0) {
             return BigDecimal.ONE;
         }
@@ -104,7 +104,7 @@ final class MathUtils {
      * @param exponent the fractional exponent
      * @return base^exponent as a BigDecimal
      */
-    static BigDecimal pow(BigDecimal base, double exponent) {
+    public static BigDecimal pow(BigDecimal base, double exponent) {
         return pow(base, exponent, DEFAULT_SCALE, DEFAULT_ROUNDING);
     }
 }

--- a/src/test/java/io/github/xmljim/retirement/domain/calculator/CompoundingFunctionsTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/calculator/CompoundingFunctionsTest.java
@@ -1,0 +1,248 @@
+package io.github.xmljim.retirement.domain.calculator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("CompoundingFunctions Tests")
+class CompoundingFunctionsTest {
+
+    private static final BigDecimal PRINCIPAL = new BigDecimal("10000");
+    private static final BigDecimal TEN_PERCENT = new BigDecimal("0.10");
+    private static final BigDecimal TWELVE_PERCENT = new BigDecimal("0.12");
+
+    @Nested
+    @DisplayName("ANNUAL Compounding")
+    class AnnualCompoundingTests {
+
+        @Test
+        @DisplayName("Should calculate annual compounding for 12 months")
+        void annualCompoundingOneYear() {
+            // 10000 * (1.10)^(12/12) = 10000 * 1.10 = 11000
+            BigDecimal result = CompoundingFunctions.ANNUAL.compound(PRINCIPAL, TEN_PERCENT, 12);
+
+            assertEquals(0, new BigDecimal("11000").compareTo(result.setScale(0, java.math.RoundingMode.HALF_UP)));
+        }
+
+        @Test
+        @DisplayName("Should calculate annual compounding for 6 months")
+        void annualCompoundingSixMonths() {
+            // 10000 * (1.10)^(6/12) = 10000 * (1.10)^0.5 = 10488.09
+            BigDecimal result = CompoundingFunctions.ANNUAL.compound(PRINCIPAL, TEN_PERCENT, 6);
+
+            assertTrue(result.compareTo(new BigDecimal("10480")) > 0);
+            assertTrue(result.compareTo(new BigDecimal("10500")) < 0);
+        }
+
+        @Test
+        @DisplayName("Should calculate annual compounding for 24 months")
+        void annualCompoundingTwoYears() {
+            // 10000 * (1.10)^(24/12) = 10000 * 1.21 = 12100
+            BigDecimal result = CompoundingFunctions.ANNUAL.compound(PRINCIPAL, TEN_PERCENT, 24);
+
+            assertEquals(0, new BigDecimal("12100").compareTo(result.setScale(0, java.math.RoundingMode.HALF_UP)));
+        }
+
+        @Test
+        @DisplayName("Should return principal for zero periods")
+        void zeroPeriods() {
+            BigDecimal result = CompoundingFunctions.ANNUAL.compound(PRINCIPAL, TEN_PERCENT, 0);
+            assertEquals(0, PRINCIPAL.compareTo(result));
+        }
+
+        @Test
+        @DisplayName("Should return principal for zero rate")
+        void zeroRate() {
+            BigDecimal result = CompoundingFunctions.ANNUAL.compound(PRINCIPAL, BigDecimal.ZERO, 12);
+            assertEquals(0, PRINCIPAL.compareTo(result));
+        }
+
+        @Test
+        @DisplayName("Should have correct name and formula")
+        void nameAndFormula() {
+            assertEquals("Annual", CompoundingFunctions.ANNUAL.getName());
+            assertTrue(CompoundingFunctions.ANNUAL.getFormula().contains("months/12"));
+        }
+    }
+
+    @Nested
+    @DisplayName("MONTHLY Compounding")
+    class MonthlyCompoundingTests {
+
+        @Test
+        @DisplayName("Should calculate monthly compounding for 12 months")
+        void monthlyCompoundingOneYear() {
+            // 10000 * (1 + 0.12/12)^12 = 10000 * (1.01)^12 = 11268.25
+            BigDecimal result = CompoundingFunctions.MONTHLY.compound(PRINCIPAL, TWELVE_PERCENT, 12);
+
+            assertTrue(result.compareTo(new BigDecimal("11260")) > 0);
+            assertTrue(result.compareTo(new BigDecimal("11280")) < 0);
+        }
+
+        @Test
+        @DisplayName("Should calculate monthly compounding for 6 months")
+        void monthlyCompoundingSixMonths() {
+            // 10000 * (1 + 0.12/12)^6 = 10000 * (1.01)^6 = 10615.20
+            BigDecimal result = CompoundingFunctions.MONTHLY.compound(PRINCIPAL, TWELVE_PERCENT, 6);
+
+            assertTrue(result.compareTo(new BigDecimal("10610")) > 0);
+            assertTrue(result.compareTo(new BigDecimal("10620")) < 0);
+        }
+
+        @Test
+        @DisplayName("Monthly should compound more than annual for same rate")
+        void monthlyMoreThanAnnual() {
+            // Monthly compounding yields more than annual for the same nominal rate
+            BigDecimal annual = CompoundingFunctions.ANNUAL.compound(PRINCIPAL, TWELVE_PERCENT, 12);
+            BigDecimal monthly = CompoundingFunctions.MONTHLY.compound(PRINCIPAL, TWELVE_PERCENT, 12);
+
+            assertTrue(monthly.compareTo(annual) > 0);
+        }
+
+        @Test
+        @DisplayName("Should have correct name and formula")
+        void nameAndFormula() {
+            assertEquals("Monthly", CompoundingFunctions.MONTHLY.getName());
+            assertTrue(CompoundingFunctions.MONTHLY.getFormula().contains("annualRate/12"));
+        }
+    }
+
+    @Nested
+    @DisplayName("DAILY Compounding")
+    class DailyCompoundingTests {
+
+        @Test
+        @DisplayName("Should calculate daily compounding for 365 days")
+        void dailyCompoundingOneYear() {
+            // 10000 * (1 + 0.10/365)^365 = 10000 * 1.10516 = 11051.6
+            BigDecimal result = CompoundingFunctions.DAILY.compound(PRINCIPAL, TEN_PERCENT, 365);
+
+            // Should be slightly more than annual compounding (11000) due to more frequent compounding
+            assertTrue(result.compareTo(new BigDecimal("11040")) > 0);
+            assertTrue(result.compareTo(new BigDecimal("11060")) < 0);
+        }
+
+        @Test
+        @DisplayName("Should calculate daily compounding for 30 days")
+        void dailyCompounding30Days() {
+            // 10000 * (1 + 0.18/365)^30 = approximate
+            BigDecimal result = CompoundingFunctions.DAILY.compound(
+                PRINCIPAL, new BigDecimal("0.18"), 30);
+
+            assertTrue(result.compareTo(new BigDecimal("10140")) > 0);
+            assertTrue(result.compareTo(new BigDecimal("10160")) < 0);
+        }
+
+        @Test
+        @DisplayName("Should have correct name and formula")
+        void nameAndFormula() {
+            assertEquals("Daily", CompoundingFunctions.DAILY.getName());
+            assertTrue(CompoundingFunctions.DAILY.getFormula().contains("365"));
+        }
+    }
+
+    @Nested
+    @DisplayName("CONTINUOUS Compounding")
+    class ContinuousCompoundingTests {
+
+        @Test
+        @DisplayName("Should calculate continuous compounding for 12 months")
+        void continuousCompoundingOneYear() {
+            // 10000 * e^(0.10 * 1) = 10000 * 1.10517 = 11051.7
+            BigDecimal result = CompoundingFunctions.CONTINUOUS.compound(PRINCIPAL, TEN_PERCENT, 12);
+
+            assertTrue(result.compareTo(new BigDecimal("11040")) > 0);
+            assertTrue(result.compareTo(new BigDecimal("11060")) < 0);
+        }
+
+        @Test
+        @DisplayName("Continuous should compound most of all methods")
+        void continuousCompoundsTheMost() {
+            // Continuous is the theoretical maximum
+            BigDecimal annual = CompoundingFunctions.ANNUAL.compound(PRINCIPAL, TEN_PERCENT, 12);
+            BigDecimal monthly = CompoundingFunctions.MONTHLY.compound(PRINCIPAL, TEN_PERCENT, 12);
+            BigDecimal continuous = CompoundingFunctions.CONTINUOUS.compound(PRINCIPAL, TEN_PERCENT, 12);
+
+            assertTrue(continuous.compareTo(monthly) > 0);
+            assertTrue(monthly.compareTo(annual) > 0);
+        }
+
+        @Test
+        @DisplayName("Should have correct name and formula")
+        void nameAndFormula() {
+            assertEquals("Continuous", CompoundingFunctions.CONTINUOUS.getName());
+            assertTrue(CompoundingFunctions.CONTINUOUS.getFormula().contains("e^"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Edge Cases")
+    class EdgeCaseTests {
+
+        @Test
+        @DisplayName("Should handle null principal")
+        void nullPrincipal() {
+            BigDecimal result = CompoundingFunctions.ANNUAL.compound(null, TEN_PERCENT, 12);
+            assertEquals(0, BigDecimal.ZERO.compareTo(result));
+        }
+
+        @Test
+        @DisplayName("Should handle null rate")
+        void nullRate() {
+            BigDecimal result = CompoundingFunctions.ANNUAL.compound(PRINCIPAL, null, 12);
+            assertEquals(0, PRINCIPAL.compareTo(result));
+        }
+
+        @Test
+        @DisplayName("Should handle negative periods")
+        void negativePeriods() {
+            BigDecimal result = CompoundingFunctions.ANNUAL.compound(PRINCIPAL, TEN_PERCENT, -1);
+            assertEquals(0, PRINCIPAL.compareTo(result));
+        }
+
+        @Test
+        @DisplayName("Should handle zero principal")
+        void zeroPrincipal() {
+            BigDecimal result = CompoundingFunctions.ANNUAL.compound(BigDecimal.ZERO, TEN_PERCENT, 12);
+            assertEquals(0, BigDecimal.ZERO.compareTo(result));
+        }
+    }
+
+    @Nested
+    @DisplayName("ReturnCalculator Integration")
+    class ReturnCalculatorIntegrationTests {
+
+        @Test
+        @DisplayName("Should use compounding function in calculator")
+        void calculatorWithCompoundingFunction() {
+            ReturnCalculator calculator = CalculatorFactory.returnCalculator();
+
+            // Using ANNUAL (default)
+            BigDecimal annual = calculator.calculateAccountGrowth(PRINCIPAL, TEN_PERCENT, 12);
+
+            // Using MONTHLY explicitly
+            BigDecimal monthly = calculator.calculateAccountGrowth(
+                PRINCIPAL, TEN_PERCENT, 12, CompoundingFunctions.MONTHLY);
+
+            // Monthly should be higher
+            assertTrue(monthly.compareTo(annual) > 0);
+        }
+
+        @Test
+        @DisplayName("Default behavior should match ANNUAL")
+        void defaultMatchesAnnual() {
+            ReturnCalculator calculator = CalculatorFactory.returnCalculator();
+
+            BigDecimal defaultResult = calculator.calculateAccountGrowth(PRINCIPAL, TEN_PERCENT, 12);
+            BigDecimal annualResult = calculator.calculateAccountGrowth(
+                PRINCIPAL, TEN_PERCENT, 12, CompoundingFunctions.ANNUAL);
+
+            assertEquals(0, defaultResult.compareTo(annualResult));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `CompoundingFunction` functional interface for pluggable compound interest strategies
- Add `CompoundingFunctions` utility class with four standard implementations:
  - **ANNUAL**: `principal * (1 + rate)^(months/12)` - for investments
  - **MONTHLY**: `principal * (1 + rate/12)^months` - for savings accounts
  - **DAILY**: `principal * (1 + rate/365)^days` - for credit cards
  - **CONTINUOUS**: `principal * e^(rate * years)` - theoretical maximum
- Update `ReturnCalculator` to accept optional `CompoundingFunction`
- Make `MathUtils` public for use by `CompoundingFunctions`

## Test Plan
- [x] ANNUAL compounding (6, 12, 24 months)
- [x] MONTHLY compounding (6, 12 months)
- [x] DAILY compounding (30, 365 days)
- [x] CONTINUOUS compounding (12 months)
- [x] Edge cases (null, zero values, negative periods)
- [x] Verify monthly > annual > default for same rate
- [x] Verify continuous > monthly > annual
- [x] ReturnCalculator integration tests
- [x] Checkstyle passes

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)