### PR TITLE
refactor(M6a): Refactor SpendingContext to use SimulationView (#251)

### DIFF
--- a/src/main/java/io/github/xmljim/retirement/domain/calculator/SpendingStrategy.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/calculator/SpendingStrategy.java
@@ -23,12 +23,11 @@ import io.github.xmljim.retirement.domain.value.SpendingPlan;
  * <pre>{@code
  * SpendingStrategy strategy = new StaticSpendingStrategy(0.04, 0.025);
  * SpendingContext context = SpendingContext.builder()
- *     .portfolio(portfolio)
+ *     .simulation(simulationView)
  *     .totalExpenses(monthlyExpenses)
  *     .otherIncome(ssIncome.add(pensionIncome))
  *     .date(LocalDate.now())
- *     .yearsInRetirement(5)
- *     .initialPortfolioBalance(initialBalance)
+ *     .retirementStartDate(retirementStart)
  *     .build();
  *
  * SpendingPlan plan = strategy.calculateWithdrawal(context);

--- a/src/test/java/io/github/xmljim/retirement/domain/calculator/TaxEfficientSequencerTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/calculator/TaxEfficientSequencerTest.java
@@ -28,10 +28,12 @@ class TaxEfficientSequencerTest {
     private TaxEfficientSequencer sequencer;
     private PersonProfile owner;
     private SpendingContext context;
+    private LocalDate retirementStart;
 
     @BeforeEach
     void setUp() {
         sequencer = new TaxEfficientSequencer();
+        retirementStart = LocalDate.of(2020, 1, 1);
         owner = PersonProfile.builder()
                 .name("Test Owner")
                 .dateOfBirth(LocalDate.of(1960, 1, 1))
@@ -40,9 +42,15 @@ class TaxEfficientSequencerTest {
     }
 
     private SpendingContext createContext(Portfolio portfolio) {
+        StubSimulationView simulation = StubSimulationView.withAccounts(
+                portfolio.getAccounts().stream()
+                        .map(a -> StubSimulationView.createTestAccount(
+                                a.getName(), a.getAccountType(), a.getBalance()))
+                        .toList());
         return SpendingContext.builder()
-                .portfolio(portfolio)
+                .simulation(simulation)
                 .date(LocalDate.now())
+                .retirementStartDate(retirementStart)
                 .build();
     }
 

--- a/src/test/java/io/github/xmljim/retirement/domain/value/SpendingContextTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/value/SpendingContextTest.java
@@ -12,47 +12,26 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import io.github.xmljim.retirement.domain.calculator.StubSimulationView;
 import io.github.xmljim.retirement.domain.enums.AccountType;
 import io.github.xmljim.retirement.domain.enums.FilingStatus;
 import io.github.xmljim.retirement.domain.exception.MissingRequiredFieldException;
-import io.github.xmljim.retirement.domain.model.InvestmentAccount;
-import io.github.xmljim.retirement.domain.model.PersonProfile;
-import io.github.xmljim.retirement.domain.model.Portfolio;
 
 @DisplayName("SpendingContext Tests")
 class SpendingContextTest {
 
-    private PersonProfile owner;
-    private Portfolio portfolio;
+    private StubSimulationView simulation;
+    private LocalDate retirementStart;
 
     @BeforeEach
     void setUp() {
-        owner = PersonProfile.builder()
-                .name("John Doe")
-                .dateOfBirth(LocalDate.of(1960, 5, 15))
-                .retirementDate(LocalDate.of(2025, 1, 1))
-                .build();
-
-        InvestmentAccount account401k = InvestmentAccount.builder()
-                .name("401(k)")
-                .accountType(AccountType.TRADITIONAL_401K)
-                .balance(new BigDecimal("500000"))
-                .allocation(AssetAllocation.of(60, 35, 5))
-                .preRetirementReturnRate(0.07)
-                .build();
-
-        InvestmentAccount rothIra = InvestmentAccount.builder()
-                .name("Roth IRA")
-                .accountType(AccountType.ROTH_IRA)
-                .balance(new BigDecimal("200000"))
-                .allocation(AssetAllocation.of(70, 25, 5))
-                .preRetirementReturnRate(0.08)
-                .build();
-
-        portfolio = Portfolio.builder()
-                .owner(owner)
-                .addAccount(account401k)
-                .addAccount(rothIra)
+        retirementStart = LocalDate.of(2024, 1, 1);
+        simulation = StubSimulationView.builder()
+                .addAccount(StubSimulationView.createTestAccount(
+                        "401(k)", AccountType.TRADITIONAL_401K, new BigDecimal("500000")))
+                .addAccount(StubSimulationView.createTestAccount(
+                        "Roth IRA", AccountType.ROTH_IRA, new BigDecimal("200000")))
+                .initialPortfolioBalance(new BigDecimal("750000"))
                 .build();
     }
 
@@ -63,22 +42,20 @@ class SpendingContextTest {
         @Test
         @DisplayName("Should create valid context with builder")
         void createsValidContext() {
-            LocalDate retirementStart = LocalDate.of(2024, 1, 1);
             LocalDate currentDate = LocalDate.of(2026, 6, 1); // 29 months after retirement
 
             SpendingContext context = SpendingContext.builder()
-                    .portfolio(portfolio)
+                    .simulation(simulation)
                     .totalExpenses(new BigDecimal("6000.00"))
                     .otherIncome(new BigDecimal("3000.00"))
                     .date(currentDate)
                     .age(66)
                     .birthYear(1960)
                     .retirementStartDate(retirementStart)
-                    .initialPortfolioBalance(new BigDecimal("750000.00"))
                     .filingStatus(FilingStatus.MARRIED_FILING_JOINTLY)
                     .build();
 
-            assertEquals(portfolio, context.portfolio());
+            assertEquals(simulation, context.simulation());
             assertEquals(0, new BigDecimal("6000.00").compareTo(context.totalExpenses()));
             assertEquals(0, new BigDecimal("3000.00").compareTo(context.otherIncome()));
             assertEquals(currentDate, context.date());
@@ -86,7 +63,7 @@ class SpendingContextTest {
             assertEquals(1960, context.birthYear());
             assertEquals(retirementStart, context.retirementStartDate());
             assertEquals(29, context.monthsInRetirement());
-            assertEquals(2, context.yearsInRetirement()); // 29 / 12 = 2
+            assertEquals(2, context.yearsInRetirement());
             assertEquals(FilingStatus.MARRIED_FILING_JOINTLY, context.filingStatus());
         }
 
@@ -94,94 +71,43 @@ class SpendingContextTest {
         @DisplayName("Should default amounts to zero")
         void defaultsAmountsToZero() {
             SpendingContext context = SpendingContext.builder()
-                    .portfolio(portfolio)
+                    .simulation(simulation)
                     .date(LocalDate.now())
+                    .retirementStartDate(retirementStart)
                     .build();
 
             assertEquals(0, BigDecimal.ZERO.compareTo(context.totalExpenses()));
             assertEquals(0, BigDecimal.ZERO.compareTo(context.otherIncome()));
-            assertEquals(0, BigDecimal.ZERO.compareTo(context.priorYearSpending()));
-            assertEquals(0, BigDecimal.ZERO.compareTo(context.priorYearPortfolioReturn()));
             assertEquals(0, BigDecimal.ZERO.compareTo(context.currentTaxableIncome()));
-        }
-
-        @Test
-        @DisplayName("Should default initial balance to portfolio balance")
-        void defaultsInitialBalance() {
-            SpendingContext context = SpendingContext.builder()
-                    .portfolio(portfolio)
-                    .date(LocalDate.now())
-                    .build();
-
-            assertEquals(0, portfolio.getTotalBalance().compareTo(context.initialPortfolioBalance()));
-        }
-
-        @Test
-        @DisplayName("Should default retirementStartDate from portfolio owner")
-        void defaultsRetirementStartDate() {
-            SpendingContext context = SpendingContext.builder()
-                    .portfolio(portfolio)
-                    .date(LocalDate.of(2027, 1, 1))
-                    .build();
-
-            // Should default to owner's retirement date (2025-01-01)
-            assertEquals(LocalDate.of(2025, 1, 1), context.retirementStartDate());
-            // 24 months between 2025-01-01 and 2027-01-01
-            assertEquals(24, context.monthsInRetirement());
-            assertEquals(2, context.yearsInRetirement());
-        }
-
-        @Test
-        @DisplayName("Should allow overriding retirementStartDate for scenario analysis")
-        void allowsRetirementStartDateOverride() {
-            // Portfolio owner's retirement date is 2025-01-01
-            // But we want to model "what if I retired in 2023 instead?"
-            LocalDate scenarioRetirement = LocalDate.of(2023, 1, 1);
-
-            SpendingContext context = SpendingContext.builder()
-                    .portfolio(portfolio)
-                    .date(LocalDate.of(2027, 1, 1))
-                    .retirementStartDate(scenarioRetirement)
-                    .build();
-
-            assertEquals(scenarioRetirement, context.retirementStartDate());
-            // 48 months between 2023-01-01 and 2027-01-01
-            assertEquals(48, context.monthsInRetirement());
-            assertEquals(4, context.yearsInRetirement());
         }
 
         @Test
         @DisplayName("Should support strategy params")
         void supportsStrategyParams() {
             SpendingContext context = SpendingContext.builder()
-                    .portfolio(portfolio)
+                    .simulation(simulation)
                     .date(LocalDate.now())
+                    .retirementStartDate(retirementStart)
                     .addStrategyParam("upperGuardrail", new BigDecimal("0.05"))
                     .addStrategyParam("lowerGuardrail", new BigDecimal("0.03"))
                     .build();
 
-            assertEquals(
-                    new BigDecimal("0.05"),
-                    context.getStrategyParam("upperGuardrail", BigDecimal.ZERO)
-            );
-            assertEquals(
-                    new BigDecimal("0.03"),
-                    context.getStrategyParam("lowerGuardrail", BigDecimal.ZERO)
-            );
+            assertEquals(new BigDecimal("0.05"),
+                    context.getStrategyParam("upperGuardrail", BigDecimal.ZERO));
+            assertEquals(new BigDecimal("0.03"),
+                    context.getStrategyParam("lowerGuardrail", BigDecimal.ZERO));
         }
 
         @Test
         @DisplayName("Should return default for missing strategy param")
         void returnsDefaultForMissingParam() {
             SpendingContext context = SpendingContext.builder()
-                    .portfolio(portfolio)
+                    .simulation(simulation)
                     .date(LocalDate.now())
+                    .retirementStartDate(retirementStart)
                     .build();
 
-            assertEquals(
-                    "default",
-                    context.getStrategyParam("nonexistent", "default")
-            );
+            assertEquals("default", context.getStrategyParam("nonexistent", "default"));
         }
     }
 
@@ -190,11 +116,12 @@ class SpendingContextTest {
     class ValidationTests {
 
         @Test
-        @DisplayName("Should throw for null portfolio")
-        void nullPortfolioThrows() {
+        @DisplayName("Should throw for null simulation")
+        void nullSimulationThrows() {
             assertThrows(MissingRequiredFieldException.class, () ->
                     SpendingContext.builder()
                             .date(LocalDate.now())
+                            .retirementStartDate(retirementStart)
                             .build());
         }
 
@@ -203,7 +130,18 @@ class SpendingContextTest {
         void nullDateThrows() {
             assertThrows(MissingRequiredFieldException.class, () ->
                     SpendingContext.builder()
-                            .portfolio(portfolio)
+                            .simulation(simulation)
+                            .retirementStartDate(retirementStart)
+                            .build());
+        }
+
+        @Test
+        @DisplayName("Should throw for null retirementStartDate")
+        void nullRetirementStartDateThrows() {
+            assertThrows(MissingRequiredFieldException.class, () ->
+                    SpendingContext.builder()
+                            .simulation(simulation)
+                            .date(LocalDate.now())
                             .build());
         }
     }
@@ -216,13 +154,13 @@ class SpendingContextTest {
         @DisplayName("Should calculate positive income gap")
         void calculatesPositiveGap() {
             SpendingContext context = SpendingContext.builder()
-                    .portfolio(portfolio)
+                    .simulation(simulation)
                     .totalExpenses(new BigDecimal("6000.00"))
                     .otherIncome(new BigDecimal("4000.00"))
                     .date(LocalDate.now())
+                    .retirementStartDate(retirementStart)
                     .build();
 
-            // Gap = 6000 - 4000 = 2000
             assertEquals(0, new BigDecimal("2000.00").compareTo(context.incomeGap()));
         }
 
@@ -230,14 +168,43 @@ class SpendingContextTest {
         @DisplayName("Should return zero when income exceeds expenses")
         void returnsZeroWhenIncomeExceeds() {
             SpendingContext context = SpendingContext.builder()
-                    .portfolio(portfolio)
+                    .simulation(simulation)
                     .totalExpenses(new BigDecimal("4000.00"))
                     .otherIncome(new BigDecimal("6000.00"))
                     .date(LocalDate.now())
+                    .retirementStartDate(retirementStart)
                     .build();
 
-            // Gap should be zero, not negative
             assertEquals(0, BigDecimal.ZERO.compareTo(context.incomeGap()));
+        }
+    }
+
+    @Nested
+    @DisplayName("Portfolio Balance Tests")
+    class PortfolioBalanceTests {
+
+        @Test
+        @DisplayName("Should delegate current balance to simulation")
+        void delegatesCurrentBalance() {
+            SpendingContext context = SpendingContext.builder()
+                    .simulation(simulation)
+                    .date(LocalDate.now())
+                    .retirementStartDate(retirementStart)
+                    .build();
+
+            assertEquals(0, new BigDecimal("700000").compareTo(context.currentPortfolioBalance()));
+        }
+
+        @Test
+        @DisplayName("Should delegate initial balance to simulation")
+        void delegatesInitialBalance() {
+            SpendingContext context = SpendingContext.builder()
+                    .simulation(simulation)
+                    .date(LocalDate.now())
+                    .retirementStartDate(retirementStart)
+                    .build();
+
+            assertEquals(0, new BigDecimal("750000").compareTo(context.initialPortfolioBalance()));
         }
     }
 
@@ -246,30 +213,35 @@ class SpendingContextTest {
     class WithdrawalRateTests {
 
         @Test
-        @DisplayName("Should calculate current withdrawal rate")
+        @DisplayName("Should calculate current withdrawal rate from simulation")
         void calculatesWithdrawalRate() {
+            StubSimulationView simWithHistory = StubSimulationView.builder()
+                    .addAccount(StubSimulationView.createTestAccount(
+                            "401(k)", AccountType.TRADITIONAL_401K, new BigDecimal("700000")))
+                    .priorYearSpending(new BigDecimal("28000"))
+                    .build();
+
             SpendingContext context = SpendingContext.builder()
-                    .portfolio(portfolio)
+                    .simulation(simWithHistory)
                     .date(LocalDate.now())
-                    .priorYearSpending(new BigDecimal("28000.00"))
+                    .retirementStartDate(retirementStart)
                     .build();
 
             // Rate = 28000 / 700000 = 0.04 (4%)
-            BigDecimal rate = context.currentWithdrawalRate();
-            assertEquals(0, new BigDecimal("0.0400").compareTo(rate));
+            assertEquals(0, new BigDecimal("0.0400").compareTo(context.currentWithdrawalRate()));
         }
 
         @Test
         @DisplayName("Should return zero rate for zero balance")
         void returnsZeroRateForZeroBalance() {
-            Portfolio emptyPortfolio = Portfolio.builder()
-                    .owner(owner)
+            StubSimulationView emptySim = StubSimulationView.builder()
+                    .priorYearSpending(new BigDecimal("28000"))
                     .build();
 
             SpendingContext context = SpendingContext.builder()
-                    .portfolio(emptyPortfolio)
+                    .simulation(emptySim)
                     .date(LocalDate.now())
-                    .priorYearSpending(new BigDecimal("28000.00"))
+                    .retirementStartDate(retirementStart)
                     .build();
 
             assertEquals(0, BigDecimal.ZERO.compareTo(context.currentWithdrawalRate()));
@@ -284,15 +256,15 @@ class SpendingContextTest {
         @DisplayName("Strategy params map should be unmodifiable")
         void strategyParamsUnmodifiable() {
             SpendingContext context = SpendingContext.builder()
-                    .portfolio(portfolio)
+                    .simulation(simulation)
                     .date(LocalDate.now())
+                    .retirementStartDate(retirementStart)
                     .strategyParams(Map.of("key", "value"))
                     .build();
 
             var params = context.strategyParams();
             assertThrows(UnsupportedOperationException.class, () ->
-                    params.put("newKey", "newValue")
-            );
+                    params.put("newKey", "newValue"));
         }
     }
 }


### PR DESCRIPTION
## Summary

- Refactors `SpendingContext` to use `SimulationView` interface instead of direct `Portfolio` reference
- Removes embedded historical fields (`priorYearSpending`, `priorYearPortfolioReturn`, etc.) - these are now accessed via `SimulationView`
- Makes `retirementStartDate` a required field
- Updates all affected tests to use `StubSimulationView`

## Changes

### SpendingContext.java
- Removed: `portfolio`, `priorYearSpending`, `priorYearPortfolioReturn`, `yearsSinceLastRatchet`, `initialPortfolioBalance` fields
- Added: `SimulationView simulation` field
- Updated convenience methods (`currentPortfolioBalance()`, `initialPortfolioBalance()`, `currentWithdrawalRate()`) to delegate to SimulationView

### Tests Updated
- `SpendingContextTest` - rewritten to use StubSimulationView
- `DefaultSpendingOrchestratorTest` - updated helper methods to build SpendingContext with SimulationView
- `RmdFirstSequencerTest` - updated helper methods
- `TaxEfficientSequencerTest` - updated helper methods

### Documentation
- Updated `SpendingStrategy` Javadoc example to show new API

## Test plan
- [x] All existing tests updated and passing
- [x] Maven build passes
- [x] Checkstyle passes
- [x] PMD passes
- [x] SpotBugs passes

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)