### PR TITLE
feat(#177): Implement Federal Tax Calculator with chained CPI

### DIFF
--- a/src/main/java/io/github/xmljim/retirement/domain/calculator/CalculatorFactory.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/calculator/CalculatorFactory.java
@@ -5,6 +5,7 @@ import io.github.xmljim.retirement.domain.calculator.impl.DefaultContributionCal
 import io.github.xmljim.retirement.domain.calculator.impl.DefaultContributionLimitChecker;
 import io.github.xmljim.retirement.domain.calculator.impl.DefaultContributionRouter;
 import io.github.xmljim.retirement.domain.calculator.impl.DefaultEarningsTestCalculator;
+import io.github.xmljim.retirement.domain.calculator.impl.DefaultFederalTaxCalculator;
 import io.github.xmljim.retirement.domain.calculator.impl.DefaultIncomeCalculator;
 import io.github.xmljim.retirement.domain.calculator.impl.DefaultInflationCalculator;
 import io.github.xmljim.retirement.domain.calculator.impl.DefaultMAGICalculator;
@@ -16,6 +17,7 @@ import io.github.xmljim.retirement.domain.calculator.impl.DefaultSocialSecurityC
 import io.github.xmljim.retirement.domain.calculator.impl.DefaultSpousalBenefitCalculator;
 import io.github.xmljim.retirement.domain.calculator.impl.DefaultWithdrawalCalculator;
 import io.github.xmljim.retirement.domain.calculator.impl.DefaultYTDContributionTracker;
+import io.github.xmljim.retirement.domain.config.FederalTaxRules;
 import io.github.xmljim.retirement.domain.config.IraPhaseOutLimits;
 import io.github.xmljim.retirement.domain.config.IrsContributionLimits;
 import io.github.xmljim.retirement.domain.config.MedicareRules;
@@ -374,5 +376,41 @@ public final class CalculatorFactory {
      */
     public static RmdCalculator rmdCalculator(RmdRules rules) {
         return new DefaultRmdCalculator(rules);
+    }
+
+    /**
+     * Returns a new federal income tax calculator.
+     *
+     * <p>The federal tax calculator computes income tax using progressive
+     * brackets and supports chained CPI indexing for future years.
+     *
+     * <p>Usage:
+     * <pre>{@code
+     * FederalTaxCalculator calculator = CalculatorFactory.federalTaxCalculator();
+     *
+     * TaxCalculationResult result = calculator.calculateTax(
+     *     new BigDecimal("75000"),  // gross income
+     *     FilingStatus.SINGLE,      // filing status
+     *     67,                        // age
+     *     2025                       // tax year
+     * );
+     * }</pre>
+     *
+     * @return a new FederalTaxCalculator instance
+     */
+    public static FederalTaxCalculator federalTaxCalculator() {
+        return new DefaultFederalTaxCalculator();
+    }
+
+    /**
+     * Returns a new federal tax calculator with custom rules.
+     *
+     * <p>Use this when you have Spring-managed FederalTaxRules configuration.
+     *
+     * @param rules the federal tax rules configuration
+     * @return a new FederalTaxCalculator instance with the provided rules
+     */
+    public static FederalTaxCalculator federalTaxCalculator(FederalTaxRules rules) {
+        return new DefaultFederalTaxCalculator(rules);
     }
 }

--- a/src/main/java/io/github/xmljim/retirement/domain/calculator/FederalTaxCalculator.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/calculator/FederalTaxCalculator.java
@@ -1,0 +1,149 @@
+package io.github.xmljim.retirement.domain.calculator;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import io.github.xmljim.retirement.domain.enums.FilingStatus;
+import io.github.xmljim.retirement.domain.value.TaxBracket;
+import io.github.xmljim.retirement.domain.value.TaxCalculationResult;
+
+/**
+ * Calculator for federal income tax.
+ *
+ * <p>Calculates federal tax liability using progressive tax brackets
+ * and standard deductions. Supports future year projections using
+ * chained CPI indexing.
+ *
+ * <p>Key features:
+ * <ul>
+ *   <li>Progressive tax bracket calculation</li>
+ *   <li>Standard deduction with age 65+ additional</li>
+ *   <li>Chained CPI indexing for future years</li>
+ *   <li>Effective and marginal rate calculations</li>
+ * </ul>
+ *
+ * @see TaxCalculationResult
+ * @see TaxBracket
+ * @see <a href="https://www.irs.gov/publications/p17">IRS Publication 17</a>
+ */
+public interface FederalTaxCalculator {
+
+    /**
+     * Calculates federal income tax liability.
+     *
+     * @param grossIncome total income before deductions
+     * @param filingStatus the filing status
+     * @param age the taxpayer's age (for 65+ deduction)
+     * @param year the tax year
+     * @return the tax calculation result
+     */
+    TaxCalculationResult calculateTax(
+        BigDecimal grossIncome,
+        FilingStatus filingStatus,
+        int age,
+        int year
+    );
+
+    /**
+     * Calculates federal income tax for married filing jointly.
+     *
+     * @param grossIncome total income before deductions
+     * @param age the primary taxpayer's age
+     * @param spouseAge the spouse's age (for additional 65+ deduction)
+     * @param year the tax year
+     * @return the tax calculation result
+     */
+    TaxCalculationResult calculateTaxMfj(
+        BigDecimal grossIncome,
+        int age,
+        int spouseAge,
+        int year
+    );
+
+    /**
+     * Gets the standard deduction for a filing status and year.
+     *
+     * <p>Includes additional deduction for age 65+ if applicable.
+     *
+     * @param filingStatus the filing status
+     * @param age the taxpayer's age
+     * @param year the tax year
+     * @return the total standard deduction
+     */
+    BigDecimal getStandardDeduction(
+        FilingStatus filingStatus,
+        int age,
+        int year
+    );
+
+    /**
+     * Gets the standard deduction for MFJ with both spouse ages.
+     *
+     * @param age the primary taxpayer's age
+     * @param spouseAge the spouse's age
+     * @param year the tax year
+     * @return the total standard deduction including both 65+ additions
+     */
+    BigDecimal getStandardDeductionMfj(int age, int spouseAge, int year);
+
+    /**
+     * Gets the tax brackets for a filing status and year.
+     *
+     * <p>Brackets are indexed to the specified year using chained CPI.
+     *
+     * @param filingStatus the filing status
+     * @param year the tax year
+     * @return the list of tax brackets
+     */
+    List<TaxBracket> getBrackets(FilingStatus filingStatus, int year);
+
+    /**
+     * Calculates the effective tax rate.
+     *
+     * <p>Effective rate = Total tax / Gross income
+     *
+     * @param grossIncome total income before deductions
+     * @param filingStatus the filing status
+     * @param age the taxpayer's age
+     * @param year the tax year
+     * @return the effective tax rate as a decimal
+     */
+    BigDecimal getEffectiveTaxRate(
+        BigDecimal grossIncome,
+        FilingStatus filingStatus,
+        int age,
+        int year
+    );
+
+    /**
+     * Calculates the marginal tax rate.
+     *
+     * <p>Marginal rate is the tax rate on the next dollar of income.
+     *
+     * @param taxableIncome income after deductions
+     * @param filingStatus the filing status
+     * @param year the tax year
+     * @return the marginal tax rate as a decimal
+     */
+    BigDecimal getMarginalTaxRate(
+        BigDecimal taxableIncome,
+        FilingStatus filingStatus,
+        int year
+    );
+
+    /**
+     * Projects a base-year value to a future year using chained CPI.
+     *
+     * <p>IRS rounds bracket thresholds and deductions to nearest $50.
+     *
+     * @param baseValue the value in the base year
+     * @param baseYear the year of the base value
+     * @param targetYear the year to project to
+     * @return the projected value rounded per IRS rules
+     */
+    BigDecimal projectValueWithChainedCpi(
+        BigDecimal baseValue,
+        int baseYear,
+        int targetYear
+    );
+}

--- a/src/main/java/io/github/xmljim/retirement/domain/calculator/impl/DefaultFederalTaxCalculator.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/calculator/impl/DefaultFederalTaxCalculator.java
@@ -1,0 +1,264 @@
+package io.github.xmljim.retirement.domain.calculator.impl;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.github.xmljim.retirement.domain.calculator.FederalTaxCalculator;
+import io.github.xmljim.retirement.domain.config.FederalTaxRules;
+import io.github.xmljim.retirement.domain.config.FederalTaxRules.BracketConfig;
+import io.github.xmljim.retirement.domain.enums.FilingStatus;
+import io.github.xmljim.retirement.domain.value.TaxBracket;
+import io.github.xmljim.retirement.domain.value.TaxCalculationResult;
+import io.github.xmljim.retirement.domain.value.TaxCalculationResult.BracketTax;
+
+/**
+ * Default implementation of federal income tax calculator.
+ *
+ * <p>Calculates federal tax using progressive tax brackets with
+ * chained CPI indexing for future year projections.
+ *
+ * @see FederalTaxCalculator
+ * @see FederalTaxRules
+ */
+@Service
+public class DefaultFederalTaxCalculator implements FederalTaxCalculator {
+
+    private static final int SCALE = 10;
+    private static final int AGE_65 = 65;
+    private static final BigDecimal FIFTY = new BigDecimal("50");
+
+    private final FederalTaxRules rules;
+
+    /**
+     * Creates a calculator with Spring-managed rules.
+     *
+     * @param rules the federal tax rules configuration
+     */
+    @Autowired
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring-managed beans")
+    public DefaultFederalTaxCalculator(FederalTaxRules rules) {
+        this.rules = rules;
+    }
+
+    /**
+     * Creates a calculator with default rules.
+     */
+    public DefaultFederalTaxCalculator() {
+        this.rules = new FederalTaxRules();
+    }
+
+    @Override
+    public TaxCalculationResult calculateTax(
+            BigDecimal grossIncome,
+            FilingStatus filingStatus,
+            int age,
+            int year) {
+
+        BigDecimal standardDeduction = getStandardDeduction(filingStatus, age, year);
+        return buildTaxResult(grossIncome, standardDeduction, filingStatus, year);
+    }
+
+    @Override
+    public TaxCalculationResult calculateTaxMfj(
+            BigDecimal grossIncome,
+            int age,
+            int spouseAge,
+            int year) {
+
+        BigDecimal standardDeduction = getStandardDeductionMfj(age, spouseAge, year);
+        return buildTaxResult(grossIncome, standardDeduction, FilingStatus.MARRIED_FILING_JOINTLY, year);
+    }
+
+    private TaxCalculationResult buildTaxResult(
+            BigDecimal grossIncome,
+            BigDecimal standardDeduction,
+            FilingStatus filingStatus,
+            int year) {
+
+        BigDecimal taxableIncome = grossIncome.subtract(standardDeduction).max(BigDecimal.ZERO);
+
+        if (taxableIncome.compareTo(BigDecimal.ZERO) <= 0) {
+            return TaxCalculationResult.noTax(grossIncome, standardDeduction, filingStatus, year);
+        }
+
+        List<TaxBracket> brackets = getBrackets(filingStatus, year);
+        List<BracketTax> bracketBreakdown = calculateBracketBreakdown(taxableIncome, brackets);
+
+        BigDecimal federalTax = bracketBreakdown.stream()
+            .map(BracketTax::taxInBracket)
+            .reduce(BigDecimal.ZERO, BigDecimal::add)
+            .setScale(2, RoundingMode.HALF_UP);
+
+        BigDecimal effectiveRate = calculateEffectiveRate(federalTax, grossIncome);
+        BigDecimal marginalRate = getMarginalTaxRate(taxableIncome, filingStatus, year);
+
+        return new TaxCalculationResult(
+            grossIncome,
+            standardDeduction,
+            taxableIncome,
+            federalTax,
+            effectiveRate,
+            marginalRate,
+            filingStatus,
+            year,
+            bracketBreakdown
+        );
+    }
+
+    @Override
+    public BigDecimal getStandardDeduction(FilingStatus filingStatus, int age, int year) {
+        BigDecimal baseDeduction = projectValueWithChainedCpi(
+            rules.getStandardDeduction(filingStatus),
+            rules.getBaseYear(),
+            year
+        );
+
+        if (age >= AGE_65) {
+            BigDecimal additional = projectValueWithChainedCpi(
+                rules.getAge65AdditionalDeduction(filingStatus),
+                rules.getBaseYear(),
+                year
+            );
+            baseDeduction = baseDeduction.add(additional);
+        }
+
+        return baseDeduction;
+    }
+
+    @Override
+    public BigDecimal getStandardDeductionMfj(int age, int spouseAge, int year) {
+        BigDecimal baseDeduction = projectValueWithChainedCpi(
+            rules.getStandardDeduction(FilingStatus.MARRIED_FILING_JOINTLY),
+            rules.getBaseYear(),
+            year
+        );
+
+        BigDecimal additional = rules.getAge65AdditionalDeduction(FilingStatus.MARRIED_FILING_JOINTLY);
+        int count65Plus = (age >= AGE_65 ? 1 : 0) + (spouseAge >= AGE_65 ? 1 : 0);
+
+        if (count65Plus > 0) {
+            BigDecimal projectedAdditional = projectValueWithChainedCpi(
+                additional.multiply(BigDecimal.valueOf(count65Plus)),
+                rules.getBaseYear(),
+                year
+            );
+            baseDeduction = baseDeduction.add(projectedAdditional);
+        }
+
+        return baseDeduction;
+    }
+
+    @Override
+    public List<TaxBracket> getBrackets(FilingStatus filingStatus, int year) {
+        List<BracketConfig> configBrackets = rules.getBrackets(filingStatus);
+        List<TaxBracket> brackets = new ArrayList<>();
+        BigDecimal previousUpper = BigDecimal.ZERO;
+
+        for (BracketConfig config : configBrackets) {
+            BigDecimal lowerBound = previousUpper;
+            BigDecimal upperBound = config.getUpperBound()
+                .map(upper -> projectValueWithChainedCpi(upper, rules.getBaseYear(), year))
+                .orElse(null);
+
+            brackets.add(TaxBracket.of(config.getRate(), lowerBound, upperBound));
+
+            if (upperBound != null) {
+                previousUpper = upperBound;
+            }
+        }
+
+        return brackets;
+    }
+
+    @Override
+    public BigDecimal getEffectiveTaxRate(
+            BigDecimal grossIncome,
+            FilingStatus filingStatus,
+            int age,
+            int year) {
+
+        TaxCalculationResult result = calculateTax(grossIncome, filingStatus, age, year);
+        return result.effectiveRate();
+    }
+
+    @Override
+    public BigDecimal getMarginalTaxRate(
+            BigDecimal taxableIncome,
+            FilingStatus filingStatus,
+            int year) {
+
+        if (taxableIncome.compareTo(BigDecimal.ZERO) <= 0) {
+            return BigDecimal.ZERO;
+        }
+
+        List<TaxBracket> brackets = getBrackets(filingStatus, year);
+
+        for (TaxBracket bracket : brackets) {
+            if (bracket.containsIncome(taxableIncome)) {
+                return bracket.rate();
+            }
+        }
+
+        // If income exceeds all brackets, return top bracket rate
+        if (!brackets.isEmpty()) {
+            return brackets.getLast().rate();
+        }
+
+        return BigDecimal.ZERO;
+    }
+
+    @Override
+    public BigDecimal projectValueWithChainedCpi(
+            BigDecimal baseValue,
+            int baseYear,
+            int targetYear) {
+
+        if (baseValue == null || baseValue.compareTo(BigDecimal.ZERO) == 0) {
+            return BigDecimal.ZERO;
+        }
+
+        int yearsElapsed = targetYear - baseYear;
+        if (yearsElapsed <= 0) {
+            return roundToNearest50(baseValue);
+        }
+
+        BigDecimal multiplier = BigDecimal.ONE.add(rules.getChainedCpiRate())
+            .pow(yearsElapsed, java.math.MathContext.DECIMAL128);
+
+        BigDecimal projected = baseValue.multiply(multiplier);
+        return roundToNearest50(projected);
+    }
+
+    private List<BracketTax> calculateBracketBreakdown(
+            BigDecimal taxableIncome,
+            List<TaxBracket> brackets) {
+
+        List<BracketTax> breakdown = new ArrayList<>();
+
+        for (TaxBracket bracket : brackets) {
+            BigDecimal incomeInBracket = bracket.getIncomeInBracket(taxableIncome);
+            if (incomeInBracket.compareTo(BigDecimal.ZERO) > 0) {
+                breakdown.add(BracketTax.of(bracket.rate(), incomeInBracket));
+            }
+        }
+
+        return breakdown;
+    }
+
+    private BigDecimal calculateEffectiveRate(BigDecimal tax, BigDecimal grossIncome) {
+        if (grossIncome.compareTo(BigDecimal.ZERO) == 0) {
+            return BigDecimal.ZERO;
+        }
+        return tax.divide(grossIncome, SCALE, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal roundToNearest50(BigDecimal value) {
+        return value.divide(FIFTY, 0, RoundingMode.HALF_UP).multiply(FIFTY);
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/domain/config/FederalTaxRules.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/config/FederalTaxRules.java
@@ -1,0 +1,142 @@
+package io.github.xmljim.retirement.domain.config;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.github.xmljim.retirement.domain.enums.FilingStatus;
+
+/**
+ * Federal income tax rules loaded from external YAML configuration.
+ *
+ * <p>This class provides configurable federal tax rules including:
+ * <ul>
+ *   <li>Tax brackets by filing status</li>
+ *   <li>Standard deductions by filing status</li>
+ *   <li>Additional deduction for age 65+</li>
+ *   <li>Chained CPI rate for bracket indexing</li>
+ * </ul>
+ *
+ * <p>Tax brackets and deductions are indexed annually using chained CPI-U,
+ * which grows approximately 0.25% slower than traditional CPI.
+ *
+ * <p>Configuration is loaded from {@code application.yml} under the
+ * {@code federal-tax} prefix.
+ *
+ * @see <a href="https://www.irs.gov/publications/p17">IRS Publication 17</a>
+ */
+@ConfigurationProperties(prefix = "federal-tax")
+@Validated
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP",
+    justification = "Spring @ConfigurationProperties requires mutable access for binding"
+)
+public class FederalTaxRules {
+
+    private BigDecimal chainedCpiRate = new BigDecimal("0.025");
+    private int baseYear = 2024;
+    private Map<FilingStatus, BigDecimal> standardDeductions = new EnumMap<>(FilingStatus.class);
+    private Map<FilingStatus, BigDecimal> age65Additional = new EnumMap<>(FilingStatus.class);
+    private Map<FilingStatus, List<BracketConfig>> brackets = new EnumMap<>(FilingStatus.class);
+
+    /**
+     * Tax bracket configuration entry.
+     */
+    public static class BracketConfig {
+        private BigDecimal rate;
+        private Optional<BigDecimal> upperBound = Optional.empty();
+
+        public BigDecimal getRate() {
+            return rate;
+        }
+
+        public void setRate(BigDecimal rate) {
+            this.rate = rate;
+        }
+
+        public Optional<BigDecimal> getUpperBound() {
+            return upperBound;
+        }
+
+        public void setUpperBound(BigDecimal upperBound) {
+            this.upperBound = Optional.ofNullable(upperBound);
+        }
+    }
+
+    public BigDecimal getChainedCpiRate() {
+        return chainedCpiRate;
+    }
+
+    public void setChainedCpiRate(BigDecimal chainedCpiRate) {
+        this.chainedCpiRate = chainedCpiRate;
+    }
+
+    public int getBaseYear() {
+        return baseYear;
+    }
+
+    public void setBaseYear(int baseYear) {
+        this.baseYear = baseYear;
+    }
+
+    public Map<FilingStatus, BigDecimal> getStandardDeductions() {
+        return standardDeductions;
+    }
+
+    public void setStandardDeductions(Map<FilingStatus, BigDecimal> standardDeductions) {
+        this.standardDeductions = standardDeductions;
+    }
+
+    public Map<FilingStatus, BigDecimal> getAge65Additional() {
+        return age65Additional;
+    }
+
+    public void setAge65Additional(Map<FilingStatus, BigDecimal> age65Additional) {
+        this.age65Additional = age65Additional;
+    }
+
+    public Map<FilingStatus, List<BracketConfig>> getBrackets() {
+        return brackets;
+    }
+
+    public void setBrackets(Map<FilingStatus, List<BracketConfig>> brackets) {
+        this.brackets = brackets;
+    }
+
+    /**
+     * Gets the standard deduction for a filing status in the base year.
+     *
+     * @param filingStatus the filing status
+     * @return the standard deduction amount
+     */
+    public BigDecimal getStandardDeduction(FilingStatus filingStatus) {
+        return standardDeductions.getOrDefault(filingStatus, BigDecimal.ZERO);
+    }
+
+    /**
+     * Gets the additional deduction for age 65+ for a filing status.
+     *
+     * @param filingStatus the filing status
+     * @return the additional deduction amount per qualifying person
+     */
+    public BigDecimal getAge65AdditionalDeduction(FilingStatus filingStatus) {
+        return age65Additional.getOrDefault(filingStatus, BigDecimal.ZERO);
+    }
+
+    /**
+     * Gets the tax brackets for a filing status in the base year.
+     *
+     * @param filingStatus the filing status
+     * @return the list of bracket configurations
+     */
+    public List<BracketConfig> getBrackets(FilingStatus filingStatus) {
+        return brackets.getOrDefault(filingStatus, new ArrayList<>());
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/domain/value/TaxBracket.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/value/TaxBracket.java
@@ -1,0 +1,117 @@
+package io.github.xmljim.retirement.domain.value;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+/**
+ * Represents a federal income tax bracket.
+ *
+ * <p>Each bracket defines a tax rate and the income range it applies to.
+ * Brackets are progressive - only income within the bracket range is taxed
+ * at that bracket's rate.
+ *
+ * @param rate the tax rate as a decimal (e.g., 0.22 for 22%)
+ * @param lowerBound the minimum income for this bracket (inclusive)
+ * @param upperBound the maximum income for this bracket (exclusive), empty for top bracket
+ *
+ * @see <a href="https://www.irs.gov/publications/p17">IRS Publication 17</a>
+ */
+public record TaxBracket(
+    BigDecimal rate,
+    BigDecimal lowerBound,
+    Optional<BigDecimal> upperBound
+) {
+
+    /**
+     * Creates a bracket with explicit bounds.
+     *
+     * @param rate the tax rate
+     * @param lowerBound the lower bound
+     * @param upperBound the upper bound (null for top bracket)
+     * @return a new TaxBracket
+     */
+    public static TaxBracket of(BigDecimal rate, BigDecimal lowerBound, BigDecimal upperBound) {
+        return new TaxBracket(rate, lowerBound, Optional.ofNullable(upperBound));
+    }
+
+    /**
+     * Creates the top bracket (no upper bound).
+     *
+     * @param rate the tax rate
+     * @param lowerBound the lower bound
+     * @return a new TaxBracket with no upper bound
+     */
+    public static TaxBracket topBracket(BigDecimal rate, BigDecimal lowerBound) {
+        return new TaxBracket(rate, lowerBound, Optional.empty());
+    }
+
+    /**
+     * Returns whether this is the top bracket (no upper bound).
+     *
+     * @return true if this bracket has no upper bound
+     */
+    public boolean isTopBracket() {
+        return upperBound.isEmpty();
+    }
+
+    /**
+     * Returns the width of this bracket (upper - lower).
+     *
+     * @return the bracket width, or empty if this is the top bracket
+     */
+    public Optional<BigDecimal> getWidth() {
+        return upperBound.map(upper -> upper.subtract(lowerBound));
+    }
+
+    /**
+     * Returns whether the given income falls within this bracket.
+     *
+     * @param income the taxable income
+     * @return true if income is within this bracket
+     */
+    public boolean containsIncome(BigDecimal income) {
+        boolean aboveLower = income.compareTo(lowerBound) >= 0;
+        boolean belowUpper = upperBound.map(upper -> income.compareTo(upper) < 0).orElse(true);
+        return aboveLower && belowUpper;
+    }
+
+    /**
+     * Calculates the amount of income that falls within this bracket.
+     *
+     * @param taxableIncome the total taxable income
+     * @return the income amount taxed at this bracket's rate
+     */
+    public BigDecimal getIncomeInBracket(BigDecimal taxableIncome) {
+        if (taxableIncome.compareTo(lowerBound) <= 0) {
+            return BigDecimal.ZERO;
+        }
+
+        BigDecimal incomeAboveLower = taxableIncome.subtract(lowerBound);
+
+        return upperBound
+            .map(upper -> {
+                BigDecimal bracketWidth = upper.subtract(lowerBound);
+                return incomeAboveLower.min(bracketWidth);
+            })
+            .orElse(incomeAboveLower);
+    }
+
+    /**
+     * Calculates the tax owed for income in this bracket.
+     *
+     * @param taxableIncome the total taxable income
+     * @return the tax amount for income in this bracket
+     */
+    public BigDecimal calculateTaxInBracket(BigDecimal taxableIncome) {
+        return getIncomeInBracket(taxableIncome).multiply(rate);
+    }
+
+    /**
+     * Returns the rate as a percentage (e.g., 22 for 22%).
+     *
+     * @return the rate multiplied by 100
+     */
+    public BigDecimal getRateAsPercentage() {
+        return rate.multiply(BigDecimal.valueOf(100));
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/domain/value/TaxCalculationResult.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/value/TaxCalculationResult.java
@@ -1,0 +1,139 @@
+package io.github.xmljim.retirement.domain.value;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.github.xmljim.retirement.domain.enums.FilingStatus;
+
+/**
+ * Result of a federal income tax calculation.
+ *
+ * <p>Contains the complete breakdown of a tax calculation including:
+ * <ul>
+ *   <li>Gross income and deductions</li>
+ *   <li>Taxable income and total tax</li>
+ *   <li>Effective and marginal tax rates</li>
+ *   <li>Per-bracket tax breakdown</li>
+ * </ul>
+ *
+ * @param grossIncome total income before deductions
+ * @param standardDeduction the standard deduction applied
+ * @param taxableIncome income subject to tax (gross - deduction)
+ * @param federalTax total federal income tax
+ * @param effectiveRate effective tax rate (tax / gross income)
+ * @param marginalRate marginal tax rate (top bracket rate)
+ * @param filingStatus the filing status used
+ * @param year the tax year
+ * @param bracketBreakdown tax calculated in each bracket
+ *
+ * @see <a href="https://www.irs.gov/publications/p17">IRS Publication 17</a>
+ */
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP",
+    justification = "Record is immutable; List is created internally and not modified"
+)
+public record TaxCalculationResult(
+    BigDecimal grossIncome,
+    BigDecimal standardDeduction,
+    BigDecimal taxableIncome,
+    BigDecimal federalTax,
+    BigDecimal effectiveRate,
+    BigDecimal marginalRate,
+    FilingStatus filingStatus,
+    int year,
+    List<BracketTax> bracketBreakdown
+) {
+
+    /**
+     * Tax calculated within a single bracket.
+     *
+     * @param rate the bracket tax rate
+     * @param incomeInBracket the income amount taxed at this rate
+     * @param taxInBracket the tax generated in this bracket
+     */
+    public record BracketTax(
+        BigDecimal rate,
+        BigDecimal incomeInBracket,
+        BigDecimal taxInBracket
+    ) {
+        /**
+         * Creates a bracket tax entry.
+         *
+         * @param rate the tax rate
+         * @param incomeInBracket the income in this bracket
+         * @return a new BracketTax with calculated tax
+         */
+        public static BracketTax of(BigDecimal rate, BigDecimal incomeInBracket) {
+            BigDecimal tax = incomeInBracket.multiply(rate)
+                .setScale(2, RoundingMode.HALF_UP);
+            return new BracketTax(rate, incomeInBracket, tax);
+        }
+    }
+
+    /**
+     * Returns the after-tax income.
+     *
+     * @return gross income minus federal tax
+     */
+    public BigDecimal getAfterTaxIncome() {
+        return grossIncome.subtract(federalTax);
+    }
+
+    /**
+     * Returns whether any tax is owed.
+     *
+     * @return true if federal tax is greater than zero
+     */
+    public boolean hasTaxLiability() {
+        return federalTax.compareTo(BigDecimal.ZERO) > 0;
+    }
+
+    /**
+     * Returns the effective rate as a percentage.
+     *
+     * @return the effective rate multiplied by 100
+     */
+    public BigDecimal getEffectiveRatePercentage() {
+        return effectiveRate.multiply(BigDecimal.valueOf(100))
+            .setScale(2, RoundingMode.HALF_UP);
+    }
+
+    /**
+     * Returns the marginal rate as a percentage.
+     *
+     * @return the marginal rate multiplied by 100
+     */
+    public BigDecimal getMarginalRatePercentage() {
+        return marginalRate.multiply(BigDecimal.valueOf(100))
+            .setScale(0, RoundingMode.HALF_UP);
+    }
+
+    /**
+     * Creates a result for zero tax liability.
+     *
+     * @param grossIncome the gross income
+     * @param standardDeduction the deduction that eliminated tax liability
+     * @param filingStatus the filing status
+     * @param year the tax year
+     * @return a result with zero tax
+     */
+    public static TaxCalculationResult noTax(
+            BigDecimal grossIncome,
+            BigDecimal standardDeduction,
+            FilingStatus filingStatus,
+            int year) {
+        return new TaxCalculationResult(
+            grossIncome,
+            standardDeduction,
+            BigDecimal.ZERO,
+            BigDecimal.ZERO,
+            BigDecimal.ZERO,
+            BigDecimal.ZERO,
+            filingStatus,
+            year,
+            List.of()
+        );
+    }
+}

--- a/src/main/resources/application-federal-tax.yml
+++ b/src/main/resources/application-federal-tax.yml
@@ -1,0 +1,113 @@
+# Federal Income Tax Configuration
+# Source: IRS Rev. Proc. 2023-34 (2024 inflation adjustments)
+#
+# Tax brackets and standard deductions are indexed annually using chained CPI-U
+# Chained CPI grows ~0.25% slower than traditional CPI
+
+federal-tax:
+  # Chained CPI rate for bracket/deduction indexing
+  # Historical average approximately 2.5%
+  chained-cpi-rate: 0.025
+
+  # Base year for configured values
+  base-year: 2024
+
+  # Standard deductions by filing status (2024)
+  standard-deductions:
+    SINGLE: 14600
+    MARRIED_FILING_JOINTLY: 29200
+    MARRIED_FILING_SEPARATELY: 14600
+    HEAD_OF_HOUSEHOLD: 21900
+    QUALIFYING_SURVIVING_SPOUSE: 29200
+
+  # Additional deduction for age 65+ (per qualifying person)
+  age-65-additional:
+    SINGLE: 1950
+    HEAD_OF_HOUSEHOLD: 1950
+    MARRIED_FILING_JOINTLY: 1550
+    MARRIED_FILING_SEPARATELY: 1550
+    QUALIFYING_SURVIVING_SPOUSE: 1550
+
+  # Tax brackets by filing status (2024)
+  # Upper bounds define the maximum income taxed at each rate
+  # Top bracket has no upper bound (null)
+  brackets:
+    SINGLE:
+      - rate: 0.10
+        upper-bound: 11600
+      - rate: 0.12
+        upper-bound: 47150
+      - rate: 0.22
+        upper-bound: 100525
+      - rate: 0.24
+        upper-bound: 191950
+      - rate: 0.32
+        upper-bound: 243725
+      - rate: 0.35
+        upper-bound: 609350
+      - rate: 0.37
+        upper-bound:
+
+    MARRIED_FILING_JOINTLY:
+      - rate: 0.10
+        upper-bound: 23200
+      - rate: 0.12
+        upper-bound: 94300
+      - rate: 0.22
+        upper-bound: 201050
+      - rate: 0.24
+        upper-bound: 383900
+      - rate: 0.32
+        upper-bound: 487450
+      - rate: 0.35
+        upper-bound: 731200
+      - rate: 0.37
+        upper-bound:
+
+    MARRIED_FILING_SEPARATELY:
+      - rate: 0.10
+        upper-bound: 11600
+      - rate: 0.12
+        upper-bound: 47150
+      - rate: 0.22
+        upper-bound: 100525
+      - rate: 0.24
+        upper-bound: 191950
+      - rate: 0.32
+        upper-bound: 243725
+      - rate: 0.35
+        upper-bound: 365600
+      - rate: 0.37
+        upper-bound:
+
+    HEAD_OF_HOUSEHOLD:
+      - rate: 0.10
+        upper-bound: 16550
+      - rate: 0.12
+        upper-bound: 63100
+      - rate: 0.22
+        upper-bound: 100500
+      - rate: 0.24
+        upper-bound: 191950
+      - rate: 0.32
+        upper-bound: 243700
+      - rate: 0.35
+        upper-bound: 609350
+      - rate: 0.37
+        upper-bound:
+
+    QUALIFYING_SURVIVING_SPOUSE:
+      - rate: 0.10
+        upper-bound: 23200
+      - rate: 0.12
+        upper-bound: 94300
+      - rate: 0.22
+        upper-bound: 201050
+      - rate: 0.24
+        upper-bound: 383900
+      - rate: 0.32
+        upper-bound: 487450
+      - rate: 0.35
+        upper-bound: 731200
+      - rate: 0.37
+        upper-bound:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,7 @@ spring:
       - application-expenses.yml
       - application-medicare.yml
       - application-rmd.yml
+      - application-federal-tax.yml
 
 # IRS Contribution Limits Configuration
 # SECURE 2.0 Act limits for 401(k), 403(b), and 457(b) plans

--- a/src/test/java/io/github/xmljim/retirement/domain/calculator/FederalTaxCalculatorTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/calculator/FederalTaxCalculatorTest.java
@@ -1,0 +1,266 @@
+package io.github.xmljim.retirement.domain.calculator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.github.xmljim.retirement.domain.config.FederalTaxRules;
+import io.github.xmljim.retirement.domain.config.FederalTaxRules.BracketConfig;
+import io.github.xmljim.retirement.domain.enums.FilingStatus;
+import io.github.xmljim.retirement.domain.value.TaxBracket;
+import io.github.xmljim.retirement.domain.value.TaxCalculationResult;
+
+@DisplayName("FederalTaxCalculator Tests")
+class FederalTaxCalculatorTest {
+
+    private FederalTaxCalculator calculator;
+    private FederalTaxRules rules;
+
+    @BeforeEach
+    void setUp() {
+        rules = createTestRules();
+        calculator = CalculatorFactory.federalTaxCalculator(rules);
+    }
+
+    @Nested
+    @DisplayName("Standard Deduction Tests")
+    class StandardDeductionTests {
+
+        @Test
+        @DisplayName("Single under 65")
+        void singleUnder65() {
+            BigDecimal deduction = calculator.getStandardDeduction(FilingStatus.SINGLE, 60, 2024);
+            assertEquals(0, new BigDecimal("14600").compareTo(deduction));
+        }
+
+        @Test
+        @DisplayName("Single 65+")
+        void single65Plus() {
+            BigDecimal deduction = calculator.getStandardDeduction(FilingStatus.SINGLE, 67, 2024);
+            // 14600 + 1950 = 16550
+            assertEquals(0, new BigDecimal("16550").compareTo(deduction));
+        }
+
+        @Test
+        @DisplayName("MFJ both under 65")
+        void mfjBothUnder65() {
+            BigDecimal deduction = calculator.getStandardDeductionMfj(60, 58, 2024);
+            assertEquals(0, new BigDecimal("29200").compareTo(deduction));
+        }
+
+        @Test
+        @DisplayName("MFJ one spouse 65+")
+        void mfjOneSpouse65Plus() {
+            BigDecimal deduction = calculator.getStandardDeductionMfj(67, 60, 2024);
+            // 29200 + 1550 = 30750
+            assertEquals(0, new BigDecimal("30750").compareTo(deduction));
+        }
+
+        @Test
+        @DisplayName("MFJ both 65+")
+        void mfjBoth65Plus() {
+            BigDecimal deduction = calculator.getStandardDeductionMfj(67, 68, 2024);
+            // 29200 + 1550 + 1550 = 32300
+            assertEquals(0, new BigDecimal("32300").compareTo(deduction));
+        }
+    }
+
+    @Nested
+    @DisplayName("Tax Calculation Tests")
+    class TaxCalculationTests {
+
+        @Test
+        @DisplayName("Single $50K income")
+        void single50kIncome() {
+            TaxCalculationResult result = calculator.calculateTax(
+                new BigDecimal("50000"), FilingStatus.SINGLE, 60, 2024);
+
+            assertTrue(result.hasTaxLiability());
+            // Taxable: 50000 - 14600 = 35400
+            assertEquals(0, new BigDecimal("35400").compareTo(result.taxableIncome()));
+        }
+
+        @Test
+        @DisplayName("Zero taxable income returns no tax")
+        void zeroTaxableIncomeNoTax() {
+            TaxCalculationResult result = calculator.calculateTax(
+                new BigDecimal("10000"), FilingStatus.SINGLE, 60, 2024);
+
+            assertFalse(result.hasTaxLiability());
+            assertEquals(0, BigDecimal.ZERO.compareTo(result.federalTax()));
+        }
+
+        @Test
+        @DisplayName("Tax calculation with bracket breakdown")
+        void taxWithBracketBreakdown() {
+            TaxCalculationResult result = calculator.calculateTax(
+                new BigDecimal("75000"), FilingStatus.SINGLE, 60, 2024);
+
+            // Taxable: 75000 - 14600 = 60400
+            assertEquals(0, new BigDecimal("60400").compareTo(result.taxableIncome()));
+
+            // Should have entries in 10%, 12%, and 22% brackets
+            assertTrue(result.bracketBreakdown().size() >= 3);
+        }
+    }
+
+    @Nested
+    @DisplayName("Marginal Rate Tests")
+    class MarginalRateTests {
+
+        @Test
+        @DisplayName("Income in 10% bracket")
+        void incomeIn10Bracket() {
+            BigDecimal rate = calculator.getMarginalTaxRate(
+                new BigDecimal("10000"), FilingStatus.SINGLE, 2024);
+            assertEquals(0, new BigDecimal("0.10").compareTo(rate));
+        }
+
+        @Test
+        @DisplayName("Income in 22% bracket")
+        void incomeIn22Bracket() {
+            BigDecimal rate = calculator.getMarginalTaxRate(
+                new BigDecimal("60000"), FilingStatus.SINGLE, 2024);
+            assertEquals(0, new BigDecimal("0.22").compareTo(rate));
+        }
+
+        @Test
+        @DisplayName("Income in top bracket")
+        void incomeInTopBracket() {
+            BigDecimal rate = calculator.getMarginalTaxRate(
+                new BigDecimal("700000"), FilingStatus.SINGLE, 2024);
+            assertEquals(0, new BigDecimal("0.37").compareTo(rate));
+        }
+    }
+
+    @Nested
+    @DisplayName("Chained CPI Projection Tests")
+    class ChainedCpiTests {
+
+        @Test
+        @DisplayName("Project value to future year")
+        void projectToFutureYear() {
+            // Base: 14600, 2.5% for 5 years = 14600 * 1.025^5 ≈ 16522
+            BigDecimal projected = calculator.projectValueWithChainedCpi(
+                new BigDecimal("14600"), 2024, 2029);
+
+            // Should be rounded to nearest $50
+            assertTrue(projected.remainder(new BigDecimal("50")).compareTo(BigDecimal.ZERO) == 0);
+            assertTrue(projected.compareTo(new BigDecimal("14600")) > 0);
+        }
+
+        @Test
+        @DisplayName("Same year returns rounded base value")
+        void sameYearReturnsBase() {
+            BigDecimal projected = calculator.projectValueWithChainedCpi(
+                new BigDecimal("14600"), 2024, 2024);
+            assertEquals(0, new BigDecimal("14600").compareTo(projected));
+        }
+    }
+
+    @Nested
+    @DisplayName("Tax Bracket Tests")
+    class TaxBracketTests {
+
+        @Test
+        @DisplayName("Get brackets for single filer")
+        void getBracketsForSingle() {
+            List<TaxBracket> brackets = calculator.getBrackets(FilingStatus.SINGLE, 2024);
+            assertEquals(7, brackets.size());
+
+            // First bracket is 10%
+            assertEquals(0, new BigDecimal("0.10").compareTo(brackets.getFirst().rate()));
+
+            // Last bracket is 37% with no upper bound
+            assertTrue(brackets.getLast().isTopBracket());
+            assertEquals(0, new BigDecimal("0.37").compareTo(brackets.getLast().rate()));
+        }
+
+        @Test
+        @DisplayName("Brackets are progressive")
+        void bracketsAreProgressive() {
+            List<TaxBracket> brackets = calculator.getBrackets(FilingStatus.SINGLE, 2024);
+
+            for (int i = 1; i < brackets.size(); i++) {
+                assertTrue(brackets.get(i).rate().compareTo(brackets.get(i - 1).rate()) > 0);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("MFJ Calculation Tests")
+    class MfjCalculationTests {
+
+        @Test
+        @DisplayName("MFJ $100K income both under 65")
+        void mfj100kBothUnder65() {
+            TaxCalculationResult result = calculator.calculateTaxMfj(
+                new BigDecimal("100000"), 60, 58, 2024);
+
+            // Taxable: 100000 - 29200 = 70800
+            assertEquals(0, new BigDecimal("70800").compareTo(result.taxableIncome()));
+            assertEquals(FilingStatus.MARRIED_FILING_JOINTLY, result.filingStatus());
+        }
+    }
+
+    private FederalTaxRules createTestRules() {
+        FederalTaxRules testRules = new FederalTaxRules();
+        testRules.setBaseYear(2024);
+        testRules.setChainedCpiRate(new BigDecimal("0.025"));
+
+        // Standard deductions
+        testRules.setStandardDeductions(Map.of(
+            FilingStatus.SINGLE, new BigDecimal("14600"),
+            FilingStatus.MARRIED_FILING_JOINTLY, new BigDecimal("29200"),
+            FilingStatus.HEAD_OF_HOUSEHOLD, new BigDecimal("21900")
+        ));
+
+        // Age 65+ additional
+        testRules.setAge65Additional(Map.of(
+            FilingStatus.SINGLE, new BigDecimal("1950"),
+            FilingStatus.MARRIED_FILING_JOINTLY, new BigDecimal("1550"),
+            FilingStatus.HEAD_OF_HOUSEHOLD, new BigDecimal("1950")
+        ));
+
+        // Single brackets
+        testRules.setBrackets(Map.of(
+            FilingStatus.SINGLE, createSingleBrackets()
+        ));
+
+        return testRules;
+    }
+
+    private List<BracketConfig> createSingleBrackets() {
+        return List.of(
+            createBracket("0.10", "11600"),
+            createBracket("0.12", "47150"),
+            createBracket("0.22", "100525"),
+            createBracket("0.24", "191950"),
+            createBracket("0.32", "243725"),
+            createBracket("0.35", "609350"),
+            createBracketNoUpper("0.37")
+        );
+    }
+
+    private BracketConfig createBracket(String rate, String upperBound) {
+        BracketConfig config = new BracketConfig();
+        config.setRate(new BigDecimal(rate));
+        config.setUpperBound(new BigDecimal(upperBound));
+        return config;
+    }
+
+    private BracketConfig createBracketNoUpper(String rate) {
+        BracketConfig config = new BracketConfig();
+        config.setRate(new BigDecimal(rate));
+        return config;
+    }
+}


### PR DESCRIPTION
## Summary
- Add federal income tax calculator with progressive tax brackets (10%-37%)
- Support chained CPI indexing for future year projections (IRS bracket adjustments)
- Implement standard deductions with age 65+ additional amounts
- Apply IRS $50 rounding rules for bracket thresholds
- Support all filing statuses: Single, MFJ, MFS, HOH

## Implementation Details

### New Files
| File | Purpose |
|------|---------|
| `FederalTaxRules.java` | Spring configuration for tax brackets, deductions, and CPI rate |
| `FederalTaxCalculator.java` | Interface for tax calculations |
| `DefaultFederalTaxCalculator.java` | Implementation with chained CPI projection |
| `TaxBracket.java` | Record for bracket definition with income calculation methods |
| `TaxCalculationResult.java` | Result record with bracket-by-bracket breakdown |
| `application-federal-tax.yml` | 2024 tax brackets for all filing statuses |

### Key Features
- **Chained CPI**: Projects tax brackets to future years at ~2.5% (configurable)
- **Age 65+ deduction**: Additional standard deduction for seniors
- **Bracket breakdown**: Shows tax computed in each bracket
- **Effective/marginal rates**: Both rates returned in results

## Test Plan
- [x] Standard deduction tests (single, MFJ, age variations)
- [x] Tax calculation with bracket breakdown
- [x] Marginal rate identification
- [x] Chained CPI projection tests
- [x] Zero taxable income scenarios

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)