### PR TITLE
feat(#171): Implement Medicare calculator with IRMAA brackets

### DIFF
--- a/src/main/java/io/github/xmljim/retirement/domain/calculator/CalculatorFactory.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/calculator/CalculatorFactory.java
@@ -8,6 +8,7 @@ import io.github.xmljim.retirement.domain.calculator.impl.DefaultEarningsTestCal
 import io.github.xmljim.retirement.domain.calculator.impl.DefaultIncomeCalculator;
 import io.github.xmljim.retirement.domain.calculator.impl.DefaultInflationCalculator;
 import io.github.xmljim.retirement.domain.calculator.impl.DefaultMAGICalculator;
+import io.github.xmljim.retirement.domain.calculator.impl.DefaultMedicareCalculator;
 import io.github.xmljim.retirement.domain.calculator.impl.DefaultPhaseOutCalculator;
 import io.github.xmljim.retirement.domain.calculator.impl.DefaultReturnCalculator;
 import io.github.xmljim.retirement.domain.calculator.impl.DefaultSocialSecurityCalculator;
@@ -16,6 +17,7 @@ import io.github.xmljim.retirement.domain.calculator.impl.DefaultWithdrawalCalcu
 import io.github.xmljim.retirement.domain.calculator.impl.DefaultYTDContributionTracker;
 import io.github.xmljim.retirement.domain.config.IraPhaseOutLimits;
 import io.github.xmljim.retirement.domain.config.IrsContributionLimits;
+import io.github.xmljim.retirement.domain.config.MedicareRules;
 
 /**
  * Factory for obtaining calculator instances.
@@ -291,5 +293,48 @@ public final class CalculatorFactory {
      */
     public static BenefitTaxationCalculator benefitTaxationCalculator() {
         return new DefaultBenefitTaxationCalculator();
+    }
+
+    /**
+     * Returns a new Medicare premium calculator.
+     *
+     * <p>The Medicare calculator determines Part B premiums and IRMAA
+     * surcharges based on MAGI and filing status.
+     *
+     * <p>Usage:
+     * <pre>{@code
+     * MedicareCalculator calculator = CalculatorFactory.medicareCalculator();
+     *
+     * MedicarePremiums premiums = calculator.calculatePremiums(
+     *     new BigDecimal("150000"),  // MAGI (from 2 years prior)
+     *     FilingStatus.SINGLE,       // filing status
+     *     2025                       // Medicare year
+     * );
+     * }</pre>
+     *
+     * @return a new MedicareCalculator instance
+     */
+    public static MedicareCalculator medicareCalculator() {
+        return new DefaultMedicareCalculator();
+    }
+
+    /**
+     * Returns a new Medicare premium calculator with custom rules.
+     *
+     * <p>Use this when you have Spring-managed MedicareRules configuration.
+     *
+     * <p>Usage:
+     * <pre>{@code
+     * @Autowired
+     * private MedicareRules medicareRules;
+     *
+     * MedicareCalculator calculator = CalculatorFactory.medicareCalculator(medicareRules);
+     * }</pre>
+     *
+     * @param rules the Medicare rules configuration
+     * @return a new MedicareCalculator instance with the provided rules
+     */
+    public static MedicareCalculator medicareCalculator(MedicareRules rules) {
+        return new DefaultMedicareCalculator(rules);
     }
 }

--- a/src/main/java/io/github/xmljim/retirement/domain/calculator/MedicareCalculator.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/calculator/MedicareCalculator.java
@@ -1,0 +1,137 @@
+package io.github.xmljim.retirement.domain.calculator;
+
+import java.math.BigDecimal;
+
+import io.github.xmljim.retirement.domain.enums.FilingStatus;
+import io.github.xmljim.retirement.domain.value.MedicarePremiums;
+import io.github.xmljim.retirement.domain.value.MedicarePremiums.IrmaaBracket;
+
+/**
+ * Calculator for Medicare premiums with IRMAA adjustments.
+ *
+ * <p>Calculates Medicare Part A, Part B, and Part D premiums based on
+ * income (MAGI) and filing status. Higher-income beneficiaries pay
+ * additional premiums through IRMAA (Income-Related Monthly Adjustment Amount).
+ *
+ * <p>Key features:
+ * <ul>
+ *   <li>Part B premium calculation with IRMAA brackets</li>
+ *   <li>Part D IRMAA surcharge calculation</li>
+ *   <li>Support for different filing statuses</li>
+ *   <li>Year-specific premium tables</li>
+ * </ul>
+ *
+ * <p><b>Important:</b> IRMAA is based on MAGI from 2 years prior.
+ * For example, 2025 premiums are based on 2023 MAGI.
+ *
+ * @see MedicarePremiums
+ * @see <a href="https://www.medicare.gov/basics/costs/medicare-costs">Medicare Costs</a>
+ */
+public interface MedicareCalculator {
+
+    /**
+     * Calculates all Medicare premiums based on income.
+     *
+     * <p>Determines the appropriate IRMAA bracket based on MAGI and
+     * filing status, then calculates Part A, Part B, and Part D costs.
+     *
+     * @param magi Modified Adjusted Gross Income (from 2 years prior)
+     * @param filingStatus the tax filing status
+     * @param year the Medicare year (e.g., 2025)
+     * @param premiumFreePartA true if the beneficiary has premium-free Part A
+     * @return the calculated Medicare premiums
+     */
+    MedicarePremiums calculatePremiums(
+        BigDecimal magi,
+        FilingStatus filingStatus,
+        int year,
+        boolean premiumFreePartA
+    );
+
+    /**
+     * Calculates Medicare premiums assuming premium-free Part A.
+     *
+     * <p>Most beneficiaries have premium-free Part A if they (or their spouse)
+     * paid Medicare taxes for at least 40 quarters (10 years).
+     *
+     * @param magi Modified Adjusted Gross Income (from 2 years prior)
+     * @param filingStatus the tax filing status
+     * @param year the Medicare year
+     * @return the calculated Medicare premiums with Part A premium of $0
+     */
+    default MedicarePremiums calculatePremiums(
+            BigDecimal magi,
+            FilingStatus filingStatus,
+            int year) {
+        return calculatePremiums(magi, filingStatus, year, true);
+    }
+
+    /**
+     * Returns the Part B base premium for a given year.
+     *
+     * @param year the Medicare year
+     * @return the Part B base monthly premium (before IRMAA)
+     */
+    BigDecimal getPartBBasePremium(int year);
+
+    /**
+     * Returns the total Part B premium including IRMAA.
+     *
+     * @param magi Modified Adjusted Gross Income (from 2 years prior)
+     * @param filingStatus the tax filing status
+     * @param year the Medicare year
+     * @return the total Part B monthly premium
+     */
+    BigDecimal getPartBPremium(
+        BigDecimal magi,
+        FilingStatus filingStatus,
+        int year
+    );
+
+    /**
+     * Returns the Part D IRMAA surcharge.
+     *
+     * <p>Note: This is the IRMAA surcharge only, not the full Part D
+     * plan premium which varies by plan.
+     *
+     * @param magi Modified Adjusted Gross Income (from 2 years prior)
+     * @param filingStatus the tax filing status
+     * @param year the Medicare year
+     * @return the Part D IRMAA monthly surcharge
+     */
+    BigDecimal getPartDIrmaa(
+        BigDecimal magi,
+        FilingStatus filingStatus,
+        int year
+    );
+
+    /**
+     * Determines the IRMAA bracket for a given MAGI and filing status.
+     *
+     * @param magi Modified Adjusted Gross Income (from 2 years prior)
+     * @param filingStatus the tax filing status
+     * @param year the Medicare year
+     * @return the IRMAA bracket (0-5)
+     */
+    IrmaaBracket getIrmaaBracket(
+        BigDecimal magi,
+        FilingStatus filingStatus,
+        int year
+    );
+
+    /**
+     * Returns the Part A premium for non-premium-free beneficiaries.
+     *
+     * <p>Part A premium depends on work history:
+     * <ul>
+     *   <li>40+ quarters: $0 (premium-free)</li>
+     *   <li>30-39 quarters: reduced premium (~$285/month in 2025)</li>
+     *   <li>Under 30 quarters: full premium (~$518/month in 2025)</li>
+     * </ul>
+     *
+     * @param year the Medicare year
+     * @param workQuarters the number of Medicare-covered work quarters
+     * @return the monthly Part A premium
+     */
+    BigDecimal getPartAPremium(int year, int workQuarters);
+}

--- a/src/main/java/io/github/xmljim/retirement/domain/calculator/impl/DefaultMedicareCalculator.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/calculator/impl/DefaultMedicareCalculator.java
@@ -1,0 +1,243 @@
+package io.github.xmljim.retirement.domain.calculator.impl;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.github.xmljim.retirement.domain.calculator.MedicareCalculator;
+import io.github.xmljim.retirement.domain.config.MedicareRules;
+import io.github.xmljim.retirement.domain.config.MedicareRules.IrmaaBracketConfig;
+import io.github.xmljim.retirement.domain.enums.FilingStatus;
+import io.github.xmljim.retirement.domain.value.MedicarePremiums;
+import io.github.xmljim.retirement.domain.value.MedicarePremiums.IrmaaBracket;
+
+/**
+ * Default implementation of Medicare premium calculator.
+ *
+ * <p>Calculates Medicare premiums including IRMAA surcharges based on
+ * MAGI and filing status. Uses configuration from YAML files for
+ * year-specific premium tables and IRMAA brackets.
+ *
+ * <p>Key features:
+ * <ul>
+ *   <li>Supports multiple years of premium data</li>
+ *   <li>Handles all filing statuses with appropriate thresholds</li>
+ *   <li>Calculates Part A, Part B, and Part D components</li>
+ * </ul>
+ *
+ * <p><b>Important:</b> IRMAA is based on MAGI from 2 years prior.
+ * The caller is responsible for providing the correct MAGI year.
+ *
+ * @see MedicareCalculator
+ * @see MedicareRules
+ */
+@Service
+public class DefaultMedicareCalculator implements MedicareCalculator {
+
+    private static final int PREMIUM_FREE_QUARTERS = 40;
+    private static final int REDUCED_PREMIUM_QUARTERS = 30;
+    private static final BigDecimal DEFAULT_PART_B_BASE = new BigDecimal("185.00");
+    private static final BigDecimal DEFAULT_PART_A_FULL = new BigDecimal("518");
+    private static final BigDecimal DEFAULT_PART_A_REDUCED = new BigDecimal("285");
+
+    private final MedicareRules rules;
+
+    /**
+     * Creates a calculator with Spring-managed rules.
+     *
+     * @param rules the Medicare rules configuration
+     */
+    @Autowired
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring-managed beans")
+    public DefaultMedicareCalculator(MedicareRules rules) {
+        this.rules = rules;
+    }
+
+    /**
+     * Creates a calculator with default rules.
+     */
+    public DefaultMedicareCalculator() {
+        this.rules = new MedicareRules();
+    }
+
+    @Override
+    public MedicarePremiums calculatePremiums(
+            BigDecimal magi,
+            FilingStatus filingStatus,
+            int year,
+            boolean premiumFreePartA) {
+
+        BigDecimal partAPremium = premiumFreePartA
+            ? BigDecimal.ZERO
+            : getPartAPremium(year, 0);  // Assume under 30 quarters if not premium-free
+
+        BigDecimal partBBase = getPartBBasePremium(year);
+        IrmaaBracket bracket = getIrmaaBracket(magi, filingStatus, year);
+
+        if (bracket == IrmaaBracket.BRACKET_0) {
+            return MedicarePremiums.standard(partAPremium, partBBase, year);
+        }
+
+        // Find matching IRMAA bracket from configuration
+        Optional<IrmaaBracketConfig> bracketConfig = findBracketConfig(magi, filingStatus, year);
+
+        BigDecimal partBIrmaa = bracketConfig
+            .map(config -> config.getPartBIrmaa(partBBase))
+            .orElse(BigDecimal.ZERO);
+
+        BigDecimal partDIrmaa = bracketConfig
+            .map(IrmaaBracketConfig::getPartDIrmaa)
+            .orElse(BigDecimal.ZERO);
+
+        return MedicarePremiums.withIrmaa(
+            partAPremium,
+            partBBase,
+            partBIrmaa,
+            partDIrmaa,
+            bracket,
+            year
+        );
+    }
+
+    @Override
+    public BigDecimal getPartBBasePremium(int year) {
+        return rules.getPartBBase(year);
+    }
+
+    @Override
+    public BigDecimal getPartBPremium(
+            BigDecimal magi,
+            FilingStatus filingStatus,
+            int year) {
+
+        BigDecimal basePremium = getPartBBasePremium(year);
+
+        Optional<IrmaaBracketConfig> bracketConfig = findBracketConfig(magi, filingStatus, year);
+        return bracketConfig
+            .map(IrmaaBracketConfig::getPartBPremium)
+            .orElse(basePremium);
+    }
+
+    @Override
+    public BigDecimal getPartDIrmaa(
+            BigDecimal magi,
+            FilingStatus filingStatus,
+            int year) {
+
+        return findBracketConfig(magi, filingStatus, year)
+            .map(IrmaaBracketConfig::getPartDIrmaa)
+            .orElse(BigDecimal.ZERO);
+    }
+
+    @Override
+    public IrmaaBracket getIrmaaBracket(
+            BigDecimal magi,
+            FilingStatus filingStatus,
+            int year) {
+
+        List<IrmaaBracketConfig> brackets = rules.getIrmaaBrackets(year);
+        if (brackets.isEmpty()) {
+            return IrmaaBracket.BRACKET_0;
+        }
+
+        int bracketIndex = 0;
+        for (int i = 0; i < brackets.size(); i++) {
+            if (isInBracket(magi, filingStatus, brackets.get(i))) {
+                bracketIndex = i;
+                break;
+            }
+            // If not in this bracket and there are more brackets, continue
+            // If we reach the end, use the last bracket (highest tier)
+            if (i == brackets.size() - 1) {
+                bracketIndex = i;
+            }
+        }
+
+        return IrmaaBracket.fromLevel(Math.min(bracketIndex, 5));
+    }
+
+    @Override
+    public BigDecimal getPartAPremium(int year, int workQuarters) {
+        if (workQuarters >= PREMIUM_FREE_QUARTERS) {
+            return BigDecimal.ZERO;
+        }
+
+        return rules.getYearConfig(year)
+            .map(config -> {
+                if (workQuarters >= REDUCED_PREMIUM_QUARTERS) {
+                    return config.getPartAPremiumReduced();
+                }
+                return config.getPartAPremiumFull();
+            })
+            .orElse(workQuarters >= REDUCED_PREMIUM_QUARTERS
+                ? DEFAULT_PART_A_REDUCED
+                : DEFAULT_PART_A_FULL);
+    }
+
+    /**
+     * Finds the IRMAA bracket configuration for the given MAGI and filing status.
+     *
+     * @param magi the Modified Adjusted Gross Income
+     * @param filingStatus the filing status
+     * @param year the Medicare year
+     * @return optional containing the matching bracket config
+     */
+    private Optional<IrmaaBracketConfig> findBracketConfig(
+            BigDecimal magi,
+            FilingStatus filingStatus,
+            int year) {
+
+        List<IrmaaBracketConfig> brackets = rules.getIrmaaBrackets(year);
+
+        for (IrmaaBracketConfig bracket : brackets) {
+            if (isInBracket(magi, filingStatus, bracket)) {
+                return Optional.of(bracket);
+            }
+        }
+
+        // If MAGI exceeds all brackets, return the highest bracket
+        if (!brackets.isEmpty()) {
+            return Optional.of(brackets.get(brackets.size() - 1));
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Checks if the MAGI falls within the given bracket for the filing status.
+     *
+     * @param magi the Modified Adjusted Gross Income
+     * @param filingStatus the filing status
+     * @param bracket the bracket configuration
+     * @return true if MAGI is within the bracket thresholds
+     */
+    private boolean isInBracket(
+            BigDecimal magi,
+            FilingStatus filingStatus,
+            IrmaaBracketConfig bracket) {
+
+        BigDecimal min;
+        BigDecimal max;
+
+        // Use joint thresholds for MFJ and QSS, single for others
+        if (filingStatus.usesJointThresholds()) {
+            min = bracket.getJointMin();
+            max = bracket.getJointMax();
+        } else {
+            min = bracket.getSingleMin();
+            max = bracket.getSingleMax();
+        }
+
+        // Check if MAGI is at or above minimum
+        boolean aboveMin = magi.compareTo(min) >= 0;
+
+        // Check if MAGI is at or below maximum (if max is set)
+        boolean belowMax = max == null || magi.compareTo(max) <= 0;
+
+        return aboveMin && belowMax;
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/domain/config/MedicareRules.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/config/MedicareRules.java
@@ -1,0 +1,253 @@
+package io.github.xmljim.retirement.domain.config;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * Medicare rules loaded from external YAML configuration.
+ *
+ * <p>This class provides configurable Medicare rules including:
+ * <ul>
+ *   <li>Part B base premium by year</li>
+ *   <li>IRMAA brackets for Part B and Part D adjustments</li>
+ *   <li>Part A and Part B deductibles</li>
+ *   <li>Part A premium for those not premium-free</li>
+ * </ul>
+ *
+ * <p>These values are sourced from CMS (Centers for Medicare and Medicaid Services):
+ * <ul>
+ *   <li>Part B premiums: <a href="https://www.medicare.gov/basics/costs/medicare-costs">Medicare Costs</a></li>
+ *   <li>IRMAA brackets: <a href="https://www.cms.gov/newsroom">CMS Newsroom</a></li>
+ * </ul>
+ *
+ * <p>Configuration is loaded from {@code application.yml} under the
+ * {@code medicare} prefix.
+ *
+ * <p>Example configuration:
+ * <pre>
+ * medicare:
+ *   years:
+ *     - year: 2025
+ *       part-b-base: 185.00
+ *       part-a-deductible: 1676
+ *       part-b-deductible: 257
+ *       part-a-premium-full: 518
+ *       part-a-premium-reduced: 285
+ *       irmaa-brackets:
+ *         - single-max: 106000
+ *           joint-max: 212000
+ *           part-b-premium: 185.00
+ *           part-d-irmaa: 0
+ * </pre>
+ */
+@ConfigurationProperties(prefix = "medicare")
+@Validated
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP",
+    justification = "Spring @ConfigurationProperties requires mutable access for binding"
+)
+public class MedicareRules {
+
+    private List<YearConfig> years = new ArrayList<>();
+
+    /**
+     * Configuration for a specific Medicare year.
+     */
+    public static class YearConfig {
+        private int year;
+        private BigDecimal partBBase = new BigDecimal("185.00");
+        private BigDecimal partADeductible = new BigDecimal("1676");
+        private BigDecimal partBDeductible = new BigDecimal("257");
+        private BigDecimal partAPremiumFull = new BigDecimal("518");
+        private BigDecimal partAPremiumReduced = new BigDecimal("285");
+        private List<IrmaaBracketConfig> irmaaBrackets = new ArrayList<>();
+
+        public int getYear() {
+            return year;
+        }
+
+        public void setYear(int year) {
+            this.year = year;
+        }
+
+        public BigDecimal getPartBBase() {
+            return partBBase;
+        }
+
+        public void setPartBBase(BigDecimal partBBase) {
+            this.partBBase = partBBase;
+        }
+
+        public BigDecimal getPartADeductible() {
+            return partADeductible;
+        }
+
+        public void setPartADeductible(BigDecimal partADeductible) {
+            this.partADeductible = partADeductible;
+        }
+
+        public BigDecimal getPartBDeductible() {
+            return partBDeductible;
+        }
+
+        public void setPartBDeductible(BigDecimal partBDeductible) {
+            this.partBDeductible = partBDeductible;
+        }
+
+        public BigDecimal getPartAPremiumFull() {
+            return partAPremiumFull;
+        }
+
+        public void setPartAPremiumFull(BigDecimal partAPremiumFull) {
+            this.partAPremiumFull = partAPremiumFull;
+        }
+
+        public BigDecimal getPartAPremiumReduced() {
+            return partAPremiumReduced;
+        }
+
+        public void setPartAPremiumReduced(BigDecimal partAPremiumReduced) {
+            this.partAPremiumReduced = partAPremiumReduced;
+        }
+
+        public List<IrmaaBracketConfig> getIrmaaBrackets() {
+            return irmaaBrackets;
+        }
+
+        public void setIrmaaBrackets(List<IrmaaBracketConfig> irmaaBrackets) {
+            this.irmaaBrackets = irmaaBrackets;
+        }
+    }
+
+    /**
+     * IRMAA bracket configuration.
+     *
+     * <p>IRMAA (Income-Related Monthly Adjustment Amount) increases
+     * Medicare premiums for higher-income beneficiaries based on MAGI
+     * from 2 years prior.
+     *
+     * <p>Each bracket defines:
+     * <ul>
+     *   <li>Income thresholds for single and joint filers</li>
+     *   <li>Part B monthly premium (base + IRMAA)</li>
+     *   <li>Part D IRMAA surcharge</li>
+     * </ul>
+     */
+    public static class IrmaaBracketConfig {
+        private BigDecimal singleMin = BigDecimal.ZERO;
+        private BigDecimal singleMax;
+        private BigDecimal jointMin = BigDecimal.ZERO;
+        private BigDecimal jointMax;
+        private BigDecimal partBPremium;
+        private BigDecimal partDIrmaa = BigDecimal.ZERO;
+
+        public BigDecimal getSingleMin() {
+            return singleMin;
+        }
+
+        public void setSingleMin(BigDecimal singleMin) {
+            this.singleMin = singleMin;
+        }
+
+        public BigDecimal getSingleMax() {
+            return singleMax;
+        }
+
+        public void setSingleMax(BigDecimal singleMax) {
+            this.singleMax = singleMax;
+        }
+
+        public BigDecimal getJointMin() {
+            return jointMin;
+        }
+
+        public void setJointMin(BigDecimal jointMin) {
+            this.jointMin = jointMin;
+        }
+
+        public BigDecimal getJointMax() {
+            return jointMax;
+        }
+
+        public void setJointMax(BigDecimal jointMax) {
+            this.jointMax = jointMax;
+        }
+
+        public BigDecimal getPartBPremium() {
+            return partBPremium;
+        }
+
+        public void setPartBPremium(BigDecimal partBPremium) {
+            this.partBPremium = partBPremium;
+        }
+
+        public BigDecimal getPartDIrmaa() {
+            return partDIrmaa;
+        }
+
+        public void setPartDIrmaa(BigDecimal partDIrmaa) {
+            this.partDIrmaa = partDIrmaa;
+        }
+
+        /**
+         * Returns the Part B IRMAA amount (premium minus base).
+         *
+         * @param partBBase the base Part B premium
+         * @return the IRMAA surcharge amount
+         */
+        public BigDecimal getPartBIrmaa(BigDecimal partBBase) {
+            return partBPremium.subtract(partBBase);
+        }
+    }
+
+    public List<YearConfig> getYears() {
+        return years;
+    }
+
+    public void setYears(List<YearConfig> years) {
+        this.years = years;
+    }
+
+    /**
+     * Gets the configuration for a specific year.
+     *
+     * @param year the year to look up
+     * @return optional containing the year config, or empty if not found
+     */
+    public Optional<YearConfig> getYearConfig(int year) {
+        return years.stream()
+            .filter(y -> y.getYear() == year)
+            .findFirst();
+    }
+
+    /**
+     * Gets the Part B base premium for a year.
+     *
+     * @param year the year
+     * @return the base premium, or default of $185 if year not found
+     */
+    public BigDecimal getPartBBase(int year) {
+        return getYearConfig(year)
+            .map(YearConfig::getPartBBase)
+            .orElse(new BigDecimal("185.00"));
+    }
+
+    /**
+     * Gets the IRMAA brackets for a specific year.
+     *
+     * @param year the year
+     * @return the brackets, or empty list if year not found
+     */
+    public List<IrmaaBracketConfig> getIrmaaBrackets(int year) {
+        return getYearConfig(year)
+            .map(YearConfig::getIrmaaBrackets)
+            .orElse(new ArrayList<>());
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/domain/value/MedicarePremiums.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/value/MedicarePremiums.java
@@ -1,0 +1,226 @@
+package io.github.xmljim.retirement.domain.value;
+
+import java.math.BigDecimal;
+
+/**
+ * Result of Medicare premium calculation.
+ *
+ * <p>Contains all Medicare premium components including:
+ * <ul>
+ *   <li>Part A premium (typically $0 for premium-free Medicare)</li>
+ *   <li>Part B base premium</li>
+ *   <li>Part B IRMAA surcharge (if applicable)</li>
+ *   <li>Part D IRMAA surcharge (if applicable)</li>
+ * </ul>
+ *
+ * <p>IRMAA (Income-Related Monthly Adjustment Amount) is an additional
+ * premium charged to higher-income beneficiaries. It is based on MAGI
+ * from 2 years prior (e.g., 2025 premiums use 2023 MAGI).
+ *
+ * @param partAPremium Part A monthly premium ($0 if premium-free, else $285 or $518)
+ * @param partBBasePremium Part B base monthly premium (e.g., $185 in 2025)
+ * @param partBIrmaa Part B IRMAA surcharge ($0-$444/month based on MAGI)
+ * @param partDIrmaa Part D IRMAA surcharge ($0-$86/month based on MAGI)
+ * @param bracket the IRMAA bracket tier
+ * @param year the Medicare year
+ *
+ * @see <a href="https://www.medicare.gov/basics/costs/medicare-costs">Medicare Costs</a>
+ */
+public record MedicarePremiums(
+    BigDecimal partAPremium,
+    BigDecimal partBBasePremium,
+    BigDecimal partBIrmaa,
+    BigDecimal partDIrmaa,
+    IrmaaBracket bracket,
+    int year
+) {
+
+    /**
+     * IRMAA bracket tiers based on MAGI thresholds.
+     *
+     * <p>Higher brackets pay higher premiums. Bracket 0 is standard
+     * (no IRMAA), while Bracket 5 is the highest IRMAA tier.
+     */
+    public enum IrmaaBracket {
+        /**
+         * Standard premium - no IRMAA (lowest income tier).
+         */
+        BRACKET_0(0, "Standard"),
+
+        /**
+         * First IRMAA tier - moderate income.
+         */
+        BRACKET_1(1, "First Tier"),
+
+        /**
+         * Second IRMAA tier.
+         */
+        BRACKET_2(2, "Second Tier"),
+
+        /**
+         * Third IRMAA tier.
+         */
+        BRACKET_3(3, "Third Tier"),
+
+        /**
+         * Fourth IRMAA tier.
+         */
+        BRACKET_4(4, "Fourth Tier"),
+
+        /**
+         * Fifth IRMAA tier - highest income (maximum premium).
+         */
+        BRACKET_5(5, "Highest Tier");
+
+        private final int level;
+        private final String description;
+
+        IrmaaBracket(int level, String description) {
+            this.level = level;
+            this.description = description;
+        }
+
+        /**
+         * Returns the numeric bracket level (0-5).
+         *
+         * @return the bracket level
+         */
+        public int getLevel() {
+            return level;
+        }
+
+        /**
+         * Returns a human-readable description.
+         *
+         * @return the description
+         */
+        public String getDescription() {
+            return description;
+        }
+
+        /**
+         * Returns the bracket for a given level.
+         *
+         * @param level the bracket level (0-5)
+         * @return the corresponding bracket
+         * @throws IllegalArgumentException if level is out of range
+         */
+        public static IrmaaBracket fromLevel(int level) {
+            for (IrmaaBracket bracket : values()) {
+                if (bracket.level == level) {
+                    return bracket;
+                }
+            }
+            throw new IllegalArgumentException("Invalid IRMAA bracket level: " + level);
+        }
+
+        /**
+         * Returns whether this bracket has IRMAA surcharges.
+         *
+         * @return true if bracket level is greater than 0
+         */
+        public boolean hasIrmaa() {
+            return level > 0;
+        }
+    }
+
+    /**
+     * Returns the total Part B monthly premium (base + IRMAA).
+     *
+     * @return the total Part B premium
+     */
+    public BigDecimal getTotalPartBPremium() {
+        return partBBasePremium.add(partBIrmaa);
+    }
+
+    /**
+     * Returns the total monthly Medicare premium (Part A + Part B + Part D IRMAA).
+     *
+     * <p>Note: This does not include Part D plan premium, only the IRMAA surcharge.
+     *
+     * @return the total monthly premium
+     */
+    public BigDecimal getTotalMonthly() {
+        return partAPremium
+            .add(partBBasePremium)
+            .add(partBIrmaa)
+            .add(partDIrmaa);
+    }
+
+    /**
+     * Returns the total annual Medicare cost.
+     *
+     * @return the monthly total multiplied by 12
+     */
+    public BigDecimal getTotalAnnual() {
+        return getTotalMonthly().multiply(BigDecimal.valueOf(12));
+    }
+
+    /**
+     * Returns whether this result includes IRMAA surcharges.
+     *
+     * @return true if bracket is above BRACKET_0
+     */
+    public boolean hasIrmaa() {
+        return bracket.hasIrmaa();
+    }
+
+    /**
+     * Returns the total IRMAA surcharge (Part B + Part D).
+     *
+     * @return the combined monthly IRMAA amount
+     */
+    public BigDecimal getTotalIrmaa() {
+        return partBIrmaa.add(partDIrmaa);
+    }
+
+    /**
+     * Creates a premium result with no IRMAA (standard bracket).
+     *
+     * @param partAPremium the Part A premium
+     * @param partBBase the Part B base premium
+     * @param year the Medicare year
+     * @return a MedicarePremiums with bracket 0 and no IRMAA
+     */
+    public static MedicarePremiums standard(
+            BigDecimal partAPremium,
+            BigDecimal partBBase,
+            int year) {
+        return new MedicarePremiums(
+            partAPremium,
+            partBBase,
+            BigDecimal.ZERO,
+            BigDecimal.ZERO,
+            IrmaaBracket.BRACKET_0,
+            year
+        );
+    }
+
+    /**
+     * Creates a premium result with IRMAA surcharges.
+     *
+     * @param partAPremium the Part A premium
+     * @param partBBase the Part B base premium
+     * @param partBIrmaa the Part B IRMAA surcharge
+     * @param partDIrmaa the Part D IRMAA surcharge
+     * @param bracket the IRMAA bracket
+     * @param year the Medicare year
+     * @return a MedicarePremiums with the specified values
+     */
+    public static MedicarePremiums withIrmaa(
+            BigDecimal partAPremium,
+            BigDecimal partBBase,
+            BigDecimal partBIrmaa,
+            BigDecimal partDIrmaa,
+            IrmaaBracket bracket,
+            int year) {
+        return new MedicarePremiums(
+            partAPremium,
+            partBBase,
+            partBIrmaa,
+            partDIrmaa,
+            bracket,
+            year
+        );
+    }
+}

--- a/src/main/resources/application-medicare.yml
+++ b/src/main/resources/application-medicare.yml
@@ -1,0 +1,125 @@
+# Medicare Premium Configuration
+# CMS (Centers for Medicare and Medicaid Services) announced values
+#
+# Sources:
+# - CMS 2025 Part B Fact Sheet
+# - Medicare.gov costs overview
+#
+# IRMAA (Income-Related Monthly Adjustment Amount):
+# - Based on MAGI from 2 years prior (e.g., 2025 premiums use 2023 MAGI)
+# - Applies to both Part B and Part D
+# - Higher-income beneficiaries pay more
+
+medicare:
+  years:
+    - year: 2025
+      # Base Part B premium (standard, no IRMAA)
+      part-b-base: 185.00
+      # Part A hospital deductible per benefit period
+      part-a-deductible: 1676
+      # Part B annual deductible
+      part-b-deductible: 257
+      # Part A premium for those not premium-free (30+ quarters of work)
+      part-a-premium-full: 518
+      # Part A premium for those with 30-39 quarters of work
+      part-a-premium-reduced: 285
+
+      # IRMAA brackets for 2025 (based on 2023 MAGI)
+      # Part B premium = base + IRMAA surcharge
+      # Part D IRMAA is an additional surcharge on top of plan premium
+      irmaa-brackets:
+        # Bracket 0: No IRMAA (standard premium)
+        - single-min: 0
+          single-max: 106000
+          joint-min: 0
+          joint-max: 212000
+          part-b-premium: 185.00
+          part-d-irmaa: 0
+
+        # Bracket 1: First IRMAA tier
+        - single-min: 106001
+          single-max: 133000
+          joint-min: 212001
+          joint-max: 266000
+          part-b-premium: 259.00
+          part-d-irmaa: 13.70
+
+        # Bracket 2: Second IRMAA tier
+        - single-min: 133001
+          single-max: 167000
+          joint-min: 266001
+          joint-max: 334000
+          part-b-premium: 370.00
+          part-d-irmaa: 35.30
+
+        # Bracket 3: Third IRMAA tier
+        - single-min: 167001
+          single-max: 200000
+          joint-min: 334001
+          joint-max: 400000
+          part-b-premium: 480.90
+          part-d-irmaa: 57.00
+
+        # Bracket 4: Fourth IRMAA tier
+        - single-min: 200001
+          single-max: 500000
+          joint-min: 400001
+          joint-max: 750000
+          part-b-premium: 591.90
+          part-d-irmaa: 78.60
+
+        # Bracket 5: Highest IRMAA tier
+        - single-min: 500001
+          # No max - open ended
+          joint-min: 750001
+          # No max - open ended
+          part-b-premium: 628.90
+          part-d-irmaa: 85.80
+
+    - year: 2024
+      part-b-base: 174.70
+      part-a-deductible: 1632
+      part-b-deductible: 240
+      part-a-premium-full: 505
+      part-a-premium-reduced: 278
+
+      irmaa-brackets:
+        - single-min: 0
+          single-max: 103000
+          joint-min: 0
+          joint-max: 206000
+          part-b-premium: 174.70
+          part-d-irmaa: 0
+
+        - single-min: 103001
+          single-max: 129000
+          joint-min: 206001
+          joint-max: 258000
+          part-b-premium: 244.60
+          part-d-irmaa: 12.90
+
+        - single-min: 129001
+          single-max: 161000
+          joint-min: 258001
+          joint-max: 322000
+          part-b-premium: 349.40
+          part-d-irmaa: 33.30
+
+        - single-min: 161001
+          single-max: 193000
+          joint-min: 322001
+          joint-max: 386000
+          part-b-premium: 454.20
+          part-d-irmaa: 53.80
+
+        - single-min: 193001
+          single-max: 500000
+          joint-min: 386001
+          joint-max: 750000
+          part-b-premium: 559.00
+          part-d-irmaa: 74.20
+
+        - single-min: 500001
+          joint-min: 750001
+          part-b-premium: 594.00
+          part-d-irmaa: 81.00

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,7 @@ spring:
     import:
       - application-social-security.yml
       - application-expenses.yml
+      - application-medicare.yml
 
 # IRS Contribution Limits Configuration
 # SECURE 2.0 Act limits for 401(k), 403(b), and 457(b) plans

--- a/src/test/java/io/github/xmljim/retirement/domain/calculator/MedicareCalculatorTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/calculator/MedicareCalculatorTest.java
@@ -1,0 +1,231 @@
+package io.github.xmljim.retirement.domain.calculator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import io.github.xmljim.retirement.domain.config.MedicareRules;
+import io.github.xmljim.retirement.domain.enums.FilingStatus;
+import io.github.xmljim.retirement.domain.value.MedicarePremiums;
+import io.github.xmljim.retirement.domain.value.MedicarePremiums.IrmaaBracket;
+
+@DisplayName("MedicareCalculator Tests")
+class MedicareCalculatorTest {
+
+    private MedicareCalculator calculator;
+    private MedicareRules rules;
+
+    @BeforeEach
+    void setUp() {
+        rules = createTestRules();
+        calculator = CalculatorFactory.medicareCalculator(rules);
+    }
+
+    @Nested
+    @DisplayName("IRMAA Bracket Tests")
+    class IrmaaBracketTests {
+
+        @ParameterizedTest
+        @DisplayName("Single filer brackets")
+        @CsvSource({
+            "50000, BRACKET_0",
+            "106000, BRACKET_0",
+            "106001, BRACKET_1",
+            "133000, BRACKET_1",
+            "133001, BRACKET_2",
+            "167000, BRACKET_2",
+            "167001, BRACKET_3",
+            "200000, BRACKET_3",
+            "200001, BRACKET_4",
+            "500000, BRACKET_4",
+            "500001, BRACKET_5",
+            "1000000, BRACKET_5"
+        })
+        void singleFilerBrackets(String magi, IrmaaBracket expected) {
+            IrmaaBracket bracket = calculator.getIrmaaBracket(
+                new BigDecimal(magi), FilingStatus.SINGLE, 2025);
+            assertEquals(expected, bracket);
+        }
+
+        @ParameterizedTest
+        @DisplayName("Joint filer brackets")
+        @CsvSource({
+            "100000, BRACKET_0",
+            "212000, BRACKET_0",
+            "212001, BRACKET_1",
+            "266000, BRACKET_1",
+            "266001, BRACKET_2",
+            "334000, BRACKET_2",
+            "334001, BRACKET_3",
+            "400000, BRACKET_3",
+            "400001, BRACKET_4",
+            "750000, BRACKET_4",
+            "750001, BRACKET_5"
+        })
+        void jointFilerBrackets(String magi, IrmaaBracket expected) {
+            IrmaaBracket bracket = calculator.getIrmaaBracket(
+                new BigDecimal(magi), FilingStatus.MARRIED_FILING_JOINTLY, 2025);
+            assertEquals(expected, bracket);
+        }
+    }
+
+    @Nested
+    @DisplayName("Premium Calculation Tests")
+    class PremiumCalculationTests {
+
+        @Test
+        @DisplayName("Standard premium - no IRMAA")
+        void standardPremium() {
+            MedicarePremiums premiums = calculator.calculatePremiums(
+                new BigDecimal("100000"), FilingStatus.SINGLE, 2025);
+
+            assertEquals(0, BigDecimal.ZERO.compareTo(premiums.partAPremium()));
+            assertEquals(0, new BigDecimal("185.00").compareTo(premiums.partBBasePremium()));
+            assertEquals(0, BigDecimal.ZERO.compareTo(premiums.partBIrmaa()));
+            assertEquals(0, BigDecimal.ZERO.compareTo(premiums.partDIrmaa()));
+            assertEquals(IrmaaBracket.BRACKET_0, premiums.bracket());
+            assertFalse(premiums.hasIrmaa());
+        }
+
+        @Test
+        @DisplayName("Bracket 1 IRMAA")
+        void bracket1Irmaa() {
+            MedicarePremiums premiums = calculator.calculatePremiums(
+                new BigDecimal("120000"), FilingStatus.SINGLE, 2025);
+
+            assertEquals(IrmaaBracket.BRACKET_1, premiums.bracket());
+            assertTrue(premiums.hasIrmaa());
+            assertEquals(0, new BigDecimal("74.00").compareTo(premiums.partBIrmaa()));
+            assertEquals(0, new BigDecimal("13.70").compareTo(premiums.partDIrmaa()));
+        }
+
+        @Test
+        @DisplayName("Highest bracket IRMAA")
+        void highestBracketIrmaa() {
+            MedicarePremiums premiums = calculator.calculatePremiums(
+                new BigDecimal("600000"), FilingStatus.SINGLE, 2025);
+
+            assertEquals(IrmaaBracket.BRACKET_5, premiums.bracket());
+            assertEquals(0, new BigDecimal("443.90").compareTo(premiums.partBIrmaa()));
+            assertEquals(0, new BigDecimal("85.80").compareTo(premiums.partDIrmaa()));
+        }
+
+        @Test
+        @DisplayName("Total monthly calculation")
+        void totalMonthlyCalculation() {
+            MedicarePremiums premiums = calculator.calculatePremiums(
+                new BigDecimal("100000"), FilingStatus.SINGLE, 2025);
+
+            assertEquals(0, new BigDecimal("185.00").compareTo(premiums.getTotalMonthly()));
+        }
+
+        @Test
+        @DisplayName("Annual calculation")
+        void annualCalculation() {
+            MedicarePremiums premiums = calculator.calculatePremiums(
+                new BigDecimal("100000"), FilingStatus.SINGLE, 2025);
+
+            assertEquals(0, new BigDecimal("2220.00").compareTo(premiums.getTotalAnnual()));
+        }
+    }
+
+    @Nested
+    @DisplayName("Part A Premium Tests")
+    class PartAPremiumTests {
+
+        @Test
+        @DisplayName("Premium-free Part A (40+ quarters)")
+        void premiumFreePartA() {
+            assertEquals(0, BigDecimal.ZERO.compareTo(calculator.getPartAPremium(2025, 40)));
+        }
+
+        @Test
+        @DisplayName("Reduced Part A (30-39 quarters)")
+        void reducedPartA() {
+            assertEquals(0, new BigDecimal("285").compareTo(calculator.getPartAPremium(2025, 35)));
+        }
+
+        @Test
+        @DisplayName("Full Part A (under 30 quarters)")
+        void fullPartA() {
+            assertEquals(0, new BigDecimal("518").compareTo(calculator.getPartAPremium(2025, 20)));
+        }
+    }
+
+    @Nested
+    @DisplayName("Filing Status Tests")
+    class FilingStatusTests {
+
+        @Test
+        @DisplayName("Head of Household uses single thresholds")
+        void headOfHouseholdUsesSingle() {
+            IrmaaBracket single = calculator.getIrmaaBracket(
+                new BigDecimal("120000"), FilingStatus.SINGLE, 2025);
+            IrmaaBracket hoh = calculator.getIrmaaBracket(
+                new BigDecimal("120000"), FilingStatus.HEAD_OF_HOUSEHOLD, 2025);
+            assertEquals(single, hoh);
+        }
+
+        @Test
+        @DisplayName("QSS uses joint thresholds")
+        void qssUsesJoint() {
+            IrmaaBracket joint = calculator.getIrmaaBracket(
+                new BigDecimal("220000"), FilingStatus.MARRIED_FILING_JOINTLY, 2025);
+            IrmaaBracket qss = calculator.getIrmaaBracket(
+                new BigDecimal("220000"), FilingStatus.QUALIFYING_SURVIVING_SPOUSE, 2025);
+            assertEquals(joint, qss);
+        }
+    }
+
+    private MedicareRules createTestRules() {
+        MedicareRules.YearConfig year2025 = new MedicareRules.YearConfig();
+        year2025.setYear(2025);
+        year2025.setPartBBase(new BigDecimal("185.00"));
+        year2025.setPartAPremiumFull(new BigDecimal("518"));
+        year2025.setPartAPremiumReduced(new BigDecimal("285"));
+        year2025.setIrmaaBrackets(java.util.List.of(
+            createBracket(0, 106000, 0, 212000, "185.00", "0"),
+            createBracket(106001, 133000, 212001, 266000, "259.00", "13.70"),
+            createBracket(133001, 167000, 266001, 334000, "370.00", "35.30"),
+            createBracket(167001, 200000, 334001, 400000, "480.90", "57.00"),
+            createBracket(200001, 500000, 400001, 750000, "591.90", "78.60"),
+            createBracketNoMax(500001, 750001, "628.90", "85.80")
+        ));
+
+        MedicareRules testRules = new MedicareRules();
+        testRules.setYears(java.util.List.of(year2025));
+        return testRules;
+    }
+
+    private MedicareRules.IrmaaBracketConfig createBracket(
+            int singleMin, int singleMax, int jointMin, int jointMax,
+            String partBPremium, String partDIrmaa) {
+        MedicareRules.IrmaaBracketConfig bracket = new MedicareRules.IrmaaBracketConfig();
+        bracket.setSingleMin(BigDecimal.valueOf(singleMin));
+        bracket.setSingleMax(BigDecimal.valueOf(singleMax));
+        bracket.setJointMin(BigDecimal.valueOf(jointMin));
+        bracket.setJointMax(BigDecimal.valueOf(jointMax));
+        bracket.setPartBPremium(new BigDecimal(partBPremium));
+        bracket.setPartDIrmaa(new BigDecimal(partDIrmaa));
+        return bracket;
+    }
+
+    private MedicareRules.IrmaaBracketConfig createBracketNoMax(
+            int singleMin, int jointMin, String partBPremium, String partDIrmaa) {
+        MedicareRules.IrmaaBracketConfig bracket = new MedicareRules.IrmaaBracketConfig();
+        bracket.setSingleMin(BigDecimal.valueOf(singleMin));
+        bracket.setJointMin(BigDecimal.valueOf(jointMin));
+        bracket.setPartBPremium(new BigDecimal(partBPremium));
+        bracket.setPartDIrmaa(new BigDecimal(partDIrmaa));
+        return bracket;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `MedicareCalculator` interface and `DefaultMedicareCalculator` implementation
- Creates `MedicareRules` configuration class with year-specific IRMAA brackets
- Creates `MedicarePremiums` record with `IrmaaBracket` enum for calculation results
- YAML configuration with 2024/2025 CMS premium tables and 6 IRMAA tiers
- Factory methods added to `CalculatorFactory`

## Key Features
| Feature | Description |
|---------|-------------|
| IRMAA Brackets | 6 tiers (0-5) based on MAGI |
| Filing Status | Single, MFJ, HOH, MFS, QSS support |
| Part A Premium | Premium-free, reduced, or full based on work quarters |
| Part B Premium | Base + IRMAA surcharge |
| Part D IRMAA | Surcharge amount by bracket |

## Test Plan
- [x] Parameterized tests for all 6 IRMAA brackets (single and joint)
- [x] Premium calculation tests with IRMAA
- [x] Part A premium tests (40+, 30-39, <30 quarters)
- [x] Filing status threshold tests

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)