### PR TITLE
feat(#141): Implement MAGI calculator

### DIFF
--- a/src/main/java/io/github/xmljim/retirement/domain/calculator/CalculatorFactory.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/calculator/CalculatorFactory.java
@@ -5,6 +5,7 @@ import io.github.xmljim.retirement.domain.calculator.impl.DefaultContributionLim
 import io.github.xmljim.retirement.domain.calculator.impl.DefaultContributionRouter;
 import io.github.xmljim.retirement.domain.calculator.impl.DefaultIncomeCalculator;
 import io.github.xmljim.retirement.domain.calculator.impl.DefaultInflationCalculator;
+import io.github.xmljim.retirement.domain.calculator.impl.DefaultMAGICalculator;
 import io.github.xmljim.retirement.domain.calculator.impl.DefaultReturnCalculator;
 import io.github.xmljim.retirement.domain.calculator.impl.DefaultWithdrawalCalculator;
 import io.github.xmljim.retirement.domain.calculator.impl.DefaultYTDContributionTracker;
@@ -43,6 +44,9 @@ public final class CalculatorFactory {
 
     private static final WithdrawalCalculator WITHDRAWAL_CALCULATOR =
         new DefaultWithdrawalCalculator();
+
+    private static final MAGICalculator MAGI_CALCULATOR =
+        new DefaultMAGICalculator();
 
     private CalculatorFactory() {
         // Prevent instantiation
@@ -91,6 +95,15 @@ public final class CalculatorFactory {
      */
     public static WithdrawalCalculator withdrawalCalculator() {
         return WITHDRAWAL_CALCULATOR;
+    }
+
+    /**
+     * Returns the MAGI calculator instance.
+     *
+     * @return the MAGI calculator
+     */
+    public static MAGICalculator magiCalculator() {
+        return MAGI_CALCULATOR;
     }
 
     /**

--- a/src/main/java/io/github/xmljim/retirement/domain/calculator/MAGICalculator.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/calculator/MAGICalculator.java
@@ -1,0 +1,53 @@
+package io.github.xmljim.retirement.domain.calculator;
+
+import java.math.BigDecimal;
+
+import io.github.xmljim.retirement.domain.value.IncomeDetails;
+
+/**
+ * Calculator for Modified Adjusted Gross Income (MAGI).
+ *
+ * <p>MAGI is used to determine eligibility for various tax benefits including:
+ * <ul>
+ *   <li>Roth IRA contribution eligibility</li>
+ *   <li>Traditional IRA deductibility (when covered by employer plan)</li>
+ *   <li>Premium tax credits (ACA)</li>
+ *   <li>Medicare premium surcharges (IRMAA)</li>
+ * </ul>
+ *
+ * <p>Note: Different tax provisions may define MAGI slightly differently.
+ * This calculator focuses on the IRA-specific definition from IRS Publication 590-A.
+ *
+ * @see IncomeDetails
+ */
+public interface MAGICalculator {
+
+    /**
+     * Calculates MAGI from income details.
+     *
+     * <p>MAGI for IRA purposes = AGI + certain deductions added back:
+     * <ul>
+     *   <li>Student loan interest deduction</li>
+     *   <li>Tuition and fees deduction</li>
+     *   <li>Foreign earned income exclusion</li>
+     *   <li>Foreign housing exclusion or deduction</li>
+     *   <li>Excluded Series EE/I savings bond interest</li>
+     *   <li>Excluded employer-provided adoption benefits</li>
+     * </ul>
+     *
+     * @param incomeDetails the income components
+     * @return the calculated MAGI
+     */
+    BigDecimal calculate(IncomeDetails incomeDetails);
+
+    /**
+     * Calculates MAGI from just AGI (no add-backs).
+     *
+     * <p>Use this when the taxpayer has no MAGI add-back items,
+     * in which case MAGI equals AGI.
+     *
+     * @param adjustedGrossIncome the AGI
+     * @return the MAGI (equal to AGI when no add-backs)
+     */
+    BigDecimal calculate(BigDecimal adjustedGrossIncome);
+}

--- a/src/main/java/io/github/xmljim/retirement/domain/calculator/impl/DefaultMAGICalculator.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/calculator/impl/DefaultMAGICalculator.java
@@ -1,0 +1,45 @@
+package io.github.xmljim.retirement.domain.calculator.impl;
+
+import java.math.BigDecimal;
+
+import org.springframework.stereotype.Service;
+
+import io.github.xmljim.retirement.domain.calculator.MAGICalculator;
+import io.github.xmljim.retirement.domain.exception.MissingRequiredFieldException;
+import io.github.xmljim.retirement.domain.value.IncomeDetails;
+
+/**
+ * Default implementation of MAGI calculator for IRA purposes.
+ *
+ * <p>Calculates Modified Adjusted Gross Income by adding back certain
+ * deductions to Adjusted Gross Income per IRS Publication 590-A.
+ *
+ * <p>Add-back items for IRA MAGI:
+ * <ul>
+ *   <li>Student loan interest deduction</li>
+ *   <li>Tuition and fees deduction (if applicable)</li>
+ *   <li>Foreign earned income exclusion</li>
+ *   <li>Foreign housing exclusion or deduction</li>
+ *   <li>Excluded savings bond interest (Form 8815)</li>
+ *   <li>Excluded employer-provided adoption benefits (Form 8839)</li>
+ * </ul>
+ */
+@Service
+public class DefaultMAGICalculator implements MAGICalculator {
+
+    @Override
+    public BigDecimal calculate(IncomeDetails incomeDetails) {
+        MissingRequiredFieldException.requireNonNull(incomeDetails, "incomeDetails");
+
+        return incomeDetails.adjustedGrossIncome()
+            .add(incomeDetails.getTotalAddBacks());
+    }
+
+    @Override
+    public BigDecimal calculate(BigDecimal adjustedGrossIncome) {
+        if (adjustedGrossIncome == null) {
+            return BigDecimal.ZERO;
+        }
+        return adjustedGrossIncome;
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/domain/value/IncomeDetails.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/value/IncomeDetails.java
@@ -1,0 +1,223 @@
+package io.github.xmljim.retirement.domain.value;
+
+import java.math.BigDecimal;
+
+import io.github.xmljim.retirement.domain.exception.ValidationException;
+
+/**
+ * Captures income components needed for MAGI calculation.
+ *
+ * <p>MAGI (Modified Adjusted Gross Income) for IRA purposes is calculated as:
+ * AGI + certain deductions that were subtracted to get AGI.
+ *
+ * <p>Example usage:
+ * <pre>{@code
+ * IncomeDetails income = IncomeDetails.builder()
+ *     .adjustedGrossIncome(new BigDecimal("150000"))
+ *     .studentLoanInterest(new BigDecimal("2500"))
+ *     .build();
+ *
+ * BigDecimal magi = magiCalculator.calculate(income);
+ * }</pre>
+ *
+ * @param adjustedGrossIncome AGI from tax return (Line 11 of Form 1040)
+ * @param studentLoanInterest student loan interest deduction claimed
+ * @param tuitionAndFees tuition and fees deduction (if applicable)
+ * @param foreignEarnedIncomeExclusion foreign earned income excluded
+ * @param foreignHousingExclusion foreign housing exclusion or deduction
+ * @param savingsBondInterestExclusion Series EE/I bond interest excluded
+ * @param adoptionBenefitsExclusion employer-provided adoption benefits excluded
+ */
+public record IncomeDetails(
+    BigDecimal adjustedGrossIncome,
+    BigDecimal studentLoanInterest,
+    BigDecimal tuitionAndFees,
+    BigDecimal foreignEarnedIncomeExclusion,
+    BigDecimal foreignHousingExclusion,
+    BigDecimal savingsBondInterestExclusion,
+    BigDecimal adoptionBenefitsExclusion
+) {
+    /**
+     * Creates IncomeDetails with validation and null handling.
+     */
+    public IncomeDetails {
+        if (adjustedGrossIncome == null) {
+            adjustedGrossIncome = BigDecimal.ZERO;
+        }
+        if (adjustedGrossIncome.compareTo(BigDecimal.ZERO) < 0) {
+            throw new ValidationException("adjustedGrossIncome", "AGI cannot be negative");
+        }
+        if (studentLoanInterest == null) {
+            studentLoanInterest = BigDecimal.ZERO;
+        }
+        if (tuitionAndFees == null) {
+            tuitionAndFees = BigDecimal.ZERO;
+        }
+        if (foreignEarnedIncomeExclusion == null) {
+            foreignEarnedIncomeExclusion = BigDecimal.ZERO;
+        }
+        if (foreignHousingExclusion == null) {
+            foreignHousingExclusion = BigDecimal.ZERO;
+        }
+        if (savingsBondInterestExclusion == null) {
+            savingsBondInterestExclusion = BigDecimal.ZERO;
+        }
+        if (adoptionBenefitsExclusion == null) {
+            adoptionBenefitsExclusion = BigDecimal.ZERO;
+        }
+    }
+
+    /**
+     * Returns the total of all MAGI add-backs.
+     *
+     * @return sum of all deductions to add back to AGI
+     */
+    public BigDecimal getTotalAddBacks() {
+        return studentLoanInterest
+            .add(tuitionAndFees)
+            .add(foreignEarnedIncomeExclusion)
+            .add(foreignHousingExclusion)
+            .add(savingsBondInterestExclusion)
+            .add(adoptionBenefitsExclusion);
+    }
+
+    /**
+     * Creates a builder for IncomeDetails.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Creates IncomeDetails with just AGI (no add-backs).
+     *
+     * @param agi the adjusted gross income
+     * @return IncomeDetails with only AGI set
+     */
+    public static IncomeDetails ofAgi(BigDecimal agi) {
+        return builder().adjustedGrossIncome(agi).build();
+    }
+
+    /**
+     * Builder for IncomeDetails.
+     */
+    public static final class Builder {
+        private BigDecimal adjustedGrossIncome;
+        private BigDecimal studentLoanInterest;
+        private BigDecimal tuitionAndFees;
+        private BigDecimal foreignEarnedIncomeExclusion;
+        private BigDecimal foreignHousingExclusion;
+        private BigDecimal savingsBondInterestExclusion;
+        private BigDecimal adoptionBenefitsExclusion;
+
+        private Builder() {
+        }
+
+        /**
+         * Sets the adjusted gross income.
+         *
+         * @param agi the AGI
+         * @return this builder
+         */
+        public Builder adjustedGrossIncome(BigDecimal agi) {
+            this.adjustedGrossIncome = agi;
+            return this;
+        }
+
+        /**
+         * Sets the adjusted gross income from a double.
+         *
+         * @param agi the AGI
+         * @return this builder
+         */
+        public Builder adjustedGrossIncome(double agi) {
+            this.adjustedGrossIncome = BigDecimal.valueOf(agi);
+            return this;
+        }
+
+        /**
+         * Sets the student loan interest deduction.
+         *
+         * @param amount the deduction amount
+         * @return this builder
+         */
+        public Builder studentLoanInterest(BigDecimal amount) {
+            this.studentLoanInterest = amount;
+            return this;
+        }
+
+        /**
+         * Sets the tuition and fees deduction.
+         *
+         * @param amount the deduction amount
+         * @return this builder
+         */
+        public Builder tuitionAndFees(BigDecimal amount) {
+            this.tuitionAndFees = amount;
+            return this;
+        }
+
+        /**
+         * Sets the foreign earned income exclusion.
+         *
+         * @param amount the exclusion amount
+         * @return this builder
+         */
+        public Builder foreignEarnedIncomeExclusion(BigDecimal amount) {
+            this.foreignEarnedIncomeExclusion = amount;
+            return this;
+        }
+
+        /**
+         * Sets the foreign housing exclusion.
+         *
+         * @param amount the exclusion amount
+         * @return this builder
+         */
+        public Builder foreignHousingExclusion(BigDecimal amount) {
+            this.foreignHousingExclusion = amount;
+            return this;
+        }
+
+        /**
+         * Sets the savings bond interest exclusion.
+         *
+         * @param amount the exclusion amount
+         * @return this builder
+         */
+        public Builder savingsBondInterestExclusion(BigDecimal amount) {
+            this.savingsBondInterestExclusion = amount;
+            return this;
+        }
+
+        /**
+         * Sets the adoption benefits exclusion.
+         *
+         * @param amount the exclusion amount
+         * @return this builder
+         */
+        public Builder adoptionBenefitsExclusion(BigDecimal amount) {
+            this.adoptionBenefitsExclusion = amount;
+            return this;
+        }
+
+        /**
+         * Builds the IncomeDetails.
+         *
+         * @return a new IncomeDetails instance
+         */
+        public IncomeDetails build() {
+            return new IncomeDetails(
+                adjustedGrossIncome,
+                studentLoanInterest,
+                tuitionAndFees,
+                foreignEarnedIncomeExclusion,
+                foreignHousingExclusion,
+                savingsBondInterestExclusion,
+                adoptionBenefitsExclusion
+            );
+        }
+    }
+}

--- a/src/test/java/io/github/xmljim/retirement/domain/calculator/MAGICalculatorTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/calculator/MAGICalculatorTest.java
@@ -1,0 +1,118 @@
+package io.github.xmljim.retirement.domain.calculator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.github.xmljim.retirement.domain.calculator.impl.DefaultMAGICalculator;
+import io.github.xmljim.retirement.domain.exception.MissingRequiredFieldException;
+import io.github.xmljim.retirement.domain.value.IncomeDetails;
+
+@DisplayName("MAGICalculator Tests")
+class MAGICalculatorTest {
+
+    private MAGICalculator calculator;
+
+    @BeforeEach
+    void setUp() {
+        calculator = new DefaultMAGICalculator();
+    }
+
+    @Nested
+    @DisplayName("Basic MAGI Calculation")
+    class BasicCalculationTests {
+
+        @Test
+        @DisplayName("MAGI equals AGI when no add-backs")
+        void magiEqualsAgiWhenNoAddBacks() {
+            IncomeDetails income = IncomeDetails.builder()
+                .adjustedGrossIncome(new BigDecimal("150000"))
+                .build();
+
+            BigDecimal magi = calculator.calculate(income);
+
+            assertEquals(0, new BigDecimal("150000").compareTo(magi));
+        }
+
+        @Test
+        @DisplayName("MAGI includes student loan interest add-back")
+        void magiIncludesStudentLoanInterest() {
+            IncomeDetails income = IncomeDetails.builder()
+                .adjustedGrossIncome(new BigDecimal("150000"))
+                .studentLoanInterest(new BigDecimal("2500"))
+                .build();
+
+            BigDecimal magi = calculator.calculate(income);
+
+            assertEquals(0, new BigDecimal("152500").compareTo(magi));
+        }
+
+        @Test
+        @DisplayName("MAGI includes all add-backs")
+        void magiIncludesAllAddBacks() {
+            IncomeDetails income = IncomeDetails.builder()
+                .adjustedGrossIncome(new BigDecimal("100000"))
+                .studentLoanInterest(new BigDecimal("2500"))
+                .foreignEarnedIncomeExclusion(new BigDecimal("120000"))
+                .foreignHousingExclusion(new BigDecimal("15000"))
+                .savingsBondInterestExclusion(new BigDecimal("1000"))
+                .adoptionBenefitsExclusion(new BigDecimal("5000"))
+                .build();
+
+            BigDecimal magi = calculator.calculate(income);
+
+            // 100000 + 2500 + 120000 + 15000 + 1000 + 5000 = 243500
+            assertEquals(0, new BigDecimal("243500").compareTo(magi));
+        }
+    }
+
+    @Nested
+    @DisplayName("Simple AGI Calculation")
+    class SimpleAgiTests {
+
+        @Test
+        @DisplayName("Calculate from just AGI")
+        void calculateFromJustAgi() {
+            BigDecimal magi = calculator.calculate(new BigDecimal("175000"));
+            assertEquals(0, new BigDecimal("175000").compareTo(magi));
+        }
+
+        @Test
+        @DisplayName("Null AGI returns zero")
+        void nullAgiReturnsZero() {
+            BigDecimal magi = calculator.calculate((BigDecimal) null);
+            assertEquals(BigDecimal.ZERO, magi);
+        }
+    }
+
+    @Nested
+    @DisplayName("Validation Tests")
+    class ValidationTests {
+
+        @Test
+        @DisplayName("Throws for null IncomeDetails")
+        void throwsForNullIncomeDetails() {
+            assertThrows(MissingRequiredFieldException.class, () ->
+                calculator.calculate((IncomeDetails) null));
+        }
+    }
+
+    @Nested
+    @DisplayName("Factory Tests")
+    class FactoryTests {
+
+        @Test
+        @DisplayName("Factory returns calculator instance")
+        void factoryReturnsInstance() {
+            MAGICalculator calc = CalculatorFactory.magiCalculator();
+            BigDecimal magi = calc.calculate(IncomeDetails.ofAgi(new BigDecimal("100000")));
+            assertEquals(0, new BigDecimal("100000").compareTo(magi));
+        }
+    }
+}

--- a/src/test/java/io/github/xmljim/retirement/domain/value/IncomeDetailsTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/value/IncomeDetailsTest.java
@@ -1,0 +1,123 @@
+package io.github.xmljim.retirement.domain.value;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.github.xmljim.retirement.domain.exception.ValidationException;
+
+@DisplayName("IncomeDetails Tests")
+class IncomeDetailsTest {
+
+    @Nested
+    @DisplayName("Builder Tests")
+    class BuilderTests {
+
+        @Test
+        @DisplayName("Should create with all fields")
+        void createsWithAllFields() {
+            IncomeDetails income = IncomeDetails.builder()
+                .adjustedGrossIncome(new BigDecimal("150000"))
+                .studentLoanInterest(new BigDecimal("2500"))
+                .tuitionAndFees(new BigDecimal("4000"))
+                .foreignEarnedIncomeExclusion(new BigDecimal("120000"))
+                .foreignHousingExclusion(new BigDecimal("15000"))
+                .savingsBondInterestExclusion(new BigDecimal("1000"))
+                .adoptionBenefitsExclusion(new BigDecimal("5000"))
+                .build();
+
+            assertEquals(0, new BigDecimal("150000").compareTo(income.adjustedGrossIncome()));
+            assertEquals(0, new BigDecimal("2500").compareTo(income.studentLoanInterest()));
+        }
+
+        @Test
+        @DisplayName("Should default null fields to zero")
+        void defaultsNullsToZero() {
+            IncomeDetails income = IncomeDetails.builder()
+                .adjustedGrossIncome(new BigDecimal("100000"))
+                .build();
+
+            assertEquals(BigDecimal.ZERO, income.studentLoanInterest());
+            assertEquals(BigDecimal.ZERO, income.foreignEarnedIncomeExclusion());
+        }
+
+        @Test
+        @DisplayName("Should accept AGI from double")
+        void acceptsAgiFromDouble() {
+            IncomeDetails income = IncomeDetails.builder()
+                .adjustedGrossIncome(150000.50)
+                .build();
+
+            assertEquals(0, new BigDecimal("150000.5").compareTo(income.adjustedGrossIncome()));
+        }
+    }
+
+    @Nested
+    @DisplayName("Static Factory Tests")
+    class StaticFactoryTests {
+
+        @Test
+        @DisplayName("ofAgi creates with just AGI")
+        void ofAgiCreatesWithJustAgi() {
+            IncomeDetails income = IncomeDetails.ofAgi(new BigDecimal("175000"));
+
+            assertEquals(0, new BigDecimal("175000").compareTo(income.adjustedGrossIncome()));
+            assertEquals(BigDecimal.ZERO, income.getTotalAddBacks());
+        }
+    }
+
+    @Nested
+    @DisplayName("Validation Tests")
+    class ValidationTests {
+
+        @Test
+        @DisplayName("Should throw for negative AGI")
+        void throwsForNegativeAgi() {
+            assertThrows(ValidationException.class, () ->
+                IncomeDetails.builder()
+                    .adjustedGrossIncome(new BigDecimal("-1000"))
+                    .build());
+        }
+
+        @Test
+        @DisplayName("Should allow zero AGI")
+        void allowsZeroAgi() {
+            IncomeDetails income = IncomeDetails.builder()
+                .adjustedGrossIncome(BigDecimal.ZERO)
+                .build();
+
+            assertEquals(BigDecimal.ZERO, income.adjustedGrossIncome());
+        }
+    }
+
+    @Nested
+    @DisplayName("Total Add-Backs Tests")
+    class TotalAddBacksTests {
+
+        @Test
+        @DisplayName("Should calculate total add-backs")
+        void calculatesTotalAddBacks() {
+            IncomeDetails income = IncomeDetails.builder()
+                .adjustedGrossIncome(new BigDecimal("100000"))
+                .studentLoanInterest(new BigDecimal("2500"))
+                .tuitionAndFees(new BigDecimal("1000"))
+                .foreignEarnedIncomeExclusion(new BigDecimal("5000"))
+                .build();
+
+            // 2500 + 1000 + 5000 = 8500
+            assertEquals(0, new BigDecimal("8500").compareTo(income.getTotalAddBacks()));
+        }
+
+        @Test
+        @DisplayName("Should return zero when no add-backs")
+        void returnsZeroWhenNoAddBacks() {
+            IncomeDetails income = IncomeDetails.ofAgi(new BigDecimal("100000"));
+            assertEquals(BigDecimal.ZERO, income.getTotalAddBacks());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `IncomeDetails` value object for income components needed for MAGI
- Add `MAGICalculator` interface and `DefaultMAGICalculator` implementation
- Support IRA-specific MAGI add-backs per IRS Publication 590-A
- Add factory method to `CalculatorFactory`

## Add-back Items Supported
- Student loan interest deduction
- Tuition and fees deduction
- Foreign earned income exclusion
- Foreign housing exclusion
- Savings bond interest exclusion
- Employer adoption benefits exclusion

## Test plan
- [x] IncomeDetails tests (builder, validation, total add-backs)
- [x] MAGICalculator tests (basic calculation, all add-backs, factory)
- [x] Full build passes (414+ tests)

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)