### PR TITLE
feat(#249): Create SimulationView interface and AccountSnapshot record

### DIFF
--- a/src/main/java/io/github/xmljim/retirement/domain/calculator/SimulationView.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/calculator/SimulationView.java
@@ -1,0 +1,139 @@
+package io.github.xmljim.retirement.domain.calculator;
+
+import java.math.BigDecimal;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import io.github.xmljim.retirement.domain.value.AccountSnapshot;
+
+/**
+ * Read-only view of simulation state for strategy calculations.
+ *
+ * <p>This interface is the <b>contract between M6 (Distribution Strategies) and M7
+ * (Simulation Engine)</b>. Strategies consume this interface to access current
+ * portfolio state and historical data without coupling to simulation internals.
+ *
+ * <p>The simulation engine implements this interface, backed by its internal
+ * account balances and TimeSeries history. Strategies can query what they need
+ * without knowing how the data is stored or managed.
+ *
+ * <h2>Design Rationale</h2>
+ *
+ * <p>By separating state ownership (simulation) from state consumption (strategies),
+ * we achieve:
+ * <ul>
+ *   <li><b>Clean separation of concerns</b> - Simulation owns state, strategies are pure calculators</li>
+ *   <li><b>Simulation mode agnosticism</b> - Same strategy code works for deterministic,
+ *       Monte Carlo, and historical backtesting modes</li>
+ *   <li><b>Testability</b> - Strategies can be unit tested with mock/stub implementations</li>
+ *   <li><b>Monte Carlo support</b> - Each run has fresh history; no strategy state to snapshot/restore</li>
+ * </ul>
+ *
+ * <h2>Usage</h2>
+ *
+ * <p>Strategies access this view through {@code SpendingContext.simulation()}:
+ * <pre>{@code
+ * public SpendingPlan calculateWithdrawal(SpendingContext context) {
+ *     BigDecimal currentBalance = context.simulation().getTotalPortfolioBalance();
+ *     BigDecimal priorSpending = context.simulation().getPriorYearSpending();
+ *     // ... calculate withdrawal
+ * }
+ * }</pre>
+ *
+ * @see SpendingStrategy
+ * @see io.github.xmljim.retirement.domain.value.SpendingContext
+ * @see AccountSnapshot
+ */
+public interface SimulationView {
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Current State (as of this simulation step)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Returns the current balance of a specific account.
+     *
+     * @param accountId the account's unique identifier
+     * @return the current balance, or {@link BigDecimal#ZERO} if account not found
+     */
+    BigDecimal getAccountBalance(UUID accountId);
+
+    /**
+     * Returns the total portfolio balance across all accounts.
+     *
+     * @return the sum of all account balances
+     */
+    BigDecimal getTotalPortfolioBalance();
+
+    /**
+     * Returns read-only snapshots of all accounts with current balances.
+     *
+     * <p>This is the primary method for strategies and sequencers to access
+     * account information. The snapshots are immutable and contain all info
+     * needed for withdrawal calculations.
+     *
+     * @return unmodifiable list of account snapshots
+     */
+    List<AccountSnapshot> getAccountSnapshots();
+
+    /**
+     * Returns the portfolio balance at retirement start.
+     *
+     * <p>Used by Static (4%) strategy to calculate base withdrawal amount.
+     *
+     * @return the initial portfolio balance
+     */
+    BigDecimal getInitialPortfolioBalance();
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Historical Queries (for dynamic strategies)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Returns total spending (withdrawals) in the prior calendar year.
+     *
+     * <p>Used by Guardrails strategies to calculate spending adjustments.
+     *
+     * @return prior year spending, or {@link BigDecimal#ZERO} if first year
+     */
+    BigDecimal getPriorYearSpending();
+
+    /**
+     * Returns the portfolio return percentage for the prior calendar year.
+     *
+     * <p>Used by dynamic strategies to determine if spending adjustments
+     * are warranted.
+     *
+     * @return prior year return as a decimal (e.g., 0.08 for 8%), or
+     *         {@link BigDecimal#ZERO} if first year
+     */
+    BigDecimal getPriorYearReturn();
+
+    /**
+     * Finds the month when a spending ratchet last occurred.
+     *
+     * <p>Used by Kitces Ratcheting strategy to enforce minimum years between
+     * spending increases.
+     *
+     * @return the month of last ratchet, or empty if no ratchet has occurred
+     */
+    Optional<YearMonth> getLastRatchetMonth();
+
+    /**
+     * Returns cumulative withdrawals since retirement start.
+     *
+     * @return total withdrawals across all periods
+     */
+    BigDecimal getCumulativeWithdrawals();
+
+    /**
+     * Returns the highest portfolio balance achieved (high water mark).
+     *
+     * <p>Used for drawdown calculations and some dynamic strategies.
+     *
+     * @return the maximum portfolio balance observed
+     */
+    BigDecimal getHighWaterMarkBalance();
+}

--- a/src/main/java/io/github/xmljim/retirement/domain/value/AccountSnapshot.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/value/AccountSnapshot.java
@@ -1,0 +1,130 @@
+package io.github.xmljim.retirement.domain.value;
+
+import java.math.BigDecimal;
+
+import io.github.xmljim.retirement.domain.enums.AccountType;
+import io.github.xmljim.retirement.domain.exception.MissingRequiredFieldException;
+import io.github.xmljim.retirement.domain.model.InvestmentAccount;
+
+/**
+ * Immutable snapshot of an account's state at a point in time.
+ *
+ * <p>This record provides read-only access to account information needed by
+ * spending strategies and account sequencers. It serves as the boundary between
+ * the simulation engine (which owns mutable account state) and the strategy layer
+ * (which needs to query account information).
+ *
+ * <p>AccountSnapshot contains all information needed for withdrawal calculations:
+ * <ul>
+ *   <li>Account identification (id, name, type)</li>
+ *   <li>Current balance</li>
+ *   <li>Tax treatment for withdrawal sequencing</li>
+ *   <li>RMD eligibility for RMD-first sequencing</li>
+ *   <li>Asset allocation for bucket strategies</li>
+ * </ul>
+ *
+ * <h2>Usage</h2>
+ *
+ * <p>Create from an InvestmentAccount using the factory method:
+ * <pre>{@code
+ * InvestmentAccount account = ...;
+ * AccountSnapshot snapshot = AccountSnapshot.from(account);
+ * }</pre>
+ *
+ * <p>Access via SimulationView in strategies:
+ * <pre>{@code
+ * List<AccountSnapshot> accounts = context.simulation().getAccountSnapshots();
+ * for (AccountSnapshot account : accounts) {
+ *     if (account.subjectToRmd()) {
+ *         // Handle RMD account
+ *     }
+ * }
+ * }</pre>
+ *
+ * @param accountId unique identifier for the account
+ * @param accountName human-readable account name
+ * @param accountType the type of account (determines tax treatment, RMD rules)
+ * @param balance current account balance
+ * @param taxTreatment tax treatment for withdrawals
+ * @param subjectToRmd whether account is subject to Required Minimum Distributions
+ * @param allocation asset allocation (stocks/bonds/cash)
+ *
+ * @see io.github.xmljim.retirement.domain.calculator.SimulationView
+ * @see io.github.xmljim.retirement.domain.calculator.AccountSequencer
+ */
+public record AccountSnapshot(
+        String accountId,
+        String accountName,
+        AccountType accountType,
+        BigDecimal balance,
+        AccountType.TaxTreatment taxTreatment,
+        boolean subjectToRmd,
+        AssetAllocation allocation
+) {
+
+    /**
+     * Compact constructor with validation.
+     */
+    public AccountSnapshot {
+        MissingRequiredFieldException.requireNonNull(accountId, "accountId");
+        MissingRequiredFieldException.requireNonNull(accountName, "accountName");
+        MissingRequiredFieldException.requireNonNull(accountType, "accountType");
+        MissingRequiredFieldException.requireNonNull(balance, "balance");
+        MissingRequiredFieldException.requireNonNull(taxTreatment, "taxTreatment");
+        MissingRequiredFieldException.requireNonNull(allocation, "allocation");
+    }
+
+    /**
+     * Creates an AccountSnapshot from an InvestmentAccount.
+     *
+     * <p>This is the primary way to create snapshots. The snapshot captures
+     * the account's current state at the moment of creation.
+     *
+     * @param account the investment account to snapshot
+     * @return a new AccountSnapshot with the account's current state
+     * @throws MissingRequiredFieldException if account is null
+     */
+    public static AccountSnapshot from(InvestmentAccount account) {
+        MissingRequiredFieldException.requireNonNull(account, "account");
+
+        return new AccountSnapshot(
+                account.getId(),
+                account.getName(),
+                account.getAccountType(),
+                account.getBalance(),
+                account.getAccountType().getTaxTreatment(),
+                account.getAccountType().isSubjectToRmd(),
+                account.getAllocation()
+        );
+    }
+
+    /**
+     * Returns whether this account has a positive balance.
+     *
+     * @return true if balance is greater than zero
+     */
+    public boolean hasBalance() {
+        return balance.compareTo(BigDecimal.ZERO) > 0;
+    }
+
+    /**
+     * Returns whether withdrawals from this account are taxable.
+     *
+     * <p>Pre-tax accounts (Traditional 401k, Traditional IRA) have taxable
+     * withdrawals. Roth and HSA (for qualified expenses) do not.
+     *
+     * @return true if withdrawals are taxable as ordinary income
+     */
+    public boolean isTaxable() {
+        return taxTreatment == AccountType.TaxTreatment.PRE_TAX;
+    }
+
+    /**
+     * Returns whether this is an employer-sponsored account.
+     *
+     * @return true if employer-sponsored (401k, 403b, 457b)
+     */
+    public boolean isEmployerSponsored() {
+        return accountType.isEmployerSponsored();
+    }
+}

--- a/src/test/java/io/github/xmljim/retirement/domain/value/AccountSnapshotTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/value/AccountSnapshotTest.java
@@ -1,0 +1,367 @@
+package io.github.xmljim.retirement.domain.value;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.github.xmljim.retirement.domain.enums.AccountType;
+import io.github.xmljim.retirement.domain.exception.MissingRequiredFieldException;
+import io.github.xmljim.retirement.domain.model.InvestmentAccount;
+
+@DisplayName("AccountSnapshot Tests")
+class AccountSnapshotTest {
+
+    private InvestmentAccount traditional401k;
+    private InvestmentAccount rothIra;
+    private InvestmentAccount hsa;
+    private InvestmentAccount taxableBrokerage;
+    private AssetAllocation defaultAllocation;
+
+    @BeforeEach
+    void setUp() {
+        defaultAllocation = AssetAllocation.of(60, 35, 5);
+
+        traditional401k = InvestmentAccount.builder()
+                .name("My 401(k)")
+                .accountType(AccountType.TRADITIONAL_401K)
+                .balance(new BigDecimal("500000.00"))
+                .allocation(defaultAllocation)
+                .preRetirementReturnRate(0.07)
+                .build();
+
+        rothIra = InvestmentAccount.builder()
+                .name("Roth IRA")
+                .accountType(AccountType.ROTH_IRA)
+                .balance(new BigDecimal("150000.00"))
+                .allocation(AssetAllocation.of(70, 25, 5))
+                .preRetirementReturnRate(0.08)
+                .build();
+
+        hsa = InvestmentAccount.builder()
+                .name("Health Savings")
+                .accountType(AccountType.HSA)
+                .balance(new BigDecimal("25000.00"))
+                .allocation(AssetAllocation.of(50, 40, 10))
+                .preRetirementReturnRate(0.06)
+                .build();
+
+        taxableBrokerage = InvestmentAccount.builder()
+                .name("Brokerage")
+                .accountType(AccountType.TAXABLE_BROKERAGE)
+                .balance(new BigDecimal("100000.00"))
+                .allocation(AssetAllocation.of(80, 15, 5))
+                .preRetirementReturnRate(0.07)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("Factory Method Tests")
+    class FactoryMethodTests {
+
+        @Test
+        @DisplayName("Should create snapshot from Traditional 401k")
+        void createsFromTraditional401k() {
+            AccountSnapshot snapshot = AccountSnapshot.from(traditional401k);
+
+            assertEquals(traditional401k.getId(), snapshot.accountId());
+            assertEquals("My 401(k)", snapshot.accountName());
+            assertEquals(AccountType.TRADITIONAL_401K, snapshot.accountType());
+            assertEquals(0, new BigDecimal("500000.00").compareTo(snapshot.balance()));
+            assertEquals(AccountType.TaxTreatment.PRE_TAX, snapshot.taxTreatment());
+            assertTrue(snapshot.subjectToRmd());
+            assertEquals(defaultAllocation, snapshot.allocation());
+        }
+
+        @Test
+        @DisplayName("Should create snapshot from Roth IRA")
+        void createsFromRothIra() {
+            AccountSnapshot snapshot = AccountSnapshot.from(rothIra);
+
+            assertEquals(AccountType.ROTH_IRA, snapshot.accountType());
+            assertEquals(AccountType.TaxTreatment.ROTH, snapshot.taxTreatment());
+            assertFalse(snapshot.subjectToRmd());
+        }
+
+        @Test
+        @DisplayName("Should create snapshot from HSA")
+        void createsFromHsa() {
+            AccountSnapshot snapshot = AccountSnapshot.from(hsa);
+
+            assertEquals(AccountType.HSA, snapshot.accountType());
+            assertEquals(AccountType.TaxTreatment.HSA, snapshot.taxTreatment());
+            assertFalse(snapshot.subjectToRmd());
+        }
+
+        @Test
+        @DisplayName("Should create snapshot from Taxable Brokerage")
+        void createsFromTaxableBrokerage() {
+            AccountSnapshot snapshot = AccountSnapshot.from(taxableBrokerage);
+
+            assertEquals(AccountType.TAXABLE_BROKERAGE, snapshot.accountType());
+            assertEquals(AccountType.TaxTreatment.TAXABLE, snapshot.taxTreatment());
+            assertFalse(snapshot.subjectToRmd());
+        }
+
+        @Test
+        @DisplayName("Should throw for null account")
+        void throwsForNullAccount() {
+            assertThrows(MissingRequiredFieldException.class, () ->
+                    AccountSnapshot.from(null));
+        }
+    }
+
+    @Nested
+    @DisplayName("Direct Construction Tests")
+    class DirectConstructionTests {
+
+        @Test
+        @DisplayName("Should create valid snapshot with constructor")
+        void createsWithConstructor() {
+            AccountSnapshot snapshot = new AccountSnapshot(
+                    "test-id",
+                    "Test Account",
+                    AccountType.TRADITIONAL_IRA,
+                    new BigDecimal("100000"),
+                    AccountType.TaxTreatment.PRE_TAX,
+                    true,
+                    defaultAllocation
+            );
+
+            assertEquals("test-id", snapshot.accountId());
+            assertEquals("Test Account", snapshot.accountName());
+            assertEquals(AccountType.TRADITIONAL_IRA, snapshot.accountType());
+            assertTrue(snapshot.subjectToRmd());
+        }
+
+        @Test
+        @DisplayName("Should throw for null accountId")
+        void throwsForNullAccountId() {
+            assertThrows(MissingRequiredFieldException.class, () ->
+                    new AccountSnapshot(
+                            null,
+                            "Test",
+                            AccountType.TRADITIONAL_IRA,
+                            BigDecimal.ZERO,
+                            AccountType.TaxTreatment.PRE_TAX,
+                            true,
+                            defaultAllocation
+                    ));
+        }
+
+        @Test
+        @DisplayName("Should throw for null accountName")
+        void throwsForNullAccountName() {
+            assertThrows(MissingRequiredFieldException.class, () ->
+                    new AccountSnapshot(
+                            "id",
+                            null,
+                            AccountType.TRADITIONAL_IRA,
+                            BigDecimal.ZERO,
+                            AccountType.TaxTreatment.PRE_TAX,
+                            true,
+                            defaultAllocation
+                    ));
+        }
+
+        @Test
+        @DisplayName("Should throw for null accountType")
+        void throwsForNullAccountType() {
+            assertThrows(MissingRequiredFieldException.class, () ->
+                    new AccountSnapshot(
+                            "id",
+                            "Test",
+                            null,
+                            BigDecimal.ZERO,
+                            AccountType.TaxTreatment.PRE_TAX,
+                            true,
+                            defaultAllocation
+                    ));
+        }
+
+        @Test
+        @DisplayName("Should throw for null balance")
+        void throwsForNullBalance() {
+            assertThrows(MissingRequiredFieldException.class, () ->
+                    new AccountSnapshot(
+                            "id",
+                            "Test",
+                            AccountType.TRADITIONAL_IRA,
+                            null,
+                            AccountType.TaxTreatment.PRE_TAX,
+                            true,
+                            defaultAllocation
+                    ));
+        }
+
+        @Test
+        @DisplayName("Should throw for null taxTreatment")
+        void throwsForNullTaxTreatment() {
+            assertThrows(MissingRequiredFieldException.class, () ->
+                    new AccountSnapshot(
+                            "id",
+                            "Test",
+                            AccountType.TRADITIONAL_IRA,
+                            BigDecimal.ZERO,
+                            null,
+                            true,
+                            defaultAllocation
+                    ));
+        }
+
+        @Test
+        @DisplayName("Should throw for null allocation")
+        void throwsForNullAllocation() {
+            assertThrows(MissingRequiredFieldException.class, () ->
+                    new AccountSnapshot(
+                            "id",
+                            "Test",
+                            AccountType.TRADITIONAL_IRA,
+                            BigDecimal.ZERO,
+                            AccountType.TaxTreatment.PRE_TAX,
+                            true,
+                            null
+                    ));
+        }
+    }
+
+    @Nested
+    @DisplayName("Helper Method Tests")
+    class HelperMethodTests {
+
+        @Test
+        @DisplayName("hasBalance should return true for positive balance")
+        void hasBalancePositive() {
+            AccountSnapshot snapshot = AccountSnapshot.from(traditional401k);
+            assertTrue(snapshot.hasBalance());
+        }
+
+        @Test
+        @DisplayName("hasBalance should return false for zero balance")
+        void hasBalanceZero() {
+            InvestmentAccount emptyAccount = InvestmentAccount.builder()
+                    .name("Empty")
+                    .accountType(AccountType.TRADITIONAL_IRA)
+                    .balance(BigDecimal.ZERO)
+                    .allocation(defaultAllocation)
+                    .preRetirementReturnRate(0.07)
+                    .build();
+
+            AccountSnapshot snapshot = AccountSnapshot.from(emptyAccount);
+            assertFalse(snapshot.hasBalance());
+        }
+
+        @Test
+        @DisplayName("isTaxable should return true for PRE_TAX accounts")
+        void isTaxablePreTax() {
+            AccountSnapshot snapshot = AccountSnapshot.from(traditional401k);
+            assertTrue(snapshot.isTaxable());
+        }
+
+        @Test
+        @DisplayName("isTaxable should return false for Roth accounts")
+        void isTaxableRoth() {
+            AccountSnapshot snapshot = AccountSnapshot.from(rothIra);
+            assertFalse(snapshot.isTaxable());
+        }
+
+        @Test
+        @DisplayName("isTaxable should return false for HSA accounts")
+        void isTaxableHsa() {
+            AccountSnapshot snapshot = AccountSnapshot.from(hsa);
+            assertFalse(snapshot.isTaxable());
+        }
+
+        @Test
+        @DisplayName("isTaxable should return false for Taxable accounts")
+        void isTaxableTaxable() {
+            // Taxable brokerage has TAXABLE treatment, not PRE_TAX
+            AccountSnapshot snapshot = AccountSnapshot.from(taxableBrokerage);
+            assertFalse(snapshot.isTaxable());
+        }
+
+        @Test
+        @DisplayName("isEmployerSponsored should return true for 401k")
+        void isEmployerSponsored401k() {
+            AccountSnapshot snapshot = AccountSnapshot.from(traditional401k);
+            assertTrue(snapshot.isEmployerSponsored());
+        }
+
+        @Test
+        @DisplayName("isEmployerSponsored should return false for IRA")
+        void isEmployerSponsoredIra() {
+            AccountSnapshot snapshot = AccountSnapshot.from(rothIra);
+            assertFalse(snapshot.isEmployerSponsored());
+        }
+    }
+
+    @Nested
+    @DisplayName("RMD Subject Tests")
+    class RmdSubjectTests {
+
+        @Test
+        @DisplayName("Traditional 401k should be subject to RMD")
+        void traditional401kSubjectToRmd() {
+            AccountSnapshot snapshot = AccountSnapshot.from(traditional401k);
+            assertTrue(snapshot.subjectToRmd());
+        }
+
+        @Test
+        @DisplayName("Roth IRA should not be subject to RMD")
+        void rothIraNotSubjectToRmd() {
+            AccountSnapshot snapshot = AccountSnapshot.from(rothIra);
+            assertFalse(snapshot.subjectToRmd());
+        }
+
+        @Test
+        @DisplayName("Traditional IRA should be subject to RMD")
+        void traditionalIraSubjectToRmd() {
+            InvestmentAccount traditionalIra = InvestmentAccount.builder()
+                    .name("Traditional IRA")
+                    .accountType(AccountType.TRADITIONAL_IRA)
+                    .balance(new BigDecimal("100000"))
+                    .allocation(defaultAllocation)
+                    .preRetirementReturnRate(0.07)
+                    .build();
+
+            AccountSnapshot snapshot = AccountSnapshot.from(traditionalIra);
+            assertTrue(snapshot.subjectToRmd());
+        }
+
+        @Test
+        @DisplayName("Roth 401k should be subject to RMD")
+        void roth401kSubjectToRmd() {
+            InvestmentAccount roth401k = InvestmentAccount.builder()
+                    .name("Roth 401(k)")
+                    .accountType(AccountType.ROTH_401K)
+                    .balance(new BigDecimal("100000"))
+                    .allocation(defaultAllocation)
+                    .preRetirementReturnRate(0.07)
+                    .build();
+
+            AccountSnapshot snapshot = AccountSnapshot.from(roth401k);
+            assertTrue(snapshot.subjectToRmd());
+        }
+
+        @Test
+        @DisplayName("HSA should not be subject to RMD")
+        void hsaNotSubjectToRmd() {
+            AccountSnapshot snapshot = AccountSnapshot.from(hsa);
+            assertFalse(snapshot.subjectToRmd());
+        }
+
+        @Test
+        @DisplayName("Taxable brokerage should not be subject to RMD")
+        void taxableBrokerageNotSubjectToRmd() {
+            AccountSnapshot snapshot = AccountSnapshot.from(taxableBrokerage);
+            assertFalse(snapshot.subjectToRmd());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Creates the contract between M6 (Distribution Strategies) and M7 (Simulation Engine) per the Simulation Integration Architecture design.

### SimulationView Interface

Read-only view of simulation state for strategy calculations:

**Current State Methods:**
- `getAccountBalance(UUID)` - balance for specific account
- `getTotalPortfolioBalance()` - sum of all account balances
- `getAccountSnapshots()` - list of immutable account snapshots
- `getInitialPortfolioBalance()` - balance at retirement start

**Historical Queries (for dynamic strategies):**
- `getPriorYearSpending()` - for Guardrails
- `getPriorYearReturn()` - for dynamic adjustments
- `getLastRatchetMonth()` - for Kitces ratcheting
- `getCumulativeWithdrawals()` - total since retirement
- `getHighWaterMarkBalance()` - for drawdown calculations

### AccountSnapshot Record

Immutable snapshot of account state:
- Account identification (id, name, type)
- Current balance
- Tax treatment and RMD eligibility
- Asset allocation
- Factory method `from(InvestmentAccount)`
- Helper methods: `hasBalance()`, `isTaxable()`, `isEmployerSponsored()`

### Benefits

1. **Clean separation** - Simulation owns state, strategies query via interface
2. **Testable** - Strategies can be tested with mock SimulationView
3. **Mode agnostic** - Same strategy code for deterministic/Monte Carlo/historical
4. **Monte Carlo ready** - No strategy state to snapshot/restore

## Test Plan

- [x] AccountSnapshot unit tests (factory method, validation, helper methods, RMD eligibility)
- [x] Build passes (checkstyle, tests, coverage)

## Related

- Closes #249
- Blocks #250 (StubSimulationView)
- Blocks #251 (SpendingContext refactor)
- Design doc: `docs/design/M6_DISTRIBUTION_STRATEGIES.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)