### PR TITLE
feat(#34): Add expense category model with differentiated inflation rates

### DIFF
--- a/src/main/java/io/github/xmljim/retirement/domain/config/InflationRates.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/config/InflationRates.java
@@ -1,0 +1,223 @@
+package io.github.xmljim.retirement.domain.config;
+
+import java.math.BigDecimal;
+import java.util.EnumMap;
+import java.util.Map;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.github.xmljim.retirement.domain.enums.ExpenseCategory;
+import io.github.xmljim.retirement.domain.enums.ExpenseCategory.InflationType;
+
+/**
+ * Inflation rate configuration for expense modeling.
+ *
+ * <p>Provides category-specific inflation rates for projecting future expenses.
+ * Different expense types inflate at different rates:
+ * <ul>
+ *   <li>General CPI: ~2.5% (food, utilities, discretionary)</li>
+ *   <li>Healthcare: ~5.5% (medical, Medicare premiums)</li>
+ *   <li>Housing: ~3.0% (property taxes, maintenance)</li>
+ *   <li>Long-term care: ~7.0% (nursing homes, assisted living)</li>
+ * </ul>
+ *
+ * <p>Configuration is loaded from YAML with prefix {@code expenses.inflation-rates}.
+ *
+ * @see ExpenseCategory
+ * @see ExpenseCategory.InflationType
+ */
+@ConfigurationProperties(prefix = "expenses.inflation-rates")
+@Validated
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP",
+    justification = "Spring @ConfigurationProperties requires mutable access for binding"
+)
+public class InflationRates {
+
+    /** Default general CPI inflation rate. */
+    public static final BigDecimal DEFAULT_GENERAL_CPI = new BigDecimal("0.025");
+
+    /** Default healthcare inflation rate. */
+    public static final BigDecimal DEFAULT_HEALTHCARE = new BigDecimal("0.055");
+
+    /** Default housing inflation rate. */
+    public static final BigDecimal DEFAULT_HOUSING = new BigDecimal("0.030");
+
+    /** Default long-term care inflation rate. */
+    public static final BigDecimal DEFAULT_LTC = new BigDecimal("0.070");
+
+    private BigDecimal generalCpi = DEFAULT_GENERAL_CPI;
+    private BigDecimal healthcare = DEFAULT_HEALTHCARE;
+    private BigDecimal housing = DEFAULT_HOUSING;
+    private BigDecimal ltc = DEFAULT_LTC;
+    private Map<ExpenseCategory, BigDecimal> categoryOverrides = new EnumMap<>(ExpenseCategory.class);
+
+    /**
+     * Returns the inflation rate for a specific expense category.
+     *
+     * <p>First checks for a category-specific override, then falls back
+     * to the rate for the category's inflation type.
+     *
+     * @param category the expense category
+     * @return the applicable inflation rate (e.g., 0.025 for 2.5%)
+     */
+    public BigDecimal getRateForCategory(ExpenseCategory category) {
+        if (category == null) {
+            return generalCpi;
+        }
+
+        // Check for category-specific override
+        if (categoryOverrides.containsKey(category)) {
+            return categoryOverrides.get(category);
+        }
+
+        // Fall back to inflation type rate
+        return getRateForInflationType(category.getInflationType());
+    }
+
+    /**
+     * Returns the inflation rate for a specific inflation type.
+     *
+     * @param type the inflation type
+     * @return the applicable inflation rate
+     */
+    public BigDecimal getRateForInflationType(InflationType type) {
+        if (type == null) {
+            return generalCpi;
+        }
+
+        return switch (type) {
+            case GENERAL -> generalCpi;
+            case HEALTHCARE -> healthcare;
+            case HOUSING -> housing;
+            case LTC -> ltc;
+            case NONE -> BigDecimal.ZERO;
+        };
+    }
+
+    /**
+     * Returns the general CPI inflation rate.
+     *
+     * @return the rate as a decimal (e.g., 0.025 for 2.5%)
+     */
+    public BigDecimal getGeneralCpi() {
+        return generalCpi;
+    }
+
+    /**
+     * Sets the general CPI inflation rate.
+     *
+     * @param generalCpi the rate as a decimal
+     */
+    public void setGeneralCpi(BigDecimal generalCpi) {
+        this.generalCpi = generalCpi != null ? generalCpi : DEFAULT_GENERAL_CPI;
+    }
+
+    /**
+     * Returns the healthcare inflation rate.
+     *
+     * @return the rate as a decimal
+     */
+    public BigDecimal getHealthcare() {
+        return healthcare;
+    }
+
+    /**
+     * Sets the healthcare inflation rate.
+     *
+     * @param healthcare the rate as a decimal
+     */
+    public void setHealthcare(BigDecimal healthcare) {
+        this.healthcare = healthcare != null ? healthcare : DEFAULT_HEALTHCARE;
+    }
+
+    /**
+     * Returns the housing inflation rate.
+     *
+     * @return the rate as a decimal
+     */
+    public BigDecimal getHousing() {
+        return housing;
+    }
+
+    /**
+     * Sets the housing inflation rate.
+     *
+     * @param housing the rate as a decimal
+     */
+    public void setHousing(BigDecimal housing) {
+        this.housing = housing != null ? housing : DEFAULT_HOUSING;
+    }
+
+    /**
+     * Returns the long-term care inflation rate.
+     *
+     * @return the rate as a decimal
+     */
+    public BigDecimal getLtc() {
+        return ltc;
+    }
+
+    /**
+     * Sets the long-term care inflation rate.
+     *
+     * @param ltc the rate as a decimal
+     */
+    public void setLtc(BigDecimal ltc) {
+        this.ltc = ltc != null ? ltc : DEFAULT_LTC;
+    }
+
+    /**
+     * Returns category-specific rate overrides.
+     *
+     * @return map of category to custom rate
+     */
+    public Map<ExpenseCategory, BigDecimal> getCategoryOverrides() {
+        return categoryOverrides;
+    }
+
+    /**
+     * Sets category-specific rate overrides.
+     *
+     * @param categoryOverrides map of category to custom rate
+     */
+    public void setCategoryOverrides(Map<ExpenseCategory, BigDecimal> categoryOverrides) {
+        this.categoryOverrides = categoryOverrides != null
+                ? new EnumMap<>(categoryOverrides)
+                : new EnumMap<>(ExpenseCategory.class);
+    }
+
+    /**
+     * Sets a custom inflation rate for a specific category.
+     *
+     * @param category the category to override
+     * @param rate the custom rate
+     */
+    public void setOverride(ExpenseCategory category, BigDecimal rate) {
+        if (category != null && rate != null) {
+            categoryOverrides.put(category, rate);
+        }
+    }
+
+    /**
+     * Removes a custom inflation rate override for a category.
+     *
+     * @param category the category to remove override for
+     */
+    public void removeOverride(ExpenseCategory category) {
+        if (category != null) {
+            categoryOverrides.remove(category);
+        }
+    }
+
+    /**
+     * Creates default inflation rates without Spring configuration.
+     *
+     * @return a new InflationRates instance with defaults
+     */
+    public static InflationRates defaults() {
+        return new InflationRates();
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/domain/enums/ExpenseCategory.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/enums/ExpenseCategory.java
@@ -1,0 +1,312 @@
+package io.github.xmljim.retirement.domain.enums;
+
+/**
+ * Expense categories for retirement budget modeling.
+ *
+ * <p>Categories are organized into {@link ExpenseCategoryGroup}s for easier
+ * management. Each category has an associated default inflation type that
+ * determines which inflation rate to apply when projecting future costs.
+ *
+ * <p>Categories support different inflation rates because costs in retirement
+ * do not all grow at the same pace. For example:
+ * <ul>
+ *   <li>Healthcare typically inflates at 5-6% annually</li>
+ *   <li>General expenses follow CPI at ~2.5%</li>
+ *   <li>Long-term care costs have risen 7-10% annually</li>
+ *   <li>Debt payments are typically fixed (no inflation)</li>
+ * </ul>
+ *
+ * @see ExpenseCategoryGroup
+ * @see InflationType
+ */
+public enum ExpenseCategory {
+
+    // ========== ESSENTIAL ==========
+
+    /**
+     * Housing expenses.
+     *
+     * <p>Includes mortgage or rent, property taxes, homeowner's insurance,
+     * HOA fees, and basic home maintenance. Property taxes often outpace
+     * general inflation.
+     */
+    HOUSING("Housing", ExpenseCategoryGroup.ESSENTIAL, InflationType.HOUSING,
+            "Mortgage/rent, property tax, insurance, HOA"),
+
+    /**
+     * Food expenses.
+     *
+     * <p>Includes groceries and dining out. Generally follows CPI.
+     */
+    FOOD("Food", ExpenseCategoryGroup.ESSENTIAL, InflationType.GENERAL,
+            "Groceries and dining"),
+
+    /**
+     * Utility expenses.
+     *
+     * <p>Includes electricity, gas, water, sewer, trash, internet, and phone.
+     */
+    UTILITIES("Utilities", ExpenseCategoryGroup.ESSENTIAL, InflationType.GENERAL,
+            "Electric, gas, water, internet, phone"),
+
+    /**
+     * Transportation expenses.
+     *
+     * <p>Includes car payments, auto insurance, fuel, maintenance, and repairs.
+     * Does not include vehicle replacement reserves (see {@link #VEHICLE_REPLACEMENT}).
+     */
+    TRANSPORTATION("Transportation", ExpenseCategoryGroup.ESSENTIAL, InflationType.GENERAL,
+            "Car payment, insurance, gas, maintenance"),
+
+    /**
+     * Non-health insurance expenses.
+     *
+     * <p>Includes life insurance, umbrella policies, and other non-health
+     * insurance not covered elsewhere.
+     */
+    INSURANCE("Insurance", ExpenseCategoryGroup.ESSENTIAL, InflationType.GENERAL,
+            "Life, umbrella, other non-health insurance"),
+
+    // ========== HEALTHCARE ==========
+
+    /**
+     * Medicare premium expenses.
+     *
+     * <p>Includes Medicare Part B, Part D, and Medigap/Medicare Supplement
+     * premiums. May include IRMAA surcharges based on income.
+     * Use {@link io.github.xmljim.retirement.domain.calculator.MedicareCalculator}
+     * for IRMAA-adjusted premiums.
+     */
+    MEDICARE_PREMIUMS("Medicare Premiums", ExpenseCategoryGroup.HEALTHCARE, InflationType.HEALTHCARE,
+            "Part B, Part D, Medigap premiums (IRMAA-adjusted)"),
+
+    /**
+     * Healthcare out-of-pocket expenses.
+     *
+     * <p>Includes copays, deductibles, prescriptions, dental, vision,
+     * and hearing costs not covered by insurance.
+     */
+    HEALTHCARE_OOP("Healthcare Out-of-Pocket", ExpenseCategoryGroup.HEALTHCARE, InflationType.HEALTHCARE,
+            "Copays, prescriptions, dental, vision, hearing"),
+
+    /**
+     * Long-term care insurance premiums.
+     *
+     * <p>Monthly or annual premiums for LTC insurance policies.
+     * Premiums may increase over time due to rate adjustments.
+     */
+    LTC_PREMIUMS("LTC Insurance Premiums", ExpenseCategoryGroup.HEALTHCARE, InflationType.LTC,
+            "Long-term care insurance premium payments"),
+
+    /**
+     * Long-term care expenses.
+     *
+     * <p>Actual costs for long-term care services including nursing home,
+     * assisted living, home health aides, and adult day care.
+     * These costs are reduced by LTC insurance benefit payouts.
+     */
+    LTC_CARE("Long-Term Care", ExpenseCategoryGroup.HEALTHCARE, InflationType.LTC,
+            "Nursing home, assisted living, home health costs"),
+
+    // ========== DISCRETIONARY ==========
+
+    /**
+     * Travel expenses.
+     *
+     * <p>Includes vacations, trips to visit family, and other travel.
+     * Often highest in early retirement (Go-Go years) and decreases with age.
+     */
+    TRAVEL("Travel", ExpenseCategoryGroup.DISCRETIONARY, InflationType.GENERAL,
+            "Vacations, trips, visiting family"),
+
+    /**
+     * Entertainment expenses.
+     *
+     * <p>Includes dining out, streaming services, concerts, movies,
+     * sports events, and other entertainment.
+     */
+    ENTERTAINMENT("Entertainment", ExpenseCategoryGroup.DISCRETIONARY, InflationType.GENERAL,
+            "Dining out, streaming, concerts, events"),
+
+    /**
+     * Hobby expenses.
+     *
+     * <p>Includes golf, crafts, club memberships, sports equipment,
+     * and other hobby-related costs.
+     */
+    HOBBIES("Hobbies", ExpenseCategoryGroup.DISCRETIONARY, InflationType.GENERAL,
+            "Golf, crafts, clubs, sports"),
+
+    /**
+     * Gifts and charitable contributions.
+     *
+     * <p>Includes gifts to family, charitable donations, and support
+     * for children/grandchildren.
+     */
+    GIFTS("Gifts & Charity", ExpenseCategoryGroup.DISCRETIONARY, InflationType.GENERAL,
+            "Family gifts, charitable donations"),
+
+    // ========== CONTINGENCY ==========
+
+    /**
+     * Home repair and maintenance reserve.
+     *
+     * <p>Annual set-aside for home repairs and major maintenance.
+     * Rule of thumb: 1-2% of home value annually. Covers roof,
+     * HVAC, appliances, and other major repairs.
+     */
+    HOME_REPAIRS("Home Repairs Reserve", ExpenseCategoryGroup.CONTINGENCY, InflationType.HOUSING,
+            "Reserve for major repairs (1-2% of home value)"),
+
+    /**
+     * Vehicle replacement reserve.
+     *
+     * <p>Amortized reserve for vehicle replacement. Example: $35,000
+     * replacement every 7 years = $5,000/year reserve.
+     */
+    VEHICLE_REPLACEMENT("Vehicle Replacement", ExpenseCategoryGroup.CONTINGENCY, InflationType.GENERAL,
+            "Amortized reserve for car replacement"),
+
+    /**
+     * Emergency fund reserve.
+     *
+     * <p>Contributions to maintain or replenish emergency fund.
+     * Target is typically 3-6 months of essential expenses.
+     */
+    EMERGENCY_RESERVE("Emergency Reserve", ExpenseCategoryGroup.CONTINGENCY, InflationType.GENERAL,
+            "Emergency fund contributions"),
+
+    // ========== DEBT ==========
+
+    /**
+     * Debt payments.
+     *
+     * <p>Fixed monthly payments for mortgage principal, car loans,
+     * student loans, and other installment debt. These payments
+     * are typically fixed and do not inflate.
+     */
+    DEBT_PAYMENTS("Debt Payments", ExpenseCategoryGroup.DEBT, InflationType.NONE,
+            "Mortgage, car loans, other fixed debt"),
+
+    // ========== OTHER ==========
+
+    /**
+     * Tax payments.
+     *
+     * <p>Estimated federal and state income tax payments.
+     * Use tax calculators for accurate projections.
+     */
+    TAXES("Taxes", ExpenseCategoryGroup.OTHER, InflationType.GENERAL,
+            "Estimated tax payments"),
+
+    /**
+     * Other miscellaneous expenses.
+     *
+     * <p>Catch-all for expenses not fitting other categories.
+     */
+    OTHER("Other", ExpenseCategoryGroup.OTHER, InflationType.GENERAL,
+            "Miscellaneous expenses");
+
+    /**
+     * Type of inflation to apply to this category.
+     */
+    public enum InflationType {
+        /** General CPI inflation (~2.5%). */
+        GENERAL,
+        /** Healthcare inflation (~5.5%). */
+        HEALTHCARE,
+        /** Housing-specific inflation (~3.0%). */
+        HOUSING,
+        /** Long-term care inflation (~7.0%). */
+        LTC,
+        /** No inflation (fixed payments). */
+        NONE
+    }
+
+    private final String displayName;
+    private final ExpenseCategoryGroup group;
+    private final InflationType inflationType;
+    private final String description;
+
+    ExpenseCategory(String displayName, ExpenseCategoryGroup group,
+                    InflationType inflationType, String description) {
+        this.displayName = displayName;
+        this.group = group;
+        this.inflationType = inflationType;
+        this.description = description;
+    }
+
+    /**
+     * Returns the human-readable display name.
+     *
+     * @return the display name
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * Returns the category group this expense belongs to.
+     *
+     * @return the category group
+     */
+    public ExpenseCategoryGroup getGroup() {
+        return group;
+    }
+
+    /**
+     * Returns the inflation type for this category.
+     *
+     * @return the inflation type
+     */
+    public InflationType getInflationType() {
+        return inflationType;
+    }
+
+    /**
+     * Returns a brief description of this category.
+     *
+     * @return the description
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Indicates whether this is an essential expense.
+     *
+     * @return true if this category is in the ESSENTIAL group
+     */
+    public boolean isEssential() {
+        return group == ExpenseCategoryGroup.ESSENTIAL;
+    }
+
+    /**
+     * Indicates whether this is a healthcare expense.
+     *
+     * @return true if this category is in the HEALTHCARE group
+     */
+    public boolean isHealthcare() {
+        return group == ExpenseCategoryGroup.HEALTHCARE;
+    }
+
+    /**
+     * Indicates whether this is a discretionary expense.
+     *
+     * @return true if this category is in the DISCRETIONARY group
+     */
+    public boolean isDiscretionary() {
+        return group == ExpenseCategoryGroup.DISCRETIONARY;
+    }
+
+    /**
+     * Indicates whether this expense is subject to inflation.
+     *
+     * <p>Fixed payments like debt service do not inflate.
+     *
+     * @return true if inflation should be applied
+     */
+    public boolean isInflationAdjusted() {
+        return inflationType != InflationType.NONE;
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/domain/enums/ExpenseCategoryGroup.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/enums/ExpenseCategoryGroup.java
@@ -1,0 +1,92 @@
+package io.github.xmljim.retirement.domain.enums;
+
+/**
+ * High-level groupings for expense categories.
+ *
+ * <p>Expense categories are organized into groups for easier management
+ * and to apply group-level defaults (such as inflation rates). Each
+ * {@link ExpenseCategory} belongs to exactly one group.
+ *
+ * @see ExpenseCategory
+ */
+public enum ExpenseCategoryGroup {
+
+    /**
+     * Essential living expenses.
+     *
+     * <p>Covers basic needs that cannot easily be reduced:
+     * housing, food, utilities, transportation, and insurance.
+     * These expenses should be prioritized in budget allocation.
+     */
+    ESSENTIAL("Essential", "Basic living expenses that are difficult to reduce"),
+
+    /**
+     * Healthcare-related expenses.
+     *
+     * <p>Includes Medicare premiums, out-of-pocket medical costs,
+     * long-term care insurance premiums, and actual long-term care costs.
+     * Healthcare typically inflates faster than general CPI (5-6% vs 2-3%).
+     */
+    HEALTHCARE("Healthcare", "Medical and long-term care expenses"),
+
+    /**
+     * Discretionary spending.
+     *
+     * <p>Non-essential lifestyle expenses such as travel, entertainment,
+     * hobbies, and gifts. These can be reduced during market downturns
+     * or when income is constrained.
+     */
+    DISCRETIONARY("Discretionary", "Lifestyle expenses that can be adjusted"),
+
+    /**
+     * Contingency and reserve expenses.
+     *
+     * <p>Funds set aside for unexpected expenses such as home repairs,
+     * vehicle replacement, and emergency reserves. These represent
+     * planned savings for irregular large expenses.
+     */
+    CONTINGENCY("Contingency", "Reserves for unexpected expenses"),
+
+    /**
+     * Debt payments.
+     *
+     * <p>Fixed debt obligations such as mortgage payments, car loans,
+     * and other installment debt. These typically do not inflate and
+     * have defined end dates.
+     */
+    DEBT("Debt", "Fixed debt payments"),
+
+    /**
+     * Other expenses.
+     *
+     * <p>Catch-all category for expenses not fitting other groups,
+     * including estimated tax payments and miscellaneous costs.
+     */
+    OTHER("Other", "Miscellaneous expenses");
+
+    private final String displayName;
+    private final String description;
+
+    ExpenseCategoryGroup(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+
+    /**
+     * Returns the human-readable display name.
+     *
+     * @return the display name
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * Returns a brief description of this group.
+     *
+     * @return the description
+     */
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/resources/application-expenses.yml
+++ b/src/main/resources/application-expenses.yml
@@ -1,0 +1,35 @@
+# Expense and Inflation Configuration
+# Milestone 5: Expense & Budget Modeling
+#
+# Sources:
+# - BLS CPI data (general inflation ~2.5%)
+# - CMS projections (healthcare ~5.5%)
+# - Genworth Cost of Care Survey (LTC ~7%)
+# - Property tax historical trends (~3%)
+
+expenses:
+  # Inflation rates by type
+  # These rates are applied to expenses based on their category's InflationType
+  inflation-rates:
+    # General CPI - applied to most expenses
+    # Historical 30-year average: ~2.5%
+    general-cpi: 0.025
+
+    # Healthcare inflation - applied to medical expenses
+    # Historical average: 5-6% (CMS projects 5.1% through 2031)
+    healthcare: 0.055
+
+    # Housing inflation - applied to property-related expenses
+    # Property taxes and maintenance often outpace CPI
+    housing: 0.030
+
+    # Long-term care inflation - applied to LTC costs
+    # Nursing homes and assisted living have increased 7-10% annually
+    ltc: 0.070
+
+    # Category-specific overrides (optional)
+    # Use to customize rates for individual categories
+    # Example: TRAVEL: 0.03 to set travel inflation to 3%
+    # category-overrides:
+    #   TRAVEL: 0.03
+    #   ENTERTAINMENT: 0.02

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,7 @@ spring:
   config:
     import:
       - application-social-security.yml
+      - application-expenses.yml
 
 # IRS Contribution Limits Configuration
 # SECURE 2.0 Act limits for 401(k), 403(b), and 457(b) plans

--- a/src/test/java/io/github/xmljim/retirement/domain/config/InflationRatesTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/config/InflationRatesTest.java
@@ -1,0 +1,282 @@
+package io.github.xmljim.retirement.domain.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.github.xmljim.retirement.domain.enums.ExpenseCategory;
+import io.github.xmljim.retirement.domain.enums.ExpenseCategory.InflationType;
+
+@DisplayName("InflationRates Tests")
+class InflationRatesTest {
+
+    private InflationRates rates;
+
+    @BeforeEach
+    void setUp() {
+        rates = new InflationRates();
+    }
+
+    @Nested
+    @DisplayName("Default Value Tests")
+    class DefaultValueTests {
+
+        @Test
+        @DisplayName("Default general CPI should be 2.5%")
+        void defaultGeneralCpi() {
+            assertEquals(new BigDecimal("0.025"), rates.getGeneralCpi());
+        }
+
+        @Test
+        @DisplayName("Default healthcare should be 5.5%")
+        void defaultHealthcare() {
+            assertEquals(new BigDecimal("0.055"), rates.getHealthcare());
+        }
+
+        @Test
+        @DisplayName("Default housing should be 3.0%")
+        void defaultHousing() {
+            assertEquals(new BigDecimal("0.030"), rates.getHousing());
+        }
+
+        @Test
+        @DisplayName("Default LTC should be 7.0%")
+        void defaultLtc() {
+            assertEquals(new BigDecimal("0.070"), rates.getLtc());
+        }
+
+        @Test
+        @DisplayName("defaults() factory method should return instance with defaults")
+        void defaultsFactoryMethod() {
+            InflationRates defaultRates = InflationRates.defaults();
+            assertNotNull(defaultRates);
+            assertEquals(InflationRates.DEFAULT_GENERAL_CPI, defaultRates.getGeneralCpi());
+            assertEquals(InflationRates.DEFAULT_HEALTHCARE, defaultRates.getHealthcare());
+            assertEquals(InflationRates.DEFAULT_HOUSING, defaultRates.getHousing());
+            assertEquals(InflationRates.DEFAULT_LTC, defaultRates.getLtc());
+        }
+    }
+
+    @Nested
+    @DisplayName("Rate Setter Tests")
+    class RateSetterTests {
+
+        @Test
+        @DisplayName("Should allow setting custom general CPI rate")
+        void setCustomGeneralCpi() {
+            rates.setGeneralCpi(new BigDecimal("0.03"));
+            assertEquals(new BigDecimal("0.03"), rates.getGeneralCpi());
+        }
+
+        @Test
+        @DisplayName("Should allow setting custom healthcare rate")
+        void setCustomHealthcare() {
+            rates.setHealthcare(new BigDecimal("0.06"));
+            assertEquals(new BigDecimal("0.06"), rates.getHealthcare());
+        }
+
+        @Test
+        @DisplayName("Should allow setting custom housing rate")
+        void setCustomHousing() {
+            rates.setHousing(new BigDecimal("0.035"));
+            assertEquals(new BigDecimal("0.035"), rates.getHousing());
+        }
+
+        @Test
+        @DisplayName("Should allow setting custom LTC rate")
+        void setCustomLtc() {
+            rates.setLtc(new BigDecimal("0.08"));
+            assertEquals(new BigDecimal("0.08"), rates.getLtc());
+        }
+
+        @Test
+        @DisplayName("Setting null general CPI should use default")
+        void nullGeneralCpiUsesDefault() {
+            rates.setGeneralCpi(null);
+            assertEquals(InflationRates.DEFAULT_GENERAL_CPI, rates.getGeneralCpi());
+        }
+
+        @Test
+        @DisplayName("Setting null healthcare should use default")
+        void nullHealthcareUsesDefault() {
+            rates.setHealthcare(null);
+            assertEquals(InflationRates.DEFAULT_HEALTHCARE, rates.getHealthcare());
+        }
+    }
+
+    @Nested
+    @DisplayName("Get Rate For Category Tests")
+    class GetRateForCategoryTests {
+
+        @Test
+        @DisplayName("HOUSING should return housing rate")
+        void housingCategoryReturnsHousingRate() {
+            assertEquals(rates.getHousing(), rates.getRateForCategory(ExpenseCategory.HOUSING));
+        }
+
+        @Test
+        @DisplayName("HOME_REPAIRS should return housing rate")
+        void homeRepairsReturnsHousingRate() {
+            assertEquals(rates.getHousing(), rates.getRateForCategory(ExpenseCategory.HOME_REPAIRS));
+        }
+
+        @Test
+        @DisplayName("MEDICARE_PREMIUMS should return healthcare rate")
+        void medicareReturnsHealthcareRate() {
+            assertEquals(rates.getHealthcare(), rates.getRateForCategory(ExpenseCategory.MEDICARE_PREMIUMS));
+        }
+
+        @Test
+        @DisplayName("HEALTHCARE_OOP should return healthcare rate")
+        void healthcareOopReturnsHealthcareRate() {
+            assertEquals(rates.getHealthcare(), rates.getRateForCategory(ExpenseCategory.HEALTHCARE_OOP));
+        }
+
+        @Test
+        @DisplayName("LTC_PREMIUMS should return LTC rate")
+        void ltcPremiumsReturnsLtcRate() {
+            assertEquals(rates.getLtc(), rates.getRateForCategory(ExpenseCategory.LTC_PREMIUMS));
+        }
+
+        @Test
+        @DisplayName("LTC_CARE should return LTC rate")
+        void ltcCareReturnsLtcRate() {
+            assertEquals(rates.getLtc(), rates.getRateForCategory(ExpenseCategory.LTC_CARE));
+        }
+
+        @Test
+        @DisplayName("FOOD should return general CPI rate")
+        void foodReturnsGeneralRate() {
+            assertEquals(rates.getGeneralCpi(), rates.getRateForCategory(ExpenseCategory.FOOD));
+        }
+
+        @Test
+        @DisplayName("TRAVEL should return general CPI rate")
+        void travelReturnsGeneralRate() {
+            assertEquals(rates.getGeneralCpi(), rates.getRateForCategory(ExpenseCategory.TRAVEL));
+        }
+
+        @Test
+        @DisplayName("DEBT_PAYMENTS should return zero")
+        void debtPaymentsReturnsZero() {
+            assertEquals(BigDecimal.ZERO, rates.getRateForCategory(ExpenseCategory.DEBT_PAYMENTS));
+        }
+
+        @Test
+        @DisplayName("Null category should return general CPI")
+        void nullCategoryReturnsGeneralCpi() {
+            assertEquals(rates.getGeneralCpi(), rates.getRateForCategory(null));
+        }
+    }
+
+    @Nested
+    @DisplayName("Get Rate For Inflation Type Tests")
+    class GetRateForInflationTypeTests {
+
+        @Test
+        @DisplayName("GENERAL should return general CPI rate")
+        void generalReturnsGeneralCpi() {
+            assertEquals(rates.getGeneralCpi(), rates.getRateForInflationType(InflationType.GENERAL));
+        }
+
+        @Test
+        @DisplayName("HEALTHCARE should return healthcare rate")
+        void healthcareReturnsHealthcare() {
+            assertEquals(rates.getHealthcare(), rates.getRateForInflationType(InflationType.HEALTHCARE));
+        }
+
+        @Test
+        @DisplayName("HOUSING should return housing rate")
+        void housingReturnsHousing() {
+            assertEquals(rates.getHousing(), rates.getRateForInflationType(InflationType.HOUSING));
+        }
+
+        @Test
+        @DisplayName("LTC should return LTC rate")
+        void ltcReturnsLtc() {
+            assertEquals(rates.getLtc(), rates.getRateForInflationType(InflationType.LTC));
+        }
+
+        @Test
+        @DisplayName("NONE should return zero")
+        void noneReturnsZero() {
+            assertEquals(BigDecimal.ZERO, rates.getRateForInflationType(InflationType.NONE));
+        }
+
+        @Test
+        @DisplayName("Null inflation type should return general CPI")
+        void nullReturnsGeneralCpi() {
+            assertEquals(rates.getGeneralCpi(), rates.getRateForInflationType(null));
+        }
+    }
+
+    @Nested
+    @DisplayName("Category Override Tests")
+    class CategoryOverrideTests {
+
+        @Test
+        @DisplayName("Should allow setting category override")
+        void setOverride() {
+            BigDecimal customRate = new BigDecimal("0.04");
+            rates.setOverride(ExpenseCategory.TRAVEL, customRate);
+            assertEquals(customRate, rates.getRateForCategory(ExpenseCategory.TRAVEL));
+        }
+
+        @Test
+        @DisplayName("Override should take precedence over default")
+        void overrideTakesPrecedence() {
+            BigDecimal customRate = new BigDecimal("0.08");
+            rates.setOverride(ExpenseCategory.HOUSING, customRate);
+
+            // Should return custom rate, not default housing rate
+            assertEquals(customRate, rates.getRateForCategory(ExpenseCategory.HOUSING));
+        }
+
+        @Test
+        @DisplayName("Should allow removing override")
+        void removeOverride() {
+            BigDecimal customRate = new BigDecimal("0.04");
+            rates.setOverride(ExpenseCategory.TRAVEL, customRate);
+            assertEquals(customRate, rates.getRateForCategory(ExpenseCategory.TRAVEL));
+
+            rates.removeOverride(ExpenseCategory.TRAVEL);
+            // Should fall back to general CPI
+            assertEquals(rates.getGeneralCpi(), rates.getRateForCategory(ExpenseCategory.TRAVEL));
+        }
+
+        @Test
+        @DisplayName("Setting null override should not add to map")
+        void nullOverrideNotAdded() {
+            rates.setOverride(ExpenseCategory.TRAVEL, null);
+            // Should return default rate
+            assertEquals(rates.getGeneralCpi(), rates.getRateForCategory(ExpenseCategory.TRAVEL));
+        }
+
+        @Test
+        @DisplayName("Setting override for null category should not throw")
+        void nullCategoryOverrideNoOp() {
+            rates.setOverride(null, new BigDecimal("0.05"));
+            // Should not throw, just be a no-op
+        }
+
+        @Test
+        @DisplayName("Removing override for null category should not throw")
+        void removeNullCategoryNoOp() {
+            rates.removeOverride(null);
+            // Should not throw, just be a no-op
+        }
+
+        @Test
+        @DisplayName("Category overrides map should be initialized empty")
+        void overridesMapInitializedEmpty() {
+            assertNotNull(rates.getCategoryOverrides());
+            assertEquals(0, rates.getCategoryOverrides().size());
+        }
+    }
+}

--- a/src/test/java/io/github/xmljim/retirement/domain/enums/ExpenseCategoryGroupTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/enums/ExpenseCategoryGroupTest.java
@@ -1,0 +1,69 @@
+package io.github.xmljim.retirement.domain.enums;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+@DisplayName("ExpenseCategoryGroup Tests")
+class ExpenseCategoryGroupTest {
+
+    @ParameterizedTest
+    @EnumSource(ExpenseCategoryGroup.class)
+    @DisplayName("All groups should have non-null display name")
+    void allGroupsHaveDisplayName(ExpenseCategoryGroup group) {
+        assertNotNull(group.getDisplayName());
+    }
+
+    @ParameterizedTest
+    @EnumSource(ExpenseCategoryGroup.class)
+    @DisplayName("All groups should have non-null description")
+    void allGroupsHaveDescription(ExpenseCategoryGroup group) {
+        assertNotNull(group.getDescription());
+    }
+
+    @Test
+    @DisplayName("ESSENTIAL should have correct display name")
+    void essentialDisplayName() {
+        assertEquals("Essential", ExpenseCategoryGroup.ESSENTIAL.getDisplayName());
+    }
+
+    @Test
+    @DisplayName("HEALTHCARE should have correct display name")
+    void healthcareDisplayName() {
+        assertEquals("Healthcare", ExpenseCategoryGroup.HEALTHCARE.getDisplayName());
+    }
+
+    @Test
+    @DisplayName("DISCRETIONARY should have correct display name")
+    void discretionaryDisplayName() {
+        assertEquals("Discretionary", ExpenseCategoryGroup.DISCRETIONARY.getDisplayName());
+    }
+
+    @Test
+    @DisplayName("CONTINGENCY should have correct display name")
+    void contingencyDisplayName() {
+        assertEquals("Contingency", ExpenseCategoryGroup.CONTINGENCY.getDisplayName());
+    }
+
+    @Test
+    @DisplayName("DEBT should have correct display name")
+    void debtDisplayName() {
+        assertEquals("Debt", ExpenseCategoryGroup.DEBT.getDisplayName());
+    }
+
+    @Test
+    @DisplayName("OTHER should have correct display name")
+    void otherDisplayName() {
+        assertEquals("Other", ExpenseCategoryGroup.OTHER.getDisplayName());
+    }
+
+    @Test
+    @DisplayName("Should have exactly 6 groups")
+    void shouldHaveSixGroups() {
+        assertEquals(6, ExpenseCategoryGroup.values().length);
+    }
+}

--- a/src/test/java/io/github/xmljim/retirement/domain/enums/ExpenseCategoryTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/enums/ExpenseCategoryTest.java
@@ -1,0 +1,292 @@
+package io.github.xmljim.retirement.domain.enums;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import io.github.xmljim.retirement.domain.enums.ExpenseCategory.InflationType;
+
+@DisplayName("ExpenseCategory Tests")
+class ExpenseCategoryTest {
+
+    @Nested
+    @DisplayName("Basic Property Tests")
+    class BasicPropertyTests {
+
+        @ParameterizedTest
+        @EnumSource(ExpenseCategory.class)
+        @DisplayName("All categories should have non-null display name")
+        void allCategoriesHaveDisplayName(ExpenseCategory category) {
+            assertNotNull(category.getDisplayName());
+        }
+
+        @ParameterizedTest
+        @EnumSource(ExpenseCategory.class)
+        @DisplayName("All categories should have non-null group")
+        void allCategoriesHaveGroup(ExpenseCategory category) {
+            assertNotNull(category.getGroup());
+        }
+
+        @ParameterizedTest
+        @EnumSource(ExpenseCategory.class)
+        @DisplayName("All categories should have non-null inflation type")
+        void allCategoriesHaveInflationType(ExpenseCategory category) {
+            assertNotNull(category.getInflationType());
+        }
+
+        @ParameterizedTest
+        @EnumSource(ExpenseCategory.class)
+        @DisplayName("All categories should have non-null description")
+        void allCategoriesHaveDescription(ExpenseCategory category) {
+            assertNotNull(category.getDescription());
+        }
+
+        @Test
+        @DisplayName("Should have 19 expense categories")
+        void shouldHave19Categories() {
+            assertEquals(19, ExpenseCategory.values().length);
+        }
+    }
+
+    @Nested
+    @DisplayName("Group Mapping Tests")
+    class GroupMappingTests {
+
+        @Test
+        @DisplayName("Essential categories should be in ESSENTIAL group")
+        void essentialCategoriesInEssentialGroup() {
+            Set<ExpenseCategory> essentialCategories = Set.of(
+                    ExpenseCategory.HOUSING,
+                    ExpenseCategory.FOOD,
+                    ExpenseCategory.UTILITIES,
+                    ExpenseCategory.TRANSPORTATION,
+                    ExpenseCategory.INSURANCE
+            );
+
+            for (ExpenseCategory category : essentialCategories) {
+                assertEquals(ExpenseCategoryGroup.ESSENTIAL, category.getGroup(),
+                        category + " should be ESSENTIAL");
+            }
+        }
+
+        @Test
+        @DisplayName("Healthcare categories should be in HEALTHCARE group")
+        void healthcareCategoriesInHealthcareGroup() {
+            Set<ExpenseCategory> healthcareCategories = Set.of(
+                    ExpenseCategory.MEDICARE_PREMIUMS,
+                    ExpenseCategory.HEALTHCARE_OOP,
+                    ExpenseCategory.LTC_PREMIUMS,
+                    ExpenseCategory.LTC_CARE
+            );
+
+            for (ExpenseCategory category : healthcareCategories) {
+                assertEquals(ExpenseCategoryGroup.HEALTHCARE, category.getGroup(),
+                        category + " should be HEALTHCARE");
+            }
+        }
+
+        @Test
+        @DisplayName("Discretionary categories should be in DISCRETIONARY group")
+        void discretionaryCategoriesInDiscretionaryGroup() {
+            Set<ExpenseCategory> discretionaryCategories = Set.of(
+                    ExpenseCategory.TRAVEL,
+                    ExpenseCategory.ENTERTAINMENT,
+                    ExpenseCategory.HOBBIES,
+                    ExpenseCategory.GIFTS
+            );
+
+            for (ExpenseCategory category : discretionaryCategories) {
+                assertEquals(ExpenseCategoryGroup.DISCRETIONARY, category.getGroup(),
+                        category + " should be DISCRETIONARY");
+            }
+        }
+
+        @Test
+        @DisplayName("Contingency categories should be in CONTINGENCY group")
+        void contingencyCategoriesInContingencyGroup() {
+            Set<ExpenseCategory> contingencyCategories = Set.of(
+                    ExpenseCategory.HOME_REPAIRS,
+                    ExpenseCategory.VEHICLE_REPLACEMENT,
+                    ExpenseCategory.EMERGENCY_RESERVE
+            );
+
+            for (ExpenseCategory category : contingencyCategories) {
+                assertEquals(ExpenseCategoryGroup.CONTINGENCY, category.getGroup(),
+                        category + " should be CONTINGENCY");
+            }
+        }
+
+        @Test
+        @DisplayName("DEBT_PAYMENTS should be in DEBT group")
+        void debtPaymentsInDebtGroup() {
+            assertEquals(ExpenseCategoryGroup.DEBT, ExpenseCategory.DEBT_PAYMENTS.getGroup());
+        }
+
+        @Test
+        @DisplayName("TAXES and OTHER should be in OTHER group")
+        void otherCategoriesInOtherGroup() {
+            assertEquals(ExpenseCategoryGroup.OTHER, ExpenseCategory.TAXES.getGroup());
+            assertEquals(ExpenseCategoryGroup.OTHER, ExpenseCategory.OTHER.getGroup());
+        }
+    }
+
+    @Nested
+    @DisplayName("Inflation Type Tests")
+    class InflationTypeTests {
+
+        @Test
+        @DisplayName("HOUSING should use HOUSING inflation type")
+        void housingUsesHousingInflation() {
+            assertEquals(InflationType.HOUSING, ExpenseCategory.HOUSING.getInflationType());
+        }
+
+        @Test
+        @DisplayName("HOME_REPAIRS should use HOUSING inflation type")
+        void homeRepairsUsesHousingInflation() {
+            assertEquals(InflationType.HOUSING, ExpenseCategory.HOME_REPAIRS.getInflationType());
+        }
+
+        @Test
+        @DisplayName("Healthcare categories should use HEALTHCARE inflation type")
+        void healthcareCategoriesUseHealthcareInflation() {
+            assertEquals(InflationType.HEALTHCARE, ExpenseCategory.MEDICARE_PREMIUMS.getInflationType());
+            assertEquals(InflationType.HEALTHCARE, ExpenseCategory.HEALTHCARE_OOP.getInflationType());
+        }
+
+        @Test
+        @DisplayName("LTC categories should use LTC inflation type")
+        void ltcCategoriesUseLtcInflation() {
+            assertEquals(InflationType.LTC, ExpenseCategory.LTC_PREMIUMS.getInflationType());
+            assertEquals(InflationType.LTC, ExpenseCategory.LTC_CARE.getInflationType());
+        }
+
+        @Test
+        @DisplayName("DEBT_PAYMENTS should use NONE inflation type")
+        void debtPaymentsUsesNoInflation() {
+            assertEquals(InflationType.NONE, ExpenseCategory.DEBT_PAYMENTS.getInflationType());
+        }
+
+        @Test
+        @DisplayName("General categories should use GENERAL inflation type")
+        void generalCategoriesUseGeneralInflation() {
+            Set<ExpenseCategory> generalCategories = Set.of(
+                    ExpenseCategory.FOOD,
+                    ExpenseCategory.UTILITIES,
+                    ExpenseCategory.TRANSPORTATION,
+                    ExpenseCategory.INSURANCE,
+                    ExpenseCategory.TRAVEL,
+                    ExpenseCategory.ENTERTAINMENT,
+                    ExpenseCategory.HOBBIES,
+                    ExpenseCategory.GIFTS,
+                    ExpenseCategory.VEHICLE_REPLACEMENT,
+                    ExpenseCategory.EMERGENCY_RESERVE,
+                    ExpenseCategory.TAXES,
+                    ExpenseCategory.OTHER
+            );
+
+            for (ExpenseCategory category : generalCategories) {
+                assertEquals(InflationType.GENERAL, category.getInflationType(),
+                        category + " should use GENERAL inflation");
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Helper Method Tests")
+    class HelperMethodTests {
+
+        @Test
+        @DisplayName("isEssential should return true for ESSENTIAL group")
+        void isEssentialForEssentialGroup() {
+            assertTrue(ExpenseCategory.HOUSING.isEssential());
+            assertTrue(ExpenseCategory.FOOD.isEssential());
+            assertTrue(ExpenseCategory.UTILITIES.isEssential());
+            assertTrue(ExpenseCategory.TRANSPORTATION.isEssential());
+            assertTrue(ExpenseCategory.INSURANCE.isEssential());
+        }
+
+        @Test
+        @DisplayName("isEssential should return false for non-ESSENTIAL groups")
+        void isNotEssentialForOtherGroups() {
+            assertFalse(ExpenseCategory.TRAVEL.isEssential());
+            assertFalse(ExpenseCategory.MEDICARE_PREMIUMS.isEssential());
+            assertFalse(ExpenseCategory.DEBT_PAYMENTS.isEssential());
+        }
+
+        @Test
+        @DisplayName("isHealthcare should return true for HEALTHCARE group")
+        void isHealthcareForHealthcareGroup() {
+            assertTrue(ExpenseCategory.MEDICARE_PREMIUMS.isHealthcare());
+            assertTrue(ExpenseCategory.HEALTHCARE_OOP.isHealthcare());
+            assertTrue(ExpenseCategory.LTC_PREMIUMS.isHealthcare());
+            assertTrue(ExpenseCategory.LTC_CARE.isHealthcare());
+        }
+
+        @Test
+        @DisplayName("isHealthcare should return false for non-HEALTHCARE groups")
+        void isNotHealthcareForOtherGroups() {
+            assertFalse(ExpenseCategory.HOUSING.isHealthcare());
+            assertFalse(ExpenseCategory.TRAVEL.isHealthcare());
+        }
+
+        @Test
+        @DisplayName("isDiscretionary should return true for DISCRETIONARY group")
+        void isDiscretionaryForDiscretionaryGroup() {
+            assertTrue(ExpenseCategory.TRAVEL.isDiscretionary());
+            assertTrue(ExpenseCategory.ENTERTAINMENT.isDiscretionary());
+            assertTrue(ExpenseCategory.HOBBIES.isDiscretionary());
+            assertTrue(ExpenseCategory.GIFTS.isDiscretionary());
+        }
+
+        @Test
+        @DisplayName("isDiscretionary should return false for non-DISCRETIONARY groups")
+        void isNotDiscretionaryForOtherGroups() {
+            assertFalse(ExpenseCategory.HOUSING.isDiscretionary());
+            assertFalse(ExpenseCategory.MEDICARE_PREMIUMS.isDiscretionary());
+        }
+
+        @Test
+        @DisplayName("isInflationAdjusted should return true for most categories")
+        void isInflationAdjustedForMostCategories() {
+            assertTrue(ExpenseCategory.HOUSING.isInflationAdjusted());
+            assertTrue(ExpenseCategory.FOOD.isInflationAdjusted());
+            assertTrue(ExpenseCategory.MEDICARE_PREMIUMS.isInflationAdjusted());
+            assertTrue(ExpenseCategory.TRAVEL.isInflationAdjusted());
+        }
+
+        @Test
+        @DisplayName("isInflationAdjusted should return false for DEBT_PAYMENTS")
+        void isNotInflationAdjustedForDebtPayments() {
+            assertFalse(ExpenseCategory.DEBT_PAYMENTS.isInflationAdjusted());
+        }
+    }
+
+    @Nested
+    @DisplayName("All Groups Covered Tests")
+    class AllGroupsCoveredTests {
+
+        @Test
+        @DisplayName("Every category group should have at least one category")
+        void everyGroupHasAtLeastOneCategory() {
+            Set<ExpenseCategoryGroup> groupsWithCategories = Arrays.stream(ExpenseCategory.values())
+                    .map(ExpenseCategory::getGroup)
+                    .collect(Collectors.toSet());
+
+            for (ExpenseCategoryGroup group : ExpenseCategoryGroup.values()) {
+                assertTrue(groupsWithCategories.contains(group),
+                        "Group " + group + " should have at least one category");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ExpenseCategoryGroup` enum with 6 high-level groups for organizing expenses
- Add `ExpenseCategory` enum with 19 granular expense categories and built-in inflation type classification
- Add `InflationRates` configuration class with Spring `@ConfigurationProperties` support
- Add `application-expenses.yml` configuration file with research-based default rates

## Details

### ExpenseCategoryGroup
6 groups for high-level expense organization:
- ESSENTIAL (housing, food, utilities, transportation, insurance)
- HEALTHCARE (Medicare, out-of-pocket, LTC)
- DISCRETIONARY (travel, entertainment, hobbies, gifts)
- CONTINGENCY (home repairs, vehicle replacement, emergency reserve)
- DEBT (fixed debt payments)
- OTHER (taxes, miscellaneous)

### ExpenseCategory
19 categories with:
- Display name and description
- Group assignment
- Inflation type (GENERAL, HEALTHCARE, HOUSING, LTC, NONE)
- Helper methods: `isEssential()`, `isHealthcare()`, `isDiscretionary()`, `isInflationAdjusted()`

### InflationRates Configuration
Default rates based on M5 research (#170):
| Type | Default Rate | Source |
|------|--------------|--------|
| General CPI | 2.5% | BLS historical |
| Healthcare | 5.5% | CMS projections |
| Housing | 3.0% | Property tax trends |
| Long-term care | 7.0% | Genworth survey |

Supports category-specific overrides via YAML or programmatically.

## Test plan
- [x] Unit tests for `ExpenseCategoryGroupTest` (6 tests)
- [x] Unit tests for `ExpenseCategoryTest` (26 tests)
- [x] Unit tests for `InflationRatesTest` (24 tests)
- [x] `mvn verify` passes all quality gates

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)