### PR TITLE
feat(#21): Implement IRA phase-out calculator

### DIFF
--- a/src/main/java/io/github/xmljim/retirement/domain/calculator/CalculatorFactory.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/calculator/CalculatorFactory.java
@@ -6,9 +6,11 @@ import io.github.xmljim.retirement.domain.calculator.impl.DefaultContributionRou
 import io.github.xmljim.retirement.domain.calculator.impl.DefaultIncomeCalculator;
 import io.github.xmljim.retirement.domain.calculator.impl.DefaultInflationCalculator;
 import io.github.xmljim.retirement.domain.calculator.impl.DefaultMAGICalculator;
+import io.github.xmljim.retirement.domain.calculator.impl.DefaultPhaseOutCalculator;
 import io.github.xmljim.retirement.domain.calculator.impl.DefaultReturnCalculator;
 import io.github.xmljim.retirement.domain.calculator.impl.DefaultWithdrawalCalculator;
 import io.github.xmljim.retirement.domain.calculator.impl.DefaultYTDContributionTracker;
+import io.github.xmljim.retirement.domain.config.IraPhaseOutLimits;
 import io.github.xmljim.retirement.domain.config.IrsContributionLimits;
 
 /**
@@ -182,5 +184,35 @@ public final class CalculatorFactory {
     public static ContributionLimitChecker limitChecker(
             IrsContributionRules irsRules, IrsContributionLimits irsLimits) {
         return new DefaultContributionLimitChecker(irsRules, irsLimits);
+    }
+
+    /**
+     * Creates a phase-out calculator for IRA contributions.
+     *
+     * <p>The phase-out calculator determines allowed IRA contributions
+     * based on MAGI and filing status, applying IRS income-based phase-out
+     * rules for both Roth IRA eligibility and Traditional IRA deductibility.
+     *
+     * <p>Usage:
+     * <pre>{@code
+     * PhaseOutCalculator calculator = CalculatorFactory.phaseOutCalculator(
+     *     phaseOutLimits, contributionLimits);
+     *
+     * PhaseOutResult result = calculator.calculateRothIraPhaseOut(
+     *     new BigDecimal("155000"),      // MAGI
+     *     FilingStatus.SINGLE,           // filing status
+     *     2025,                          // year
+     *     new BigDecimal("7000"),        // requested contribution
+     *     45                             // age
+     * );
+     * }</pre>
+     *
+     * @param phaseOutLimits the IRA phase-out thresholds configuration
+     * @param contributionLimits the IRS contribution limits configuration
+     * @return a new PhaseOutCalculator instance
+     */
+    public static PhaseOutCalculator phaseOutCalculator(
+            IraPhaseOutLimits phaseOutLimits, IrsContributionLimits contributionLimits) {
+        return new DefaultPhaseOutCalculator(phaseOutLimits, contributionLimits);
     }
 }

--- a/src/main/java/io/github/xmljim/retirement/domain/calculator/PhaseOutCalculator.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/calculator/PhaseOutCalculator.java
@@ -1,0 +1,93 @@
+package io.github.xmljim.retirement.domain.calculator;
+
+import java.math.BigDecimal;
+
+import io.github.xmljim.retirement.domain.enums.FilingStatus;
+
+/**
+ * Calculator for IRA contribution phase-out rules.
+ *
+ * <p>Determines the allowed IRA contribution amount based on Modified
+ * Adjusted Gross Income (MAGI) and filing status. Phase-out rules differ
+ * between Roth IRA (contribution eligibility) and Traditional IRA
+ * (deductibility of contributions).
+ *
+ * <p>Phase-out calculation:
+ * <ul>
+ *   <li>MAGI below lower bound: full contribution allowed</li>
+ *   <li>MAGI above upper bound: no contribution (Roth) or no deduction (Traditional)</li>
+ *   <li>MAGI within range: linear interpolation</li>
+ * </ul>
+ *
+ * @see <a href="https://www.irs.gov/retirement-plans/amount-of-roth-ira-contributions-that-you-can-make-for-2024">
+ *     IRS: Roth IRA Contribution Limits</a>
+ * @see <a href="https://www.irs.gov/retirement-plans/ira-deduction-limits">
+ *     IRS: IRA Deduction Limits</a>
+ */
+public interface PhaseOutCalculator {
+
+    /**
+     * Calculates the Roth IRA contribution phase-out.
+     *
+     * <p>Determines the maximum Roth IRA contribution allowed based on MAGI.
+     * If fully phased out, the result indicates backdoor Roth eligibility.
+     *
+     * @param magi the Modified Adjusted Gross Income
+     * @param filingStatus the tax filing status
+     * @param year the tax year
+     * @param requestedContribution the contribution amount requested
+     * @param age the contributor's age for catch-up eligibility
+     * @return the phase-out result with allowed contribution
+     */
+    PhaseOutResult calculateRothIraPhaseOut(
+        BigDecimal magi,
+        FilingStatus filingStatus,
+        int year,
+        BigDecimal requestedContribution,
+        int age
+    );
+
+    /**
+     * Calculates the Traditional IRA deductibility phase-out.
+     *
+     * <p>Determines the deductible portion of a Traditional IRA contribution.
+     * Phase-out only applies if the contributor or spouse is covered by
+     * an employer retirement plan.
+     *
+     * <p>Coverage scenarios:
+     * <ul>
+     *   <li>Neither covered: full deduction regardless of MAGI</li>
+     *   <li>Contributor covered: use "covered" phase-out thresholds</li>
+     *   <li>Only spouse covered: use "spouse covered" thresholds (higher)</li>
+     * </ul>
+     *
+     * @param magi the Modified Adjusted Gross Income
+     * @param filingStatus the tax filing status
+     * @param year the tax year
+     * @param requestedContribution the contribution amount requested
+     * @param age the contributor's age for catch-up eligibility
+     * @param coveredByEmployerPlan true if contributor has employer plan
+     * @param spouseCoveredByEmployerPlan true if spouse has employer plan
+     * @return the phase-out result with deductible portion
+     */
+    PhaseOutResult calculateTraditionalIraPhaseOut(
+        BigDecimal magi,
+        FilingStatus filingStatus,
+        int year,
+        BigDecimal requestedContribution,
+        int age,
+        boolean coveredByEmployerPlan,
+        boolean spouseCoveredByEmployerPlan
+    );
+
+    /**
+     * Returns the maximum IRA contribution limit for the year and age.
+     *
+     * <p>Includes catch-up contributions for age 50+.
+     *
+     * @param year the tax year
+     * @param age the contributor's age
+     * @return the maximum contribution limit
+     */
+    BigDecimal getMaxIraContribution(int year, int age);
+}

--- a/src/main/java/io/github/xmljim/retirement/domain/calculator/PhaseOutResult.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/calculator/PhaseOutResult.java
@@ -1,0 +1,209 @@
+package io.github.xmljim.retirement.domain.calculator;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.github.xmljim.retirement.domain.enums.AccountType;
+
+/**
+ * Result of an IRA phase-out calculation.
+ *
+ * <p>Contains the allowed contribution amount after applying income-based
+ * phase-out rules, along with details about the phase-out status.
+ *
+ * @param accountType the IRA account type evaluated
+ * @param requestedContribution the original contribution amount requested
+ * @param allowedContribution the maximum contribution allowed after phase-out
+ * @param phaseOutPercentage percentage through the phase-out range (0.0-1.0)
+ * @param isFullyPhasedOut true if MAGI exceeds the upper phase-out bound
+ * @param backdoorRothEligible true if Roth direct contribution is blocked
+ *                              but backdoor Roth conversion is available
+ * @param deductiblePortion for Traditional IRA, the deductible portion
+ *                          (may be less than allowed contribution)
+ * @param warnings any warnings or notes about the calculation
+ */
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP",
+    justification = "Record component returns immutable List.copyOf() from builder"
+)
+public record PhaseOutResult(
+    AccountType accountType,
+    BigDecimal requestedContribution,
+    BigDecimal allowedContribution,
+    BigDecimal phaseOutPercentage,
+    boolean isFullyPhasedOut,
+    boolean backdoorRothEligible,
+    BigDecimal deductiblePortion,
+    List<String> warnings
+) {
+
+    /**
+     * Creates a PhaseOutResult with defaults for null values.
+     */
+    public PhaseOutResult {
+        if (requestedContribution == null) {
+            requestedContribution = BigDecimal.ZERO;
+        }
+        if (allowedContribution == null) {
+            allowedContribution = BigDecimal.ZERO;
+        }
+        if (phaseOutPercentage == null) {
+            phaseOutPercentage = BigDecimal.ZERO;
+        }
+        if (deductiblePortion == null) {
+            deductiblePortion = BigDecimal.ZERO;
+        }
+        if (warnings == null) {
+            warnings = List.of();
+        }
+    }
+
+    /**
+     * Returns true if the full requested contribution is allowed.
+     *
+     * @return true if no reduction due to phase-out
+     */
+    public boolean isFullContributionAllowed() {
+        return allowedContribution.compareTo(requestedContribution) >= 0;
+    }
+
+    /**
+     * Returns true if any contribution is allowed.
+     *
+     * @return true if allowed contribution is greater than zero
+     */
+    public boolean canContribute() {
+        return allowedContribution.compareTo(BigDecimal.ZERO) > 0;
+    }
+
+    /**
+     * Builder for creating PhaseOutResult instances.
+     */
+    public static class Builder {
+        private AccountType accountType;
+        private BigDecimal requestedContribution = BigDecimal.ZERO;
+        private BigDecimal allowedContribution = BigDecimal.ZERO;
+        private BigDecimal phaseOutPercentage = BigDecimal.ZERO;
+        private boolean isFullyPhasedOut;
+        private boolean backdoorRothEligible;
+        private BigDecimal deductiblePortion = BigDecimal.ZERO;
+        private List<String> warnings = new ArrayList<>();
+
+        /**
+         * Sets the account type.
+         *
+         * @param accountType the IRA account type
+         * @return this builder
+         */
+        public Builder accountType(AccountType accountType) {
+            this.accountType = accountType;
+            return this;
+        }
+
+        /**
+         * Sets the requested contribution amount.
+         *
+         * @param amount the requested amount
+         * @return this builder
+         */
+        public Builder requestedContribution(BigDecimal amount) {
+            this.requestedContribution = amount;
+            return this;
+        }
+
+        /**
+         * Sets the allowed contribution amount.
+         *
+         * @param amount the allowed amount after phase-out
+         * @return this builder
+         */
+        public Builder allowedContribution(BigDecimal amount) {
+            this.allowedContribution = amount;
+            return this;
+        }
+
+        /**
+         * Sets the phase-out percentage.
+         *
+         * @param percentage the percentage (0.0 to 1.0)
+         * @return this builder
+         */
+        public Builder phaseOutPercentage(BigDecimal percentage) {
+            this.phaseOutPercentage = percentage;
+            return this;
+        }
+
+        /**
+         * Sets whether fully phased out.
+         *
+         * @param fullyPhasedOut true if MAGI exceeds upper bound
+         * @return this builder
+         */
+        public Builder isFullyPhasedOut(boolean fullyPhasedOut) {
+            this.isFullyPhasedOut = fullyPhasedOut;
+            return this;
+        }
+
+        /**
+         * Sets whether backdoor Roth is eligible.
+         *
+         * @param eligible true if backdoor available
+         * @return this builder
+         */
+        public Builder backdoorRothEligible(boolean eligible) {
+            this.backdoorRothEligible = eligible;
+            return this;
+        }
+
+        /**
+         * Sets the deductible portion for Traditional IRA.
+         *
+         * @param deductible the deductible amount
+         * @return this builder
+         */
+        public Builder deductiblePortion(BigDecimal deductible) {
+            this.deductiblePortion = deductible;
+            return this;
+        }
+
+        /**
+         * Adds a warning message.
+         *
+         * @param warning the warning
+         * @return this builder
+         */
+        public Builder addWarning(String warning) {
+            this.warnings.add(warning);
+            return this;
+        }
+
+        /**
+         * Builds the PhaseOutResult.
+         *
+         * @return the constructed result
+         */
+        public PhaseOutResult build() {
+            return new PhaseOutResult(
+                accountType,
+                requestedContribution,
+                allowedContribution,
+                phaseOutPercentage,
+                isFullyPhasedOut,
+                backdoorRothEligible,
+                deductiblePortion,
+                List.copyOf(warnings)
+            );
+        }
+    }
+
+    /**
+     * Creates a new builder.
+     *
+     * @return a new builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/domain/calculator/impl/DefaultPhaseOutCalculator.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/calculator/impl/DefaultPhaseOutCalculator.java
@@ -1,0 +1,257 @@
+package io.github.xmljim.retirement.domain.calculator.impl;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import org.springframework.stereotype.Service;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.github.xmljim.retirement.domain.calculator.PhaseOutCalculator;
+import io.github.xmljim.retirement.domain.calculator.PhaseOutResult;
+import io.github.xmljim.retirement.domain.config.IraPhaseOutLimits;
+import io.github.xmljim.retirement.domain.config.IraPhaseOutLimits.PhaseOutRange;
+import io.github.xmljim.retirement.domain.config.IraPhaseOutLimits.YearPhaseOuts;
+import io.github.xmljim.retirement.domain.config.IrsContributionLimits;
+import io.github.xmljim.retirement.domain.config.IrsContributionLimits.IraLimits;
+import io.github.xmljim.retirement.domain.enums.AccountType;
+import io.github.xmljim.retirement.domain.enums.FilingStatus;
+import io.github.xmljim.retirement.domain.exception.MissingRequiredFieldException;
+
+/**
+ * Default implementation of IRA phase-out calculations.
+ *
+ * <p>Uses IRS phase-out thresholds from configuration to determine
+ * allowed contributions and deductible portions based on MAGI.
+ *
+ * <p>Phase-out formula:
+ * <pre>
+ * phaseOutPercentage = (MAGI - lowerBound) / (upperBound - lowerBound)
+ * allowedAmount = limit * (1 - phaseOutPercentage)
+ * </pre>
+ *
+ * <p>IRS rounding: Allowed amounts are rounded UP to the nearest $10
+ * (with a $200 minimum if partially phased out).
+ */
+@Service
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Spring-managed configuration objects are shared by design"
+)
+public class DefaultPhaseOutCalculator implements PhaseOutCalculator {
+
+    private static final int CATCH_UP_AGE = 50;
+    private static final int SCALE = 10;
+    private static final RoundingMode ROUNDING_MODE = RoundingMode.HALF_UP;
+    private static final BigDecimal TEN = new BigDecimal("10");
+    private static final BigDecimal MINIMUM_PARTIAL = new BigDecimal("200");
+
+    private final IraPhaseOutLimits phaseOutLimits;
+    private final IrsContributionLimits contributionLimits;
+
+    /**
+     * Creates a new DefaultPhaseOutCalculator.
+     *
+     * @param phaseOutLimits the IRA phase-out configuration
+     * @param contributionLimits the IRS contribution limits
+     */
+    public DefaultPhaseOutCalculator(
+            IraPhaseOutLimits phaseOutLimits,
+            IrsContributionLimits contributionLimits) {
+        this.phaseOutLimits = phaseOutLimits;
+        this.contributionLimits = contributionLimits;
+    }
+
+    @Override
+    public PhaseOutResult calculateRothIraPhaseOut(
+            BigDecimal magi,
+            FilingStatus filingStatus,
+            int year,
+            BigDecimal requestedContribution,
+            int age) {
+
+        MissingRequiredFieldException.requireNonNull(magi, "magi");
+        MissingRequiredFieldException.requireNonNull(filingStatus, "filingStatus");
+
+        BigDecimal maxContribution = getMaxIraContribution(year, age);
+        BigDecimal effectiveRequest = requestedContribution != null
+            ? requestedContribution.min(maxContribution)
+            : maxContribution;
+
+        YearPhaseOuts yearPhaseOuts = phaseOutLimits.getRothIraPhaseOutsForYear(year);
+        PhaseOutRange range = yearPhaseOuts.forStatus(filingStatus);
+
+        PhaseOutResult.Builder builder = PhaseOutResult.builder()
+            .accountType(AccountType.ROTH_IRA)
+            .requestedContribution(effectiveRequest);
+
+        // Handle special MFS restrictions
+        if (filingStatus.hasSpecialRestrictions()) {
+            builder.addWarning("Married Filing Separately has reduced phase-out thresholds. "
+                + "If not living with spouse, SINGLE thresholds may apply.");
+        }
+
+        return applyPhaseOut(builder, magi, range, maxContribution, effectiveRequest, true);
+    }
+
+    @Override
+    public PhaseOutResult calculateTraditionalIraPhaseOut(
+            BigDecimal magi,
+            FilingStatus filingStatus,
+            int year,
+            BigDecimal requestedContribution,
+            int age,
+            boolean coveredByEmployerPlan,
+            boolean spouseCoveredByEmployerPlan) {
+
+        MissingRequiredFieldException.requireNonNull(magi, "magi");
+        MissingRequiredFieldException.requireNonNull(filingStatus, "filingStatus");
+
+        BigDecimal maxContribution = getMaxIraContribution(year, age);
+        BigDecimal effectiveRequest = requestedContribution != null
+            ? requestedContribution.min(maxContribution)
+            : maxContribution;
+
+        PhaseOutResult.Builder builder = PhaseOutResult.builder()
+            .accountType(AccountType.TRADITIONAL_IRA)
+            .requestedContribution(effectiveRequest);
+
+        // Determine applicable phase-out range based on coverage
+        PhaseOutRange range;
+        if (!coveredByEmployerPlan && !spouseCoveredByEmployerPlan) {
+            // Neither covered - full deduction regardless of income
+            return builder
+                .allowedContribution(effectiveRequest)
+                .deductiblePortion(effectiveRequest)
+                .phaseOutPercentage(BigDecimal.ZERO)
+                .isFullyPhasedOut(false)
+                .addWarning("No employer plan coverage - full deduction allowed at any income")
+                .build();
+        } else if (coveredByEmployerPlan) {
+            // Contributor is covered - use covered thresholds
+            YearPhaseOuts yearPhaseOuts = phaseOutLimits.getTraditionalIraCoveredPhaseOutsForYear(year);
+            range = yearPhaseOuts.forStatus(filingStatus);
+        } else {
+            // Only spouse is covered - use spouse-covered thresholds (higher limits)
+            // Note: spouse-covered only applies to married filers
+            if (filingStatus.usesJointThresholds()) {
+                YearPhaseOuts yearPhaseOuts =
+                    phaseOutLimits.getTraditionalIraSpouseCoveredPhaseOutsForYear(year);
+                range = yearPhaseOuts.forStatus(filingStatus);
+                builder.addWarning("Spouse is covered by employer plan - using spouse-covered thresholds");
+            } else {
+                // Single filer with spouse covered doesn't make sense - full deduction
+                return builder
+                    .allowedContribution(effectiveRequest)
+                    .deductiblePortion(effectiveRequest)
+                    .phaseOutPercentage(BigDecimal.ZERO)
+                    .isFullyPhasedOut(false)
+                    .build();
+            }
+        }
+
+        // Handle special MFS restrictions
+        if (filingStatus.hasSpecialRestrictions()) {
+            builder.addWarning("Married Filing Separately has very limited deduction phase-out range");
+        }
+
+        return applyPhaseOut(builder, magi, range, maxContribution, effectiveRequest, false);
+    }
+
+    @Override
+    public BigDecimal getMaxIraContribution(int year, int age) {
+        IraLimits limits = contributionLimits.getIraLimitsForYear(year);
+        BigDecimal base = limits.baseLimit();
+        if (age >= CATCH_UP_AGE) {
+            return base.add(limits.catchUpLimit());
+        }
+        return base;
+    }
+
+    /**
+     * Applies the phase-out calculation and builds the result.
+     */
+    private PhaseOutResult applyPhaseOut(
+            PhaseOutResult.Builder builder,
+            BigDecimal magi,
+            PhaseOutRange range,
+            BigDecimal maxContribution,
+            BigDecimal effectiveRequest,
+            boolean isRothIra) {
+
+        BigDecimal lowerBound = range.lowerBound();
+        BigDecimal upperBound = range.upperBound();
+
+        // Below lower bound - full contribution allowed
+        if (magi.compareTo(lowerBound) < 0) {
+            return builder
+                .allowedContribution(effectiveRequest)
+                .deductiblePortion(isRothIra ? BigDecimal.ZERO : effectiveRequest)
+                .phaseOutPercentage(BigDecimal.ZERO)
+                .isFullyPhasedOut(false)
+                .backdoorRothEligible(false)
+                .build();
+        }
+
+        // At or above upper bound - fully phased out
+        if (magi.compareTo(upperBound) >= 0) {
+            builder.allowedContribution(BigDecimal.ZERO)
+                .deductiblePortion(BigDecimal.ZERO)
+                .phaseOutPercentage(BigDecimal.ONE)
+                .isFullyPhasedOut(true);
+
+            if (isRothIra) {
+                builder.backdoorRothEligible(true)
+                    .addWarning("Direct Roth IRA contribution not allowed. "
+                        + "Consider backdoor Roth: contribute to Traditional IRA, then convert to Roth.");
+            } else {
+                builder.addWarning("Traditional IRA contribution allowed but not deductible. "
+                    + "Consider Roth IRA or backdoor Roth strategy.");
+            }
+            return builder.build();
+        }
+
+        // Within phase-out range - calculate partial
+        BigDecimal rangeSize = range.getRange();
+        BigDecimal positionInRange = magi.subtract(lowerBound);
+        BigDecimal phaseOutPct = positionInRange.divide(rangeSize, SCALE, ROUNDING_MODE);
+
+        // Calculate allowed amount before IRS rounding
+        BigDecimal reductionFactor = BigDecimal.ONE.subtract(phaseOutPct);
+        BigDecimal calculatedAllowed = maxContribution.multiply(reductionFactor);
+
+        // Apply IRS rounding (up to nearest $10, minimum $200 if partial)
+        BigDecimal allowedAmount = roundUpToTen(calculatedAllowed);
+        if (allowedAmount.compareTo(BigDecimal.ZERO) > 0
+                && allowedAmount.compareTo(MINIMUM_PARTIAL) < 0) {
+            allowedAmount = MINIMUM_PARTIAL;
+        }
+
+        // Cap at requested amount
+        allowedAmount = allowedAmount.min(effectiveRequest);
+
+        builder.allowedContribution(allowedAmount)
+            .phaseOutPercentage(phaseOutPct)
+            .isFullyPhasedOut(false);
+
+        if (isRothIra) {
+            builder.deductiblePortion(BigDecimal.ZERO)
+                .backdoorRothEligible(false);
+        } else {
+            // For Traditional IRA, deductible = allowed when in phase-out
+            builder.deductiblePortion(allowedAmount);
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Rounds up to the nearest $10 (IRS rule for partial phase-out).
+     */
+    private BigDecimal roundUpToTen(BigDecimal value) {
+        if (value == null || value.compareTo(BigDecimal.ZERO) <= 0) {
+            return BigDecimal.ZERO;
+        }
+        // Ceiling division by 10, then multiply by 10
+        return value.divide(TEN, 0, RoundingMode.CEILING).multiply(TEN);
+    }
+}

--- a/src/test/java/io/github/xmljim/retirement/domain/calculator/PhaseOutCalculatorTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/calculator/PhaseOutCalculatorTest.java
@@ -1,0 +1,253 @@
+package io.github.xmljim.retirement.domain.calculator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.github.xmljim.retirement.domain.calculator.impl.DefaultPhaseOutCalculator;
+import io.github.xmljim.retirement.domain.config.IraPhaseOutLimits;
+import io.github.xmljim.retirement.domain.config.IraPhaseOutLimits.PhaseOutRange;
+import io.github.xmljim.retirement.domain.config.IraPhaseOutLimits.YearPhaseOuts;
+import io.github.xmljim.retirement.domain.config.IrsContributionLimits;
+import io.github.xmljim.retirement.domain.config.IrsContributionLimits.IraLimits;
+import io.github.xmljim.retirement.domain.enums.AccountType;
+import io.github.xmljim.retirement.domain.enums.FilingStatus;
+import io.github.xmljim.retirement.domain.exception.MissingRequiredFieldException;
+
+@DisplayName("PhaseOutCalculator Tests")
+class PhaseOutCalculatorTest {
+
+    private PhaseOutCalculator calculator;
+    private IraPhaseOutLimits phaseOutLimits;
+    private IrsContributionLimits contributionLimits;
+
+    @BeforeEach
+    void setUp() {
+        phaseOutLimits = createTestPhaseOutLimits();
+        contributionLimits = createTestContributionLimits();
+        calculator = new DefaultPhaseOutCalculator(phaseOutLimits, contributionLimits);
+    }
+
+    private IraPhaseOutLimits createTestPhaseOutLimits() {
+        IraPhaseOutLimits limits = new IraPhaseOutLimits();
+
+        // Roth IRA 2025 thresholds
+        Map<Integer, YearPhaseOuts> rothIra = new HashMap<>();
+        rothIra.put(2025, new YearPhaseOuts(
+            new PhaseOutRange(new BigDecimal("150000"), new BigDecimal("165000")),
+            new PhaseOutRange(new BigDecimal("236000"), new BigDecimal("246000")),
+            new PhaseOutRange(BigDecimal.ZERO, new BigDecimal("10000"))
+        ));
+        limits.setRothIra(rothIra);
+
+        // Traditional IRA covered 2025 thresholds
+        Map<Integer, YearPhaseOuts> tradCovered = new HashMap<>();
+        tradCovered.put(2025, new YearPhaseOuts(
+            new PhaseOutRange(new BigDecimal("79000"), new BigDecimal("89000")),
+            new PhaseOutRange(new BigDecimal("126000"), new BigDecimal("146000")),
+            new PhaseOutRange(BigDecimal.ZERO, new BigDecimal("10000"))
+        ));
+        limits.setTraditionalIraCovered(tradCovered);
+
+        // Traditional IRA spouse covered 2025 thresholds
+        Map<Integer, YearPhaseOuts> spouseCovered = new HashMap<>();
+        spouseCovered.put(2025, new YearPhaseOuts(
+            PhaseOutRange.ZERO,
+            new PhaseOutRange(new BigDecimal("236000"), new BigDecimal("246000")),
+            PhaseOutRange.ZERO
+        ));
+        limits.setTraditionalIraSpouseCovered(spouseCovered);
+
+        return limits;
+    }
+
+    private IrsContributionLimits createTestContributionLimits() {
+        IrsContributionLimits limits = new IrsContributionLimits();
+        Map<Integer, IraLimits> iraLimits = new HashMap<>();
+        iraLimits.put(2025, new IraLimits(new BigDecimal("7000"), new BigDecimal("1000")));
+        limits.setIraLimits(iraLimits);
+        return limits;
+    }
+
+    @Nested
+    @DisplayName("Roth IRA Phase-Out Tests")
+    class RothIraPhaseOutTests {
+
+        @Test
+        @DisplayName("Below phase-out: full contribution allowed")
+        void belowPhaseOutFullAllowed() {
+            PhaseOutResult result = calculator.calculateRothIraPhaseOut(
+                new BigDecimal("100000"), FilingStatus.SINGLE, 2025, new BigDecimal("7000"), 45);
+
+            assertEquals(AccountType.ROTH_IRA, result.accountType());
+            assertEquals(0, new BigDecimal("7000").compareTo(result.allowedContribution()));
+            assertEquals(0, BigDecimal.ZERO.compareTo(result.phaseOutPercentage()));
+            assertFalse(result.isFullyPhasedOut());
+            assertFalse(result.backdoorRothEligible());
+        }
+
+        @Test
+        @DisplayName("Above phase-out: no contribution, backdoor eligible")
+        void abovePhaseOutNoContribution() {
+            PhaseOutResult result = calculator.calculateRothIraPhaseOut(
+                new BigDecimal("170000"), FilingStatus.SINGLE, 2025, new BigDecimal("7000"), 45);
+
+            assertEquals(0, BigDecimal.ZERO.compareTo(result.allowedContribution()));
+            assertEquals(0, BigDecimal.ONE.compareTo(result.phaseOutPercentage()));
+            assertTrue(result.isFullyPhasedOut());
+            assertTrue(result.backdoorRothEligible());
+            assertTrue(result.warnings().stream().anyMatch(w -> w.contains("backdoor")));
+        }
+
+        @Test
+        @DisplayName("Mid phase-out: partial contribution")
+        void midPhaseOutPartialContribution() {
+            // MAGI at midpoint of $150K-$165K range = $157,500 = 50% phased out
+            PhaseOutResult result = calculator.calculateRothIraPhaseOut(
+                new BigDecimal("157500"), FilingStatus.SINGLE, 2025, new BigDecimal("7000"), 45);
+
+            assertFalse(result.isFullyPhasedOut());
+            assertTrue(result.allowedContribution().compareTo(BigDecimal.ZERO) > 0);
+            assertTrue(result.allowedContribution().compareTo(new BigDecimal("7000")) < 0);
+        }
+
+        @Test
+        @DisplayName("MFJ uses joint thresholds")
+        void mfjUsesJointThresholds() {
+            // $200K is below MFJ lower bound of $236K
+            PhaseOutResult result = calculator.calculateRothIraPhaseOut(
+                new BigDecimal("200000"), FilingStatus.MARRIED_FILING_JOINTLY, 2025,
+                new BigDecimal("7000"), 45);
+
+            assertEquals(0, new BigDecimal("7000").compareTo(result.allowedContribution()));
+            assertFalse(result.isFullyPhasedOut());
+        }
+
+        @Test
+        @DisplayName("Age 50+ gets catch-up contribution")
+        void age50GetsCatchUp() {
+            BigDecimal maxLimit = calculator.getMaxIraContribution(2025, 55);
+            assertEquals(0, new BigDecimal("8000").compareTo(maxLimit));
+        }
+    }
+
+    @Nested
+    @DisplayName("Traditional IRA Phase-Out Tests")
+    class TraditionalIraPhaseOutTests {
+
+        @Test
+        @DisplayName("Not covered: full deduction regardless of income")
+        void notCoveredFullDeduction() {
+            PhaseOutResult result = calculator.calculateTraditionalIraPhaseOut(
+                new BigDecimal("500000"), FilingStatus.SINGLE, 2025,
+                new BigDecimal("7000"), 45, false, false);
+
+            assertEquals(AccountType.TRADITIONAL_IRA, result.accountType());
+            assertEquals(0, new BigDecimal("7000").compareTo(result.allowedContribution()));
+            assertEquals(0, new BigDecimal("7000").compareTo(result.deductiblePortion()));
+        }
+
+        @Test
+        @DisplayName("Covered below phase-out: full deduction")
+        void coveredBelowPhaseOut() {
+            PhaseOutResult result = calculator.calculateTraditionalIraPhaseOut(
+                new BigDecimal("70000"), FilingStatus.SINGLE, 2025,
+                new BigDecimal("7000"), 45, true, false);
+
+            assertEquals(0, new BigDecimal("7000").compareTo(result.deductiblePortion()));
+            assertFalse(result.isFullyPhasedOut());
+        }
+
+        @Test
+        @DisplayName("Covered above phase-out: no deduction")
+        void coveredAbovePhaseOut() {
+            PhaseOutResult result = calculator.calculateTraditionalIraPhaseOut(
+                new BigDecimal("100000"), FilingStatus.SINGLE, 2025,
+                new BigDecimal("7000"), 45, true, false);
+
+            assertEquals(0, BigDecimal.ZERO.compareTo(result.deductiblePortion()));
+            assertTrue(result.isFullyPhasedOut());
+        }
+
+        @Test
+        @DisplayName("Spouse covered uses higher thresholds")
+        void spouseCoveredHigherThresholds() {
+            // $200K is below spouse-covered MFJ threshold of $236K
+            PhaseOutResult result = calculator.calculateTraditionalIraPhaseOut(
+                new BigDecimal("200000"), FilingStatus.MARRIED_FILING_JOINTLY, 2025,
+                new BigDecimal("7000"), 45, false, true);
+
+            assertEquals(0, new BigDecimal("7000").compareTo(result.deductiblePortion()));
+            assertFalse(result.isFullyPhasedOut());
+        }
+    }
+
+    @Nested
+    @DisplayName("Validation Tests")
+    class ValidationTests {
+
+        @Test
+        @DisplayName("Throws for null MAGI")
+        void throwsForNullMagi() {
+            assertThrows(MissingRequiredFieldException.class, () ->
+                calculator.calculateRothIraPhaseOut(null, FilingStatus.SINGLE, 2025,
+                    new BigDecimal("7000"), 45));
+        }
+
+        @Test
+        @DisplayName("Throws for null filing status")
+        void throwsForNullFilingStatus() {
+            assertThrows(MissingRequiredFieldException.class, () ->
+                calculator.calculateRothIraPhaseOut(new BigDecimal("100000"), null, 2025,
+                    new BigDecimal("7000"), 45));
+        }
+    }
+
+    @Nested
+    @DisplayName("PhaseOutResult Tests")
+    class PhaseOutResultTests {
+
+        @Test
+        @DisplayName("Builder creates valid result")
+        void builderCreatesValidResult() {
+            PhaseOutResult result = PhaseOutResult.builder()
+                .accountType(AccountType.ROTH_IRA)
+                .requestedContribution(new BigDecimal("7000"))
+                .allowedContribution(new BigDecimal("3500"))
+                .phaseOutPercentage(new BigDecimal("0.5"))
+                .isFullyPhasedOut(false)
+                .backdoorRothEligible(false)
+                .addWarning("Test warning")
+                .build();
+
+            assertNotNull(result);
+            assertEquals(AccountType.ROTH_IRA, result.accountType());
+            assertFalse(result.isFullContributionAllowed());
+            assertTrue(result.canContribute());
+        }
+    }
+
+    @Nested
+    @DisplayName("Factory Tests")
+    class FactoryTests {
+
+        @Test
+        @DisplayName("Factory creates calculator")
+        void factoryCreatesCalculator() {
+            PhaseOutCalculator calc = CalculatorFactory.phaseOutCalculator(
+                phaseOutLimits, contributionLimits);
+            assertNotNull(calc);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `PhaseOutCalculator` interface and `DefaultPhaseOutCalculator` for IRA contribution phase-out rules
- Support Roth IRA contribution eligibility phase-out (with backdoor Roth awareness)
- Support Traditional IRA deductibility phase-out based on employer plan coverage
- Apply IRS rounding rules (up to nearest $10, $200 minimum for partial phase-out)
- Add `PhaseOutResult` record with builder pattern

## Key Features
- Linear interpolation within phase-out ranges
- Filing status support (Single, MFJ, MFS, HOH, QSS)
- Catch-up contribution handling for age 50+
- Warning messages for special cases (MFS restrictions, backdoor Roth)

## Test plan
- [x] Roth IRA: below phase-out = full contribution
- [x] Roth IRA: above phase-out = no contribution, backdoor eligible
- [x] Roth IRA: mid phase-out = partial contribution
- [x] Traditional IRA: not covered = full deduction at any income
- [x] Traditional IRA: covered = phase-out applies
- [x] Traditional IRA: spouse covered = higher thresholds
- [x] Validation: null MAGI throws exception
- [x] Factory method creates calculator

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)