### PR TITLE
test(#143): Add M3b phase-out integration tests

### DIFF
--- a/src/test/java/io/github/xmljim/retirement/domain/calculator/PhaseOutCalculatorTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/calculator/PhaseOutCalculatorTest.java
@@ -7,8 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -17,10 +15,7 @@ import org.junit.jupiter.api.Test;
 
 import io.github.xmljim.retirement.domain.calculator.impl.DefaultPhaseOutCalculator;
 import io.github.xmljim.retirement.domain.config.IraPhaseOutLimits;
-import io.github.xmljim.retirement.domain.config.IraPhaseOutLimits.PhaseOutRange;
-import io.github.xmljim.retirement.domain.config.IraPhaseOutLimits.YearPhaseOuts;
 import io.github.xmljim.retirement.domain.config.IrsContributionLimits;
-import io.github.xmljim.retirement.domain.config.IrsContributionLimits.IraLimits;
 import io.github.xmljim.retirement.domain.enums.AccountType;
 import io.github.xmljim.retirement.domain.enums.FilingStatus;
 import io.github.xmljim.retirement.domain.exception.MissingRequiredFieldException;
@@ -34,50 +29,9 @@ class PhaseOutCalculatorTest {
 
     @BeforeEach
     void setUp() {
-        phaseOutLimits = createTestPhaseOutLimits();
-        contributionLimits = createTestContributionLimits();
+        phaseOutLimits = TestPhaseOutFixture.createTestPhaseOutLimits();
+        contributionLimits = TestPhaseOutFixture.createTestContributionLimits();
         calculator = new DefaultPhaseOutCalculator(phaseOutLimits, contributionLimits);
-    }
-
-    private IraPhaseOutLimits createTestPhaseOutLimits() {
-        IraPhaseOutLimits limits = new IraPhaseOutLimits();
-
-        // Roth IRA 2025 thresholds
-        Map<Integer, YearPhaseOuts> rothIra = new HashMap<>();
-        rothIra.put(2025, new YearPhaseOuts(
-            new PhaseOutRange(new BigDecimal("150000"), new BigDecimal("165000")),
-            new PhaseOutRange(new BigDecimal("236000"), new BigDecimal("246000")),
-            new PhaseOutRange(BigDecimal.ZERO, new BigDecimal("10000"))
-        ));
-        limits.setRothIra(rothIra);
-
-        // Traditional IRA covered 2025 thresholds
-        Map<Integer, YearPhaseOuts> tradCovered = new HashMap<>();
-        tradCovered.put(2025, new YearPhaseOuts(
-            new PhaseOutRange(new BigDecimal("79000"), new BigDecimal("89000")),
-            new PhaseOutRange(new BigDecimal("126000"), new BigDecimal("146000")),
-            new PhaseOutRange(BigDecimal.ZERO, new BigDecimal("10000"))
-        ));
-        limits.setTraditionalIraCovered(tradCovered);
-
-        // Traditional IRA spouse covered 2025 thresholds
-        Map<Integer, YearPhaseOuts> spouseCovered = new HashMap<>();
-        spouseCovered.put(2025, new YearPhaseOuts(
-            PhaseOutRange.ZERO,
-            new PhaseOutRange(new BigDecimal("236000"), new BigDecimal("246000")),
-            PhaseOutRange.ZERO
-        ));
-        limits.setTraditionalIraSpouseCovered(spouseCovered);
-
-        return limits;
-    }
-
-    private IrsContributionLimits createTestContributionLimits() {
-        IrsContributionLimits limits = new IrsContributionLimits();
-        Map<Integer, IraLimits> iraLimits = new HashMap<>();
-        iraLimits.put(2025, new IraLimits(new BigDecimal("7000"), new BigDecimal("1000")));
-        limits.setIraLimits(iraLimits);
-        return limits;
     }
 
     @Nested

--- a/src/test/java/io/github/xmljim/retirement/domain/calculator/TestPhaseOutFixture.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/calculator/TestPhaseOutFixture.java
@@ -1,0 +1,75 @@
+package io.github.xmljim.retirement.domain.calculator;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.github.xmljim.retirement.domain.config.IraPhaseOutLimits;
+import io.github.xmljim.retirement.domain.config.IraPhaseOutLimits.PhaseOutRange;
+import io.github.xmljim.retirement.domain.config.IraPhaseOutLimits.YearPhaseOuts;
+import io.github.xmljim.retirement.domain.config.IrsContributionLimits;
+import io.github.xmljim.retirement.domain.config.IrsContributionLimits.IraLimits;
+
+/**
+ * Shared test fixtures for phase-out calculator tests.
+ *
+ * <p>Provides consistent test data across unit and integration tests
+ * for IRA phase-out calculations.
+ */
+public final class TestPhaseOutFixture {
+
+    private TestPhaseOutFixture() {
+        // Utility class
+    }
+
+    /**
+     * Creates test phase-out limits with 2025 thresholds.
+     *
+     * @return configured IraPhaseOutLimits
+     */
+    public static IraPhaseOutLimits createTestPhaseOutLimits() {
+        IraPhaseOutLimits limits = new IraPhaseOutLimits();
+
+        // Roth IRA 2025 thresholds
+        Map<Integer, YearPhaseOuts> rothIra = new HashMap<>();
+        rothIra.put(2025, new YearPhaseOuts(
+            new PhaseOutRange(new BigDecimal("150000"), new BigDecimal("165000")),
+            new PhaseOutRange(new BigDecimal("236000"), new BigDecimal("246000")),
+            new PhaseOutRange(BigDecimal.ZERO, new BigDecimal("10000"))
+        ));
+        limits.setRothIra(rothIra);
+
+        // Traditional IRA covered 2025 thresholds
+        Map<Integer, YearPhaseOuts> tradCovered = new HashMap<>();
+        tradCovered.put(2025, new YearPhaseOuts(
+            new PhaseOutRange(new BigDecimal("79000"), new BigDecimal("89000")),
+            new PhaseOutRange(new BigDecimal("126000"), new BigDecimal("146000")),
+            new PhaseOutRange(BigDecimal.ZERO, new BigDecimal("10000"))
+        ));
+        limits.setTraditionalIraCovered(tradCovered);
+
+        // Traditional IRA spouse covered 2025 thresholds
+        Map<Integer, YearPhaseOuts> spouseCovered = new HashMap<>();
+        spouseCovered.put(2025, new YearPhaseOuts(
+            PhaseOutRange.ZERO,
+            new PhaseOutRange(new BigDecimal("236000"), new BigDecimal("246000")),
+            PhaseOutRange.ZERO
+        ));
+        limits.setTraditionalIraSpouseCovered(spouseCovered);
+
+        return limits;
+    }
+
+    /**
+     * Creates test IRA contribution limits with 2025 values.
+     *
+     * @return configured IrsContributionLimits
+     */
+    public static IrsContributionLimits createTestContributionLimits() {
+        IrsContributionLimits limits = new IrsContributionLimits();
+        Map<Integer, IraLimits> iraLimits = new HashMap<>();
+        iraLimits.put(2025, new IraLimits(new BigDecimal("7000"), new BigDecimal("1000")));
+        limits.setIraLimits(iraLimits);
+        return limits;
+    }
+}

--- a/src/test/java/io/github/xmljim/retirement/domain/calculator/impl/PhaseOutIntegrationTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/calculator/impl/PhaseOutIntegrationTest.java
@@ -1,0 +1,199 @@
+package io.github.xmljim.retirement.domain.calculator.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.github.xmljim.retirement.domain.calculator.CalculatorFactory;
+import io.github.xmljim.retirement.domain.calculator.MAGICalculator;
+import io.github.xmljim.retirement.domain.calculator.PhaseOutCalculator;
+import io.github.xmljim.retirement.domain.calculator.PhaseOutResult;
+import io.github.xmljim.retirement.domain.calculator.TestPhaseOutFixture;
+import io.github.xmljim.retirement.domain.config.IraPhaseOutLimits;
+import io.github.xmljim.retirement.domain.config.IrsContributionLimits;
+import io.github.xmljim.retirement.domain.enums.FilingStatus;
+import io.github.xmljim.retirement.domain.value.IncomeDetails;
+
+/**
+ * Integration tests for M3b phase-out flow: MAGI calculation to phase-out determination.
+ */
+@DisplayName("Phase-Out Integration Tests")
+class PhaseOutIntegrationTest {
+
+    private MAGICalculator magiCalculator;
+    private PhaseOutCalculator phaseOutCalculator;
+
+    @BeforeEach
+    void setUp() {
+        magiCalculator = CalculatorFactory.magiCalculator();
+        IraPhaseOutLimits phaseOutLimits = TestPhaseOutFixture.createTestPhaseOutLimits();
+        IrsContributionLimits contributionLimits = TestPhaseOutFixture.createTestContributionLimits();
+        phaseOutCalculator = CalculatorFactory.phaseOutCalculator(phaseOutLimits, contributionLimits);
+    }
+
+    @Test
+    @DisplayName("High earner with add-backs gets phased out of Roth")
+    void highEarnerWithAddBacksPhasedOut() {
+        IncomeDetails income = IncomeDetails.builder()
+            .adjustedGrossIncome(new BigDecimal("140000"))
+            .studentLoanInterest(new BigDecimal("15000"))
+            .build();
+
+        BigDecimal magi = magiCalculator.calculate(income);
+        assertEquals(0, new BigDecimal("155000").compareTo(magi));
+
+        PhaseOutResult result = phaseOutCalculator.calculateRothIraPhaseOut(
+            magi, FilingStatus.SINGLE, 2025, new BigDecimal("7000"), 45);
+
+        assertFalse(result.isFullyPhasedOut());
+        assertTrue(result.canContribute());
+        assertTrue(result.allowedContribution().compareTo(new BigDecimal("4000")) > 0);
+        assertTrue(result.allowedContribution().compareTo(new BigDecimal("5000")) < 0);
+    }
+
+    @Test
+    @DisplayName("Couple with foreign income exclusion exceeds Roth limit")
+    void coupleWithForeignIncomeExceedRoth() {
+        IncomeDetails income = IncomeDetails.builder()
+            .adjustedGrossIncome(new BigDecimal("200000"))
+            .foreignEarnedIncomeExclusion(new BigDecimal("50000"))
+            .build();
+
+        BigDecimal magi = magiCalculator.calculate(income);
+        assertEquals(0, new BigDecimal("250000").compareTo(magi));
+
+        PhaseOutResult result = phaseOutCalculator.calculateRothIraPhaseOut(
+            magi, FilingStatus.MARRIED_FILING_JOINTLY, 2025, new BigDecimal("7000"), 45);
+
+        assertTrue(result.isFullyPhasedOut());
+        assertFalse(result.canContribute());
+        assertTrue(result.backdoorRothEligible());
+    }
+
+    @Test
+    @DisplayName("AGI without add-backs uses simple MAGI")
+    void agiWithoutAddBacksSimpleMagi() {
+        IncomeDetails income = IncomeDetails.ofAgi(new BigDecimal("100000"));
+
+        BigDecimal magi = magiCalculator.calculate(income);
+        assertEquals(0, new BigDecimal("100000").compareTo(magi));
+
+        PhaseOutResult result = phaseOutCalculator.calculateRothIraPhaseOut(
+            magi, FilingStatus.SINGLE, 2025, new BigDecimal("7000"), 45);
+
+        assertTrue(result.isFullContributionAllowed());
+        assertEquals(0, new BigDecimal("7000").compareTo(result.allowedContribution()));
+    }
+
+    @Test
+    @DisplayName("MFS has restricted phase-out starting at $0")
+    void mfsRestrictedPhaseOut() {
+        BigDecimal magi = new BigDecimal("5000");
+
+        PhaseOutResult result = phaseOutCalculator.calculateRothIraPhaseOut(
+            magi, FilingStatus.MARRIED_FILING_SEPARATELY, 2025, new BigDecimal("7000"), 45);
+
+        assertFalse(result.isFullyPhasedOut());
+        assertTrue(result.allowedContribution().compareTo(new BigDecimal("3000")) > 0);
+        assertTrue(result.allowedContribution().compareTo(new BigDecimal("4000")) < 0);
+    }
+
+    @Test
+    @DisplayName("Head of Household uses single thresholds")
+    void hohUsesSingleThresholds() {
+        BigDecimal magi = new BigDecimal("155000");
+
+        PhaseOutResult singleResult = phaseOutCalculator.calculateRothIraPhaseOut(
+            magi, FilingStatus.SINGLE, 2025, new BigDecimal("7000"), 45);
+
+        PhaseOutResult hohResult = phaseOutCalculator.calculateRothIraPhaseOut(
+            magi, FilingStatus.HEAD_OF_HOUSEHOLD, 2025, new BigDecimal("7000"), 45);
+
+        assertEquals(0, singleResult.allowedContribution().compareTo(hohResult.allowedContribution()));
+    }
+
+    @Test
+    @DisplayName("QSS uses MFJ thresholds")
+    void qssUsesMfjThresholds() {
+        BigDecimal magi = new BigDecimal("240000");
+
+        PhaseOutResult mfjResult = phaseOutCalculator.calculateRothIraPhaseOut(
+            magi, FilingStatus.MARRIED_FILING_JOINTLY, 2025, new BigDecimal("7000"), 45);
+
+        PhaseOutResult qssResult = phaseOutCalculator.calculateRothIraPhaseOut(
+            magi, FilingStatus.QUALIFYING_SURVIVING_SPOUSE, 2025, new BigDecimal("7000"), 45);
+
+        assertEquals(0, mfjResult.allowedContribution().compareTo(qssResult.allowedContribution()));
+    }
+
+    @Test
+    @DisplayName("Not covered by plan: full deduction at any income")
+    void notCoveredFullDeduction() {
+        IncomeDetails income = IncomeDetails.ofAgi(new BigDecimal("500000"));
+        BigDecimal magi = magiCalculator.calculate(income);
+
+        PhaseOutResult result = phaseOutCalculator.calculateTraditionalIraPhaseOut(
+            magi, FilingStatus.SINGLE, 2025, new BigDecimal("7000"), 45, false, false);
+
+        assertEquals(0, new BigDecimal("7000").compareTo(result.deductiblePortion()));
+        assertFalse(result.isFullyPhasedOut());
+    }
+
+    @Test
+    @DisplayName("Covered and above phase-out: contribution allowed but not deductible")
+    void coveredAbovePhaseOut() {
+        IncomeDetails income = IncomeDetails.ofAgi(new BigDecimal("100000"));
+        BigDecimal magi = magiCalculator.calculate(income);
+
+        PhaseOutResult result = phaseOutCalculator.calculateTraditionalIraPhaseOut(
+            magi, FilingStatus.SINGLE, 2025, new BigDecimal("7000"), 45, true, false);
+
+        assertEquals(0, BigDecimal.ZERO.compareTo(result.deductiblePortion()));
+        assertTrue(result.isFullyPhasedOut());
+    }
+
+    @Test
+    @DisplayName("Spouse covered uses higher threshold")
+    void spouseCoveredHigherThreshold() {
+        BigDecimal magi = new BigDecimal("200000");
+
+        PhaseOutResult result = phaseOutCalculator.calculateTraditionalIraPhaseOut(
+            magi, FilingStatus.MARRIED_FILING_JOINTLY, 2025, new BigDecimal("7000"), 45,
+            false, true);
+
+        assertEquals(0, new BigDecimal("7000").compareTo(result.deductiblePortion()));
+        assertFalse(result.isFullyPhasedOut());
+    }
+
+    @Test
+    @DisplayName("Age 50+ gets $8,000 limit")
+    void age50GetsCatchUp() {
+        BigDecimal maxLimit = phaseOutCalculator.getMaxIraContribution(2025, 55);
+        assertEquals(0, new BigDecimal("8000").compareTo(maxLimit));
+    }
+
+    @Test
+    @DisplayName("Age 49 gets $7,000 limit")
+    void age49NoCatchUp() {
+        BigDecimal maxLimit = phaseOutCalculator.getMaxIraContribution(2025, 49);
+        assertEquals(0, new BigDecimal("7000").compareTo(maxLimit));
+    }
+
+    @Test
+    @DisplayName("Partial phase-out respects catch-up limit")
+    void partialPhaseOutWithCatchUp() {
+        BigDecimal magi = new BigDecimal("157500");
+
+        PhaseOutResult result = phaseOutCalculator.calculateRothIraPhaseOut(
+            magi, FilingStatus.SINGLE, 2025, new BigDecimal("8000"), 55);
+
+        assertTrue(result.allowedContribution().compareTo(new BigDecimal("3500")) > 0);
+        assertTrue(result.allowedContribution().compareTo(new BigDecimal("4500")) < 0);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `PhaseOutIntegrationTest` with 12 end-to-end integration tests
- Tests the complete MAGI → Phase-out → Allowed contribution flow
- Covers all filing statuses and coverage scenarios

## Test Scenarios Covered
- High earner with add-backs gets phased out of Roth
- Couple with foreign income exclusion exceeds Roth limit
- AGI without add-backs uses simple MAGI
- MFS has restricted phase-out starting at $0
- Head of Household uses single thresholds
- QSS uses MFJ thresholds
- Traditional IRA: not covered = full deduction
- Traditional IRA: covered above phase-out
- Traditional IRA: spouse covered uses higher threshold
- Catch-up contribution handling (age 50+)

## Test plan
- [x] All 12 integration tests pass
- [x] Full test suite passes (721 tests)
- [x] Checkstyle passes

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)