### PR TITLE
feat(#36): Add OneTimeExpense value object for planned expenses

### DIFF
--- a/src/main/java/io/github/xmljim/retirement/domain/value/OneTimeExpense.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/value/OneTimeExpense.java
@@ -1,0 +1,372 @@
+package io.github.xmljim.retirement.domain.value;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+import java.util.Optional;
+
+import io.github.xmljim.retirement.domain.annotation.Generated;
+import io.github.xmljim.retirement.domain.enums.ExpenseCategory;
+import io.github.xmljim.retirement.domain.exception.MissingRequiredFieldException;
+import io.github.xmljim.retirement.domain.exception.ValidationException;
+
+/**
+ * Represents a one-time expense in retirement planning.
+ *
+ * <p>Models planned, known expenses with specific dates such as:
+ * <ul>
+ *   <li>New car purchase in 5 years</li>
+ *   <li>Home renovation next year</li>
+ *   <li>Special vacation</li>
+ *   <li>Wedding expenses</li>
+ *   <li>Major appliance replacement</li>
+ * </ul>
+ *
+ * <p>For future expenses, the amount can optionally be adjusted for inflation
+ * from a base date. The expense only applies in the month of the target date.
+ *
+ * <p>This is an immutable value object. Use the {@link Builder} to create instances.
+ *
+ * @see RecurringExpense
+ */
+public final class OneTimeExpense {
+
+    private static final MathContext MATH_CONTEXT = new MathContext(10, RoundingMode.HALF_UP);
+    private static final int MONTHS_PER_YEAR = 12;
+
+    private final String name;
+    private final ExpenseCategory category;
+    private final BigDecimal baseAmount;
+    private final LocalDate targetDate;
+    private final Optional<LocalDate> baseDate;
+    private final Optional<BigDecimal> inflationRate;
+
+    private OneTimeExpense(Builder builder) {
+        this.name = builder.name;
+        this.category = builder.category;
+        this.baseAmount = builder.baseAmount;
+        this.targetDate = builder.targetDate;
+        this.baseDate = Optional.ofNullable(builder.baseDate);
+        this.inflationRate = Optional.ofNullable(builder.inflationRate);
+    }
+
+    /**
+     * Returns the name or description of this expense.
+     *
+     * @return the expense name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the expense category.
+     *
+     * @return the category
+     */
+    public ExpenseCategory getCategory() {
+        return category;
+    }
+
+    /**
+     * Returns the base amount before any inflation adjustment.
+     *
+     * @return the base amount
+     */
+    public BigDecimal getBaseAmount() {
+        return baseAmount;
+    }
+
+    /**
+     * Returns the target date when this expense occurs.
+     *
+     * @return the target date
+     */
+    public LocalDate getTargetDate() {
+        return targetDate;
+    }
+
+    /**
+     * Returns the base date for inflation calculations, if set.
+     *
+     * @return optional containing base date, or empty if not set
+     */
+    public Optional<LocalDate> getBaseDate() {
+        return baseDate;
+    }
+
+    /**
+     * Returns the custom inflation rate, if set.
+     *
+     * @return optional containing the rate, or empty if not set
+     */
+    public Optional<BigDecimal> getInflationRate() {
+        return inflationRate;
+    }
+
+    /**
+     * Returns the inflation-adjusted amount at the target date.
+     *
+     * <p>If inflation rate and base date are set, calculates the
+     * inflated amount from base date to target date.
+     *
+     * @return the adjusted amount
+     */
+    public BigDecimal getAdjustedAmount() {
+        return getAdjustedAmount(null);
+    }
+
+    /**
+     * Returns the inflation-adjusted amount using a default rate.
+     *
+     * @param defaultRate the default inflation rate to use if not set
+     * @return the adjusted amount
+     */
+    public BigDecimal getAdjustedAmount(BigDecimal defaultRate) {
+        return getEffectiveInflationRate(defaultRate)
+                .filter(rate -> rate.compareTo(BigDecimal.ZERO) != 0)
+                .flatMap(rate -> baseDate.map(base -> calculateInflatedAmount(base, rate)))
+                .orElse(baseAmount);
+    }
+
+    /**
+     * Returns the expense amount for a given month.
+     *
+     * <p>Returns the adjusted amount only if the given date falls in the
+     * same month as the target date. Returns zero for all other months.
+     *
+     * @param asOfDate the date to check
+     * @return the expense amount if in target month, zero otherwise
+     */
+    public BigDecimal getAmountForMonth(LocalDate asOfDate) {
+        return getAmountForMonth(asOfDate, null);
+    }
+
+    /**
+     * Returns the expense amount for a given month using a default rate.
+     *
+     * @param asOfDate the date to check
+     * @param defaultRate the default inflation rate
+     * @return the expense amount if in target month, zero otherwise
+     */
+    public BigDecimal getAmountForMonth(LocalDate asOfDate, BigDecimal defaultRate) {
+        if (isInTargetMonth(asOfDate)) {
+            return getAdjustedAmount(defaultRate);
+        }
+        return BigDecimal.ZERO;
+    }
+
+    /**
+     * Returns whether the given date is in the same month as the target date.
+     *
+     * @param asOfDate the date to check
+     * @return true if in target month
+     */
+    public boolean isInTargetMonth(LocalDate asOfDate) {
+        YearMonth target = YearMonth.from(targetDate);
+        YearMonth check = YearMonth.from(asOfDate);
+        return target.equals(check);
+    }
+
+    /**
+     * Returns whether this expense is in the future relative to the given date.
+     *
+     * @param asOfDate the reference date
+     * @return true if target date is after the given date
+     */
+    public boolean isFuture(LocalDate asOfDate) {
+        return targetDate.isAfter(asOfDate);
+    }
+
+    /**
+     * Returns whether this expense is in the past relative to the given date.
+     *
+     * @param asOfDate the reference date
+     * @return true if target date is before the given date
+     */
+    public boolean isPast(LocalDate asOfDate) {
+        return targetDate.isBefore(asOfDate);
+    }
+
+    private BigDecimal calculateInflatedAmount(LocalDate fromDate, BigDecimal rate) {
+        long monthsElapsed = ChronoUnit.MONTHS.between(fromDate, targetDate);
+        int yearsElapsed = (int) (monthsElapsed / MONTHS_PER_YEAR);
+
+        if (yearsElapsed <= 0) {
+            return baseAmount;
+        }
+
+        BigDecimal multiplier = BigDecimal.ONE.add(rate).pow(yearsElapsed, MATH_CONTEXT);
+        return baseAmount.multiply(multiplier).setScale(2, RoundingMode.HALF_UP);
+    }
+
+    private Optional<BigDecimal> getEffectiveInflationRate(BigDecimal defaultRate) {
+        return inflationRate.or(() -> Optional.ofNullable(defaultRate));
+    }
+
+    /**
+     * Creates a new builder for OneTimeExpense.
+     *
+     * @return a new builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Generated
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OneTimeExpense that = (OneTimeExpense) o;
+        return Objects.equals(name, that.name)
+            && category == that.category
+            && baseAmount.compareTo(that.baseAmount) == 0
+            && Objects.equals(targetDate, that.targetDate)
+            && baseDate.equals(that.baseDate)
+            && inflationRate.equals(that.inflationRate);
+    }
+
+    @Generated
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, category, baseAmount, targetDate, baseDate, inflationRate);
+    }
+
+    @Generated
+    @Override
+    public String toString() {
+        return "OneTimeExpense{name='" + name + "', category=" + category
+            + ", baseAmount=" + baseAmount + ", targetDate=" + targetDate + '}';
+    }
+
+    /**
+     * Builder for creating OneTimeExpense instances.
+     */
+    public static class Builder {
+        private String name;
+        private ExpenseCategory category;
+        private BigDecimal baseAmount = BigDecimal.ZERO;
+        private LocalDate targetDate;
+        private LocalDate baseDate;
+        private BigDecimal inflationRate;
+
+        /**
+         * Sets the expense name.
+         *
+         * @param name the name
+         * @return this builder
+         */
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        /**
+         * Sets the expense category.
+         *
+         * @param category the category
+         * @return this builder
+         */
+        public Builder category(ExpenseCategory category) {
+            this.category = category;
+            return this;
+        }
+
+        /**
+         * Sets the base amount.
+         *
+         * @param amount the amount
+         * @return this builder
+         */
+        public Builder amount(BigDecimal amount) {
+            this.baseAmount = amount;
+            return this;
+        }
+
+        /**
+         * Sets the base amount.
+         *
+         * @param amount the amount
+         * @return this builder
+         */
+        public Builder amount(double amount) {
+            return amount(BigDecimal.valueOf(amount));
+        }
+
+        /**
+         * Sets the target date when the expense occurs.
+         *
+         * @param date the target date
+         * @return this builder
+         */
+        public Builder targetDate(LocalDate date) {
+            this.targetDate = date;
+            return this;
+        }
+
+        /**
+         * Sets the base date for inflation calculations.
+         *
+         * <p>If set along with inflation rate, the amount will be
+         * adjusted from this date to the target date.
+         *
+         * @param date the base date
+         * @return this builder
+         */
+        public Builder baseDate(LocalDate date) {
+            this.baseDate = date;
+            return this;
+        }
+
+        /**
+         * Sets the inflation rate for future expense adjustment.
+         *
+         * @param rate the rate as decimal (e.g., 0.03 for 3%)
+         * @return this builder
+         */
+        public Builder inflationRate(BigDecimal rate) {
+            this.inflationRate = rate;
+            return this;
+        }
+
+        /**
+         * Sets the inflation rate for future expense adjustment.
+         *
+         * @param rate the rate as decimal
+         * @return this builder
+         */
+        public Builder inflationRate(double rate) {
+            return inflationRate(BigDecimal.valueOf(rate));
+        }
+
+        /**
+         * Builds the OneTimeExpense instance.
+         *
+         * @return a new OneTimeExpense
+         * @throws MissingRequiredFieldException if required fields missing
+         * @throws ValidationException if validation fails
+         */
+        public OneTimeExpense build() {
+            validate();
+            return new OneTimeExpense(this);
+        }
+
+        private void validate() {
+            MissingRequiredFieldException.requireNonNull(name, "name");
+            ValidationException.validate("name", name, n -> !n.isBlank(), "Name cannot be blank");
+            MissingRequiredFieldException.requireNonNull(category, "category");
+            MissingRequiredFieldException.requireNonNull(targetDate, "targetDate");
+            ValidationException.validate("baseAmount", baseAmount,
+                v -> v.compareTo(BigDecimal.ZERO) >= 0, "Amount cannot be negative");
+        }
+    }
+}

--- a/src/test/java/io/github/xmljim/retirement/domain/value/OneTimeExpenseTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/value/OneTimeExpenseTest.java
@@ -1,0 +1,294 @@
+package io.github.xmljim.retirement.domain.value;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.github.xmljim.retirement.domain.enums.ExpenseCategory;
+import io.github.xmljim.retirement.domain.exception.MissingRequiredFieldException;
+import io.github.xmljim.retirement.domain.exception.ValidationException;
+
+@DisplayName("OneTimeExpense Tests")
+class OneTimeExpenseTest {
+
+    private static final LocalDate TARGET_DATE = LocalDate.of(2028, 6, 15);
+    private static final LocalDate BASE_DATE = LocalDate.of(2025, 1, 1);
+
+    @Nested
+    @DisplayName("Builder Tests")
+    class BuilderTests {
+
+        @Test
+        @DisplayName("Should build with required fields")
+        void buildWithRequiredFields() {
+            OneTimeExpense expense = OneTimeExpense.builder()
+                .name("New Car")
+                .category(ExpenseCategory.VEHICLE_REPLACEMENT)
+                .amount(40000)
+                .targetDate(TARGET_DATE)
+                .build();
+
+            assertEquals("New Car", expense.getName());
+            assertEquals(ExpenseCategory.VEHICLE_REPLACEMENT, expense.getCategory());
+            assertEquals(0, new BigDecimal("40000").compareTo(expense.getBaseAmount()));
+            assertEquals(TARGET_DATE, expense.getTargetDate());
+        }
+
+        @Test
+        @DisplayName("Should throw on missing name")
+        void throwOnMissingName() {
+            assertThrows(MissingRequiredFieldException.class, () ->
+                OneTimeExpense.builder()
+                    .category(ExpenseCategory.TRAVEL)
+                    .amount(10000)
+                    .targetDate(TARGET_DATE)
+                    .build());
+        }
+
+        @Test
+        @DisplayName("Should throw on blank name")
+        void throwOnBlankName() {
+            assertThrows(ValidationException.class, () ->
+                OneTimeExpense.builder()
+                    .name("   ")
+                    .category(ExpenseCategory.TRAVEL)
+                    .amount(10000)
+                    .targetDate(TARGET_DATE)
+                    .build());
+        }
+
+        @Test
+        @DisplayName("Should throw on missing category")
+        void throwOnMissingCategory() {
+            assertThrows(MissingRequiredFieldException.class, () ->
+                OneTimeExpense.builder()
+                    .name("Vacation")
+                    .amount(10000)
+                    .targetDate(TARGET_DATE)
+                    .build());
+        }
+
+        @Test
+        @DisplayName("Should throw on missing target date")
+        void throwOnMissingTargetDate() {
+            assertThrows(MissingRequiredFieldException.class, () ->
+                OneTimeExpense.builder()
+                    .name("Vacation")
+                    .category(ExpenseCategory.TRAVEL)
+                    .amount(10000)
+                    .build());
+        }
+
+        @Test
+        @DisplayName("Should throw on negative amount")
+        void throwOnNegativeAmount() {
+            assertThrows(ValidationException.class, () ->
+                OneTimeExpense.builder()
+                    .name("Vacation")
+                    .category(ExpenseCategory.TRAVEL)
+                    .amount(-1000)
+                    .targetDate(TARGET_DATE)
+                    .build());
+        }
+    }
+
+    @Nested
+    @DisplayName("Amount Calculation Tests")
+    class AmountCalculationTests {
+
+        @Test
+        @DisplayName("Should return base amount when no inflation set")
+        void baseAmountWithNoInflation() {
+            OneTimeExpense expense = OneTimeExpense.builder()
+                .name("New Car")
+                .category(ExpenseCategory.VEHICLE_REPLACEMENT)
+                .amount(40000)
+                .targetDate(TARGET_DATE)
+                .build();
+
+            assertEquals(0, new BigDecimal("40000").compareTo(expense.getAdjustedAmount()));
+        }
+
+        @Test
+        @DisplayName("Should inflate amount when rate and base date set")
+        void inflatedAmount() {
+            OneTimeExpense expense = OneTimeExpense.builder()
+                .name("New Car")
+                .category(ExpenseCategory.VEHICLE_REPLACEMENT)
+                .amount(40000)
+                .targetDate(TARGET_DATE)
+                .baseDate(BASE_DATE)
+                .inflationRate(0.03)
+                .build();
+
+            // 3 years from 2025 to 2028, 3% inflation: 40000 * 1.03^3 = 43709.08
+            BigDecimal adjusted = expense.getAdjustedAmount();
+            assertEquals(0, new BigDecimal("43709.08").compareTo(adjusted));
+        }
+
+        @Test
+        @DisplayName("Should use default rate when provided")
+        void useDefaultRate() {
+            OneTimeExpense expense = OneTimeExpense.builder()
+                .name("New Car")
+                .category(ExpenseCategory.VEHICLE_REPLACEMENT)
+                .amount(40000)
+                .targetDate(TARGET_DATE)
+                .baseDate(BASE_DATE)
+                .build();
+
+            // 3 years, 2.5% default rate: 40000 * 1.025^3 = 43075.63
+            BigDecimal adjusted = expense.getAdjustedAmount(new BigDecimal("0.025"));
+            assertEquals(0, new BigDecimal("43075.63").compareTo(adjusted));
+        }
+
+        @Test
+        @DisplayName("Should prefer custom rate over default")
+        void preferCustomRate() {
+            OneTimeExpense expense = OneTimeExpense.builder()
+                .name("New Car")
+                .category(ExpenseCategory.VEHICLE_REPLACEMENT)
+                .amount(40000)
+                .targetDate(TARGET_DATE)
+                .baseDate(BASE_DATE)
+                .inflationRate(0.03)
+                .build();
+
+            // Should use 3% not 2.5%
+            BigDecimal adjusted = expense.getAdjustedAmount(new BigDecimal("0.025"));
+            assertEquals(0, new BigDecimal("43709.08").compareTo(adjusted));
+        }
+    }
+
+    @Nested
+    @DisplayName("Target Month Tests")
+    class TargetMonthTests {
+
+        @Test
+        @DisplayName("Should return amount in target month")
+        void amountInTargetMonth() {
+            OneTimeExpense expense = OneTimeExpense.builder()
+                .name("Vacation")
+                .category(ExpenseCategory.TRAVEL)
+                .amount(10000)
+                .targetDate(TARGET_DATE)
+                .build();
+
+            // Same month as target (June 2028)
+            LocalDate sameMonth = LocalDate.of(2028, 6, 1);
+            assertEquals(0, new BigDecimal("10000").compareTo(expense.getAmountForMonth(sameMonth)));
+        }
+
+        @Test
+        @DisplayName("Should return zero outside target month")
+        void zeroOutsideTargetMonth() {
+            OneTimeExpense expense = OneTimeExpense.builder()
+                .name("Vacation")
+                .category(ExpenseCategory.TRAVEL)
+                .amount(10000)
+                .targetDate(TARGET_DATE)
+                .build();
+
+            // Month before target
+            LocalDate beforeMonth = LocalDate.of(2028, 5, 15);
+            assertEquals(BigDecimal.ZERO, expense.getAmountForMonth(beforeMonth));
+
+            // Month after target
+            LocalDate afterMonth = LocalDate.of(2028, 7, 1);
+            assertEquals(BigDecimal.ZERO, expense.getAmountForMonth(afterMonth));
+        }
+
+        @Test
+        @DisplayName("isInTargetMonth should be true for same month")
+        void isInTargetMonthTrue() {
+            OneTimeExpense expense = OneTimeExpense.builder()
+                .name("Vacation")
+                .category(ExpenseCategory.TRAVEL)
+                .amount(10000)
+                .targetDate(TARGET_DATE)
+                .build();
+
+            assertTrue(expense.isInTargetMonth(LocalDate.of(2028, 6, 1)));
+            assertTrue(expense.isInTargetMonth(LocalDate.of(2028, 6, 30)));
+        }
+
+        @Test
+        @DisplayName("isInTargetMonth should be false for different month")
+        void isInTargetMonthFalse() {
+            OneTimeExpense expense = OneTimeExpense.builder()
+                .name("Vacation")
+                .category(ExpenseCategory.TRAVEL)
+                .amount(10000)
+                .targetDate(TARGET_DATE)
+                .build();
+
+            assertFalse(expense.isInTargetMonth(LocalDate.of(2028, 5, 15)));
+            assertFalse(expense.isInTargetMonth(LocalDate.of(2029, 6, 15)));
+        }
+    }
+
+    @Nested
+    @DisplayName("Future/Past Tests")
+    class FuturePastTests {
+
+        @Test
+        @DisplayName("isFuture should be true when target is after reference")
+        void isFutureTrue() {
+            OneTimeExpense expense = OneTimeExpense.builder()
+                .name("New Car")
+                .category(ExpenseCategory.VEHICLE_REPLACEMENT)
+                .amount(40000)
+                .targetDate(TARGET_DATE)
+                .build();
+
+            assertTrue(expense.isFuture(LocalDate.of(2025, 1, 1)));
+        }
+
+        @Test
+        @DisplayName("isFuture should be false when target is before reference")
+        void isFutureFalse() {
+            OneTimeExpense expense = OneTimeExpense.builder()
+                .name("New Car")
+                .category(ExpenseCategory.VEHICLE_REPLACEMENT)
+                .amount(40000)
+                .targetDate(TARGET_DATE)
+                .build();
+
+            assertFalse(expense.isFuture(LocalDate.of(2030, 1, 1)));
+        }
+
+        @Test
+        @DisplayName("isPast should be true when target is before reference")
+        void isPastTrue() {
+            OneTimeExpense expense = OneTimeExpense.builder()
+                .name("New Car")
+                .category(ExpenseCategory.VEHICLE_REPLACEMENT)
+                .amount(40000)
+                .targetDate(TARGET_DATE)
+                .build();
+
+            assertTrue(expense.isPast(LocalDate.of(2030, 1, 1)));
+        }
+
+        @Test
+        @DisplayName("isPast should be false when target is after reference")
+        void isPastFalse() {
+            OneTimeExpense expense = OneTimeExpense.builder()
+                .name("New Car")
+                .category(ExpenseCategory.VEHICLE_REPLACEMENT)
+                .amount(40000)
+                .targetDate(TARGET_DATE)
+                .build();
+
+            assertFalse(expense.isPast(LocalDate.of(2025, 1, 1)));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `OneTimeExpense` immutable value object with builder pattern for modeling planned, one-time expenses
- Supports optional inflation adjustment from base date to target date using compound growth formula
- Uses `Optional<T>` for nullable fields (`baseDate`, `inflationRate`) per Java 25 patterns
- Includes comprehensive unit tests covering builder validation, amount calculations, and target month logic

## Changes
| File | Description |
|------|-------------|
| `OneTimeExpense.java` | New value object for one-time expenses |
| `OneTimeExpenseTest.java` | Unit tests with builder, inflation, and timing tests |

## Test Plan
- [x] Builder tests: required fields, validation, blank name, negative amount
- [x] Amount calculation: base amount, inflated amount, default rate, custom rate preference
- [x] Target month: amount in/outside target month, isInTargetMonth checks
- [x] Future/past tests: isFuture/isPast relative to reference date

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)