### PR TITLE
feat(#142): Implement FilingStatus enum and IRA phase-out configuration

### DIFF
--- a/src/main/java/io/github/xmljim/retirement/domain/config/IraPhaseOutLimits.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/config/IraPhaseOutLimits.java
@@ -1,0 +1,252 @@
+package io.github.xmljim.retirement.domain.config;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.github.xmljim.retirement.domain.enums.FilingStatus;
+
+/**
+ * IRS IRA phase-out limits loaded from external YAML configuration.
+ *
+ * <p>Phase-outs determine when Traditional IRA deductions are reduced
+ * and when Roth IRA contributions are limited based on MAGI.
+ */
+@ConfigurationProperties(prefix = "irs.phase-out")
+@Validated
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP",
+    justification = "Spring @ConfigurationProperties requires mutable access for binding"
+)
+public class IraPhaseOutLimits {
+
+    private static final BigDecimal INCOME_INCREMENT = new BigDecimal("1000");
+    private static final RoundingMode ROUNDING_MODE = RoundingMode.HALF_UP;
+
+    private BigDecimal defaultAnnualIncreaseRate = new BigDecimal("0.02");
+    private Map<Integer, YearPhaseOuts> rothIra = new HashMap<>();
+    private Map<Integer, YearPhaseOuts> traditionalIraCovered = new HashMap<>();
+    private Map<Integer, YearPhaseOuts> traditionalIraSpouseCovered = new HashMap<>();
+
+    /**
+     * Phase-out thresholds for a specific year by filing status.
+     *
+     * @param single thresholds for single/HOH filers
+     * @param marriedFilingJointly thresholds for MFJ/QSS filers
+     * @param marriedFilingSeparately thresholds for MFS filers
+     */
+    public record YearPhaseOuts(
+        PhaseOutRange single,
+        PhaseOutRange marriedFilingJointly,
+        PhaseOutRange marriedFilingSeparately
+    ) {
+        /**
+         * Creates YearPhaseOuts with defaults for null values.
+         */
+        public YearPhaseOuts {
+            if (single == null) {
+                single = PhaseOutRange.ZERO;
+            }
+            if (marriedFilingJointly == null) {
+                marriedFilingJointly = PhaseOutRange.ZERO;
+            }
+            if (marriedFilingSeparately == null) {
+                marriedFilingSeparately = PhaseOutRange.ZERO;
+            }
+        }
+
+        /**
+         * Returns the phase-out range for the given filing status.
+         *
+         * @param status the filing status
+         * @return the applicable phase-out range
+         */
+        public PhaseOutRange forStatus(FilingStatus status) {
+            return switch (status) {
+                case SINGLE, HEAD_OF_HOUSEHOLD -> single;
+                case MARRIED_FILING_JOINTLY, QUALIFYING_SURVIVING_SPOUSE -> marriedFilingJointly;
+                case MARRIED_FILING_SEPARATELY -> marriedFilingSeparately;
+            };
+        }
+    }
+
+    /**
+     * MAGI range where phase-out occurs.
+     *
+     * @param lowerBound MAGI below this = full contribution allowed
+     * @param upperBound MAGI above this = no contribution allowed
+     */
+    public record PhaseOutRange(BigDecimal lowerBound, BigDecimal upperBound) {
+        /** Zero range indicating no phase-out applies. */
+        public static final PhaseOutRange ZERO = new PhaseOutRange(BigDecimal.ZERO, BigDecimal.ZERO);
+
+        /**
+         * Creates PhaseOutRange with defaults for null values.
+         */
+        public PhaseOutRange {
+            if (lowerBound == null) {
+                lowerBound = BigDecimal.ZERO;
+            }
+            if (upperBound == null) {
+                upperBound = BigDecimal.ZERO;
+            }
+        }
+
+        /**
+         * Returns the size of the phase-out range.
+         *
+         * @return upper minus lower bound
+         */
+        public BigDecimal getRange() {
+            return upperBound.subtract(lowerBound);
+        }
+    }
+
+    /**
+     * Returns Roth IRA phase-outs for the specified year.
+     *
+     * @param year the tax year
+     * @return phase-out thresholds by filing status
+     */
+    public YearPhaseOuts getRothIraPhaseOutsForYear(int year) {
+        return getPhaseOutsForYear(rothIra, year);
+    }
+
+    /**
+     * Returns Traditional IRA deductibility phase-outs when covered by employer plan.
+     *
+     * @param year the tax year
+     * @return phase-out thresholds by filing status
+     */
+    public YearPhaseOuts getTraditionalIraCoveredPhaseOutsForYear(int year) {
+        return getPhaseOutsForYear(traditionalIraCovered, year);
+    }
+
+    /**
+     * Returns Traditional IRA deductibility phase-outs when spouse is covered.
+     *
+     * @param year the tax year
+     * @return phase-out thresholds by filing status
+     */
+    public YearPhaseOuts getTraditionalIraSpouseCoveredPhaseOutsForYear(int year) {
+        return getPhaseOutsForYear(traditionalIraSpouseCovered, year);
+    }
+
+    private YearPhaseOuts getPhaseOutsForYear(Map<Integer, YearPhaseOuts> map, int year) {
+        if (map.containsKey(year)) {
+            return map.get(year);
+        }
+        NavigableMap<Integer, YearPhaseOuts> sorted = new TreeMap<>(map);
+        if (sorted.isEmpty()) {
+            return new YearPhaseOuts(PhaseOutRange.ZERO, PhaseOutRange.ZERO, PhaseOutRange.ZERO);
+        }
+        var latest = sorted.lastEntry();
+        if (year <= latest.getKey()) {
+            var floor = sorted.floorEntry(year);
+            return floor != null ? floor.getValue() : latest.getValue();
+        }
+        return extrapolate(latest.getValue(), year - latest.getKey());
+    }
+
+    private YearPhaseOuts extrapolate(YearPhaseOuts base, int years) {
+        BigDecimal mult = BigDecimal.ONE.add(defaultAnnualIncreaseRate).pow(years);
+        return new YearPhaseOuts(
+            extrapolateRange(base.single(), mult),
+            extrapolateRange(base.marriedFilingJointly(), mult),
+            base.marriedFilingSeparately() // MFS thresholds typically don't change
+        );
+    }
+
+    private PhaseOutRange extrapolateRange(PhaseOutRange range, BigDecimal multiplier) {
+        return new PhaseOutRange(
+            roundToIncrement(range.lowerBound().multiply(multiplier)),
+            roundToIncrement(range.upperBound().multiply(multiplier))
+        );
+    }
+
+    private BigDecimal roundToIncrement(BigDecimal value) {
+        if (value == null || value.compareTo(BigDecimal.ZERO) == 0) {
+            return BigDecimal.ZERO;
+        }
+        return value.divide(INCOME_INCREMENT, 0, ROUNDING_MODE).multiply(INCOME_INCREMENT);
+    }
+
+    /**
+     * Returns the Roth IRA phase-out map.
+     *
+     * @return map of year to phase-outs
+     */
+    public Map<Integer, YearPhaseOuts> getRothIra() {
+        return rothIra;
+    }
+
+    /**
+     * Sets the Roth IRA phase-out map.
+     *
+     * @param rothIra the map
+     */
+    public void setRothIra(Map<Integer, YearPhaseOuts> rothIra) {
+        this.rothIra = rothIra;
+    }
+
+    /**
+     * Returns the Traditional IRA (covered) phase-out map.
+     *
+     * @return map of year to phase-outs
+     */
+    public Map<Integer, YearPhaseOuts> getTraditionalIraCovered() {
+        return traditionalIraCovered;
+    }
+
+    /**
+     * Sets the Traditional IRA (covered) phase-out map.
+     *
+     * @param traditionalIraCovered the map
+     */
+    public void setTraditionalIraCovered(Map<Integer, YearPhaseOuts> traditionalIraCovered) {
+        this.traditionalIraCovered = traditionalIraCovered;
+    }
+
+    /**
+     * Returns the Traditional IRA (spouse covered) phase-out map.
+     *
+     * @return map of year to phase-outs
+     */
+    public Map<Integer, YearPhaseOuts> getTraditionalIraSpouseCovered() {
+        return traditionalIraSpouseCovered;
+    }
+
+    /**
+     * Sets the Traditional IRA (spouse covered) phase-out map.
+     *
+     * @param traditionalIraSpouseCovered the map
+     */
+    public void setTraditionalIraSpouseCovered(Map<Integer, YearPhaseOuts> traditionalIraSpouseCovered) {
+        this.traditionalIraSpouseCovered = traditionalIraSpouseCovered;
+    }
+
+    /**
+     * Returns the default annual increase rate for extrapolation.
+     *
+     * @return the rate as a decimal
+     */
+    public BigDecimal getDefaultAnnualIncreaseRate() {
+        return defaultAnnualIncreaseRate;
+    }
+
+    /**
+     * Sets the default annual increase rate.
+     *
+     * @param rate the rate as a decimal
+     */
+    public void setDefaultAnnualIncreaseRate(BigDecimal rate) {
+        this.defaultAnnualIncreaseRate = rate;
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/domain/enums/FilingStatus.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/enums/FilingStatus.java
@@ -1,0 +1,112 @@
+package io.github.xmljim.retirement.domain.enums;
+
+/**
+ * Federal tax filing status for IRS calculations.
+ *
+ * <p>Filing status affects many tax-related calculations including:
+ * <ul>
+ *   <li>Traditional IRA deductibility phase-out ranges</li>
+ *   <li>Roth IRA contribution eligibility phase-out ranges</li>
+ *   <li>Tax bracket thresholds</li>
+ *   <li>Standard deduction amounts</li>
+ * </ul>
+ *
+ * <p>Special considerations:
+ * <ul>
+ *   <li>{@link #MARRIED_FILING_SEPARATELY} has unique restrictions for Roth IRA
+ *       (phase-out starts at $0 if living with spouse)</li>
+ *   <li>{@link #QUALIFYING_SURVIVING_SPOUSE} uses MFJ thresholds</li>
+ * </ul>
+ *
+ * @see <a href="https://www.irs.gov/filing/filing-status">IRS Filing Status</a>
+ */
+public enum FilingStatus {
+
+    /**
+     * Single filer - unmarried, divorced, or legally separated.
+     */
+    SINGLE("Single"),
+
+    /**
+     * Married Filing Jointly - married couple files one joint return.
+     *
+     * <p>This status typically has the highest income thresholds for
+     * contribution phase-outs.
+     */
+    MARRIED_FILING_JOINTLY("Married Filing Jointly"),
+
+    /**
+     * Married Filing Separately - married couple files separate returns.
+     *
+     * <p>This status has significant restrictions for retirement contributions:
+     * <ul>
+     *   <li>Roth IRA phase-out starts at $0 (if living with spouse)</li>
+     *   <li>Traditional IRA deductibility reduced</li>
+     * </ul>
+     *
+     * <p>Note: If not living with spouse during the year, the filer may
+     * use SINGLE status thresholds for IRA phase-outs.
+     */
+    MARRIED_FILING_SEPARATELY("Married Filing Separately"),
+
+    /**
+     * Head of Household - unmarried taxpayer who pays more than half
+     * the cost of maintaining a home for a qualifying person.
+     *
+     * <p>Uses same IRA phase-out thresholds as SINGLE for most purposes.
+     */
+    HEAD_OF_HOUSEHOLD("Head of Household"),
+
+    /**
+     * Qualifying Surviving Spouse (Widow/Widower) - surviving spouse
+     * with dependent child, for up to 2 years after spouse's death.
+     *
+     * <p>Uses same thresholds as MARRIED_FILING_JOINTLY.
+     */
+    QUALIFYING_SURVIVING_SPOUSE("Qualifying Surviving Spouse");
+
+    private final String displayName;
+
+    FilingStatus(String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
+     * Returns the human-readable display name.
+     *
+     * @return the display name
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * Returns whether this status uses SINGLE filer thresholds for IRA phase-outs.
+     *
+     * @return true for SINGLE and HEAD_OF_HOUSEHOLD
+     */
+    public boolean usesSingleThresholds() {
+        return this == SINGLE || this == HEAD_OF_HOUSEHOLD;
+    }
+
+    /**
+     * Returns whether this status uses MARRIED_FILING_JOINTLY thresholds.
+     *
+     * @return true for MFJ and QUALIFYING_SURVIVING_SPOUSE
+     */
+    public boolean usesJointThresholds() {
+        return this == MARRIED_FILING_JOINTLY || this == QUALIFYING_SURVIVING_SPOUSE;
+    }
+
+    /**
+     * Returns whether this status has special restrictions.
+     *
+     * <p>MARRIED_FILING_SEPARATELY has unique phase-out rules
+     * that differ significantly from other statuses.
+     *
+     * @return true for MARRIED_FILING_SEPARATELY
+     */
+    public boolean hasSpecialRestrictions() {
+        return this == MARRIED_FILING_SEPARATELY;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -64,3 +64,41 @@ irs:
         individual-limit: 4400   # Estimated
         family-limit: 8750       # Estimated
         catch-up-limit: 1000     # Not indexed for inflation
+
+  # IRA Phase-Out Limits
+  # Sources: IRS Publication 590-A, IRS News Releases
+  phase-out:
+    default-annual-increase-rate: 0.02
+
+    # Roth IRA contribution phase-outs by MAGI
+    roth-ira:
+      2024:
+        single: { lower-bound: 146000, upper-bound: 161000 }
+        married-filing-jointly: { lower-bound: 230000, upper-bound: 240000 }
+        married-filing-separately: { lower-bound: 0, upper-bound: 10000 }
+      2025:
+        single: { lower-bound: 150000, upper-bound: 165000 }
+        married-filing-jointly: { lower-bound: 236000, upper-bound: 246000 }
+        married-filing-separately: { lower-bound: 0, upper-bound: 10000 }
+
+    # Traditional IRA deductibility phase-outs (when covered by employer plan)
+    traditional-ira-covered:
+      2024:
+        single: { lower-bound: 77000, upper-bound: 87000 }
+        married-filing-jointly: { lower-bound: 123000, upper-bound: 143000 }
+        married-filing-separately: { lower-bound: 0, upper-bound: 10000 }
+      2025:
+        single: { lower-bound: 79000, upper-bound: 89000 }
+        married-filing-jointly: { lower-bound: 126000, upper-bound: 146000 }
+        married-filing-separately: { lower-bound: 0, upper-bound: 10000 }
+
+    # Traditional IRA deductibility phase-outs (not covered, but spouse is)
+    traditional-ira-spouse-covered:
+      2024:
+        single: { lower-bound: 0, upper-bound: 0 }  # N/A for single
+        married-filing-jointly: { lower-bound: 230000, upper-bound: 240000 }
+        married-filing-separately: { lower-bound: 0, upper-bound: 10000 }
+      2025:
+        single: { lower-bound: 0, upper-bound: 0 }  # N/A for single
+        married-filing-jointly: { lower-bound: 236000, upper-bound: 246000 }
+        married-filing-separately: { lower-bound: 0, upper-bound: 10000 }

--- a/src/test/java/io/github/xmljim/retirement/domain/config/IraPhaseOutLimitsTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/config/IraPhaseOutLimitsTest.java
@@ -1,0 +1,126 @@
+package io.github.xmljim.retirement.domain.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.github.xmljim.retirement.domain.config.IraPhaseOutLimits.PhaseOutRange;
+import io.github.xmljim.retirement.domain.config.IraPhaseOutLimits.YearPhaseOuts;
+import io.github.xmljim.retirement.domain.enums.FilingStatus;
+
+@DisplayName("IraPhaseOutLimits Tests")
+class IraPhaseOutLimitsTest {
+
+    private IraPhaseOutLimits limits;
+
+    @BeforeEach
+    void setUp() {
+        limits = new IraPhaseOutLimits();
+        limits.getRothIra().put(2024, new YearPhaseOuts(
+            new PhaseOutRange(new BigDecimal("146000"), new BigDecimal("161000")),
+            new PhaseOutRange(new BigDecimal("230000"), new BigDecimal("240000")),
+            new PhaseOutRange(BigDecimal.ZERO, new BigDecimal("10000"))
+        ));
+        limits.getRothIra().put(2025, new YearPhaseOuts(
+            new PhaseOutRange(new BigDecimal("150000"), new BigDecimal("165000")),
+            new PhaseOutRange(new BigDecimal("236000"), new BigDecimal("246000")),
+            new PhaseOutRange(BigDecimal.ZERO, new BigDecimal("10000"))
+        ));
+    }
+
+    @Nested
+    @DisplayName("Roth IRA Phase-Out Tests")
+    class RothIraTests {
+
+        @Test
+        @DisplayName("Should return 2024 Roth IRA limits for single")
+        void returns2024SingleLimits() {
+            var phaseOuts = limits.getRothIraPhaseOutsForYear(2024);
+            var range = phaseOuts.forStatus(FilingStatus.SINGLE);
+
+            assertEquals(0, new BigDecimal("146000").compareTo(range.lowerBound()));
+            assertEquals(0, new BigDecimal("161000").compareTo(range.upperBound()));
+        }
+
+        @Test
+        @DisplayName("Should return 2025 Roth IRA limits for MFJ")
+        void returns2025MfjLimits() {
+            var phaseOuts = limits.getRothIraPhaseOutsForYear(2025);
+            var range = phaseOuts.forStatus(FilingStatus.MARRIED_FILING_JOINTLY);
+
+            assertEquals(0, new BigDecimal("236000").compareTo(range.lowerBound()));
+            assertEquals(0, new BigDecimal("246000").compareTo(range.upperBound()));
+        }
+
+        @Test
+        @DisplayName("Should return MFS limits with restricted range")
+        void returnsMfsRestrictedLimits() {
+            var phaseOuts = limits.getRothIraPhaseOutsForYear(2024);
+            var range = phaseOuts.forStatus(FilingStatus.MARRIED_FILING_SEPARATELY);
+
+            assertEquals(0, BigDecimal.ZERO.compareTo(range.lowerBound()));
+            assertEquals(0, new BigDecimal("10000").compareTo(range.upperBound()));
+        }
+
+        @Test
+        @DisplayName("HEAD_OF_HOUSEHOLD uses single thresholds")
+        void hohUsesSingleThresholds() {
+            var phaseOuts = limits.getRothIraPhaseOutsForYear(2024);
+            var hohRange = phaseOuts.forStatus(FilingStatus.HEAD_OF_HOUSEHOLD);
+            var singleRange = phaseOuts.forStatus(FilingStatus.SINGLE);
+
+            assertEquals(singleRange, hohRange);
+        }
+    }
+
+    @Nested
+    @DisplayName("Extrapolation Tests")
+    class ExtrapolationTests {
+
+        @Test
+        @DisplayName("Should extrapolate future year limits")
+        void extrapolatesFutureYear() {
+            var phaseOuts = limits.getRothIraPhaseOutsForYear(2026);
+            assertNotNull(phaseOuts);
+
+            // 2025 single: $150,000 * 1.02 = $153,000 (rounded to $1000)
+            var range = phaseOuts.forStatus(FilingStatus.SINGLE);
+            assertEquals(0, new BigDecimal("153000").compareTo(range.lowerBound()));
+        }
+
+        @Test
+        @DisplayName("Should return empty phase-outs for empty config")
+        void returnsEmptyForEmptyConfig() {
+            IraPhaseOutLimits empty = new IraPhaseOutLimits();
+            var phaseOuts = empty.getRothIraPhaseOutsForYear(2024);
+
+            assertEquals(PhaseOutRange.ZERO, phaseOuts.forStatus(FilingStatus.SINGLE));
+        }
+    }
+
+    @Nested
+    @DisplayName("PhaseOutRange Tests")
+    class PhaseOutRangeTests {
+
+        @Test
+        @DisplayName("Should calculate range correctly")
+        void calculatesRange() {
+            var range = new PhaseOutRange(new BigDecimal("146000"), new BigDecimal("161000"));
+            assertEquals(0, new BigDecimal("15000").compareTo(range.getRange()));
+        }
+
+        @Test
+        @DisplayName("Should handle null values")
+        void handlesNullValues() {
+            var range = new PhaseOutRange(null, null);
+            assertEquals(BigDecimal.ZERO, range.lowerBound());
+            assertEquals(BigDecimal.ZERO, range.upperBound());
+        }
+    }
+}

--- a/src/test/java/io/github/xmljim/retirement/domain/enums/FilingStatusTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/enums/FilingStatusTest.java
@@ -1,0 +1,83 @@
+package io.github.xmljim.retirement.domain.enums;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("FilingStatus Tests")
+class FilingStatusTest {
+
+    @Nested
+    @DisplayName("Display Name Tests")
+    class DisplayNameTests {
+
+        @Test
+        @DisplayName("Should return correct display names")
+        void displayNames() {
+            assertEquals("Single", FilingStatus.SINGLE.getDisplayName());
+            assertEquals("Married Filing Jointly", FilingStatus.MARRIED_FILING_JOINTLY.getDisplayName());
+            assertEquals("Married Filing Separately", FilingStatus.MARRIED_FILING_SEPARATELY.getDisplayName());
+            assertEquals("Head of Household", FilingStatus.HEAD_OF_HOUSEHOLD.getDisplayName());
+            assertEquals("Qualifying Surviving Spouse", FilingStatus.QUALIFYING_SURVIVING_SPOUSE.getDisplayName());
+        }
+    }
+
+    @Nested
+    @DisplayName("Threshold Mapping Tests")
+    class ThresholdMappingTests {
+
+        @Test
+        @DisplayName("SINGLE uses single thresholds")
+        void singleUsesSingleThresholds() {
+            assertTrue(FilingStatus.SINGLE.usesSingleThresholds());
+            assertFalse(FilingStatus.SINGLE.usesJointThresholds());
+        }
+
+        @Test
+        @DisplayName("HEAD_OF_HOUSEHOLD uses single thresholds")
+        void hohUsesSingleThresholds() {
+            assertTrue(FilingStatus.HEAD_OF_HOUSEHOLD.usesSingleThresholds());
+            assertFalse(FilingStatus.HEAD_OF_HOUSEHOLD.usesJointThresholds());
+        }
+
+        @Test
+        @DisplayName("MARRIED_FILING_JOINTLY uses joint thresholds")
+        void mfjUsesJointThresholds() {
+            assertTrue(FilingStatus.MARRIED_FILING_JOINTLY.usesJointThresholds());
+            assertFalse(FilingStatus.MARRIED_FILING_JOINTLY.usesSingleThresholds());
+        }
+
+        @Test
+        @DisplayName("QUALIFYING_SURVIVING_SPOUSE uses joint thresholds")
+        void qssUsesJointThresholds() {
+            assertTrue(FilingStatus.QUALIFYING_SURVIVING_SPOUSE.usesJointThresholds());
+            assertFalse(FilingStatus.QUALIFYING_SURVIVING_SPOUSE.usesSingleThresholds());
+        }
+
+        @Test
+        @DisplayName("MARRIED_FILING_SEPARATELY uses neither")
+        void mfsUsesNeither() {
+            assertFalse(FilingStatus.MARRIED_FILING_SEPARATELY.usesSingleThresholds());
+            assertFalse(FilingStatus.MARRIED_FILING_SEPARATELY.usesJointThresholds());
+        }
+    }
+
+    @Nested
+    @DisplayName("Special Restrictions Tests")
+    class SpecialRestrictionsTests {
+
+        @Test
+        @DisplayName("Only MFS has special restrictions")
+        void onlyMfsHasSpecialRestrictions() {
+            assertTrue(FilingStatus.MARRIED_FILING_SEPARATELY.hasSpecialRestrictions());
+            assertFalse(FilingStatus.SINGLE.hasSpecialRestrictions());
+            assertFalse(FilingStatus.MARRIED_FILING_JOINTLY.hasSpecialRestrictions());
+            assertFalse(FilingStatus.HEAD_OF_HOUSEHOLD.hasSpecialRestrictions());
+            assertFalse(FilingStatus.QUALIFYING_SURVIVING_SPOUSE.hasSpecialRestrictions());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `FilingStatus` enum with 5 filing statuses and threshold helper methods
- Add `IraPhaseOutLimits` configuration class for YAML-driven phase-out thresholds
- Configure 2024-2025 IRS phase-out ranges for Roth IRA and Traditional IRA
- Support extrapolation for future years with IRS-style $1000 rounding

## Changes
- `FilingStatus.java` - Enum with SINGLE, MFJ, MFS, HOH, QSS and helper methods
- `IraPhaseOutLimits.java` - Spring `@ConfigurationProperties` for phase-out config
- `application.yml` - 2024-2025 phase-out thresholds from IRS publications
- Tests for both new classes (15 tests)

## Test plan
- [x] FilingStatus enum tests (display names, threshold mapping, special restrictions)
- [x] IraPhaseOutLimits tests (2024/2025 lookups, extrapolation, edge cases)
- [x] Full build passes (414 tests)

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)