### PR TITLE
feat(M6b): Implement IncomeGapStrategy (#230)

### DIFF
--- a/src/main/java/io/github/xmljim/retirement/domain/calculator/impl/IncomeGapStrategy.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/calculator/impl/IncomeGapStrategy.java
@@ -1,0 +1,162 @@
+package io.github.xmljim.retirement.domain.calculator.impl;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import io.github.xmljim.retirement.domain.calculator.SpendingStrategy;
+import io.github.xmljim.retirement.domain.value.SpendingContext;
+import io.github.xmljim.retirement.domain.value.SpendingPlan;
+
+/**
+ * Spending strategy that withdraws exactly the gap between expenses and other income.
+ *
+ * <p>This strategy is the simplest approach: withdraw only what you need to cover
+ * expenses after accounting for other income sources (Social Security, pensions, etc.).
+ *
+ * <h2>Formula</h2>
+ * <ul>
+ *   <li><b>Net Gap</b>: {@code totalExpenses - otherIncome}</li>
+ *   <li><b>Gross Withdrawal</b>: {@code netGap / (1 - marginalTaxRate)}</li>
+ * </ul>
+ *
+ * <h2>Tax Gross-Up</h2>
+ *
+ * <p>When withdrawing from tax-deferred accounts (Traditional IRA, 401k), the
+ * withdrawal is taxable income. To end up with the needed net amount, the
+ * gross withdrawal must be "grossed up" to account for taxes.
+ *
+ * <p>Example: If you need $1,000 net and your marginal rate is 22%:
+ * <pre>
+ * Gross needed = $1,000 / (1 - 0.22) = $1,282.05
+ * Taxes = $1,282.05 × 0.22 = $282.05
+ * Net received = $1,282.05 - $282.05 = $1,000
+ * </pre>
+ *
+ * <h2>When to Use</h2>
+ * <ul>
+ *   <li>Retirees who want to minimize portfolio withdrawals</li>
+ *   <li>Those with significant guaranteed income (SS, pensions)</li>
+ *   <li>Preserving portfolio for legacy or late-life expenses</li>
+ * </ul>
+ *
+ * <h2>Usage</h2>
+ * <pre>{@code
+ * // Simple: withdraw net gap
+ * SpendingStrategy strategy = new IncomeGapStrategy();
+ *
+ * // With tax gross-up for pre-tax withdrawals
+ * SpendingStrategy strategy = new IncomeGapStrategy(new BigDecimal("0.22"));
+ *
+ * SpendingPlan plan = strategy.calculateWithdrawal(context);
+ * }</pre>
+ *
+ * @see SpendingStrategy
+ * @see SpendingContext#incomeGap()
+ */
+public class IncomeGapStrategy implements SpendingStrategy {
+
+    private static final int SCALE = 10;
+
+    private final BigDecimal marginalTaxRate;
+    private final boolean grossUpForTaxes;
+
+    /**
+     * Creates an income gap strategy without tax gross-up.
+     *
+     * <p>Use this when withdrawing from Roth or taxable accounts,
+     * or when tax handling is done elsewhere.
+     */
+    public IncomeGapStrategy() {
+        this.marginalTaxRate = BigDecimal.ZERO;
+        this.grossUpForTaxes = false;
+    }
+
+    /**
+     * Creates an income gap strategy with tax gross-up.
+     *
+     * <p>Use this when primarily withdrawing from tax-deferred accounts
+     * and you want the withdrawal to cover taxes as well.
+     *
+     * @param marginalTaxRate the marginal tax rate as a decimal (e.g., 0.22 for 22%)
+     */
+    public IncomeGapStrategy(BigDecimal marginalTaxRate) {
+        this.marginalTaxRate = marginalTaxRate != null ? marginalTaxRate : BigDecimal.ZERO;
+        this.grossUpForTaxes = marginalTaxRate != null && marginalTaxRate.compareTo(BigDecimal.ZERO) > 0;
+    }
+
+    @Override
+    public SpendingPlan calculateWithdrawal(SpendingContext context) {
+        BigDecimal incomeGap = context.incomeGap();
+
+        // Apply tax gross-up if configured
+        BigDecimal targetWithdrawal;
+        if (grossUpForTaxes && incomeGap.compareTo(BigDecimal.ZERO) > 0) {
+            // Gross = Net / (1 - taxRate)
+            BigDecimal divisor = BigDecimal.ONE.subtract(marginalTaxRate);
+            targetWithdrawal = incomeGap.divide(divisor, SCALE, RoundingMode.HALF_UP);
+        } else {
+            targetWithdrawal = incomeGap;
+        }
+
+        // Check if portfolio can support this withdrawal
+        BigDecimal currentBalance = context.currentPortfolioBalance();
+        boolean meetsTarget = currentBalance.compareTo(targetWithdrawal) >= 0;
+        BigDecimal actualWithdrawal = meetsTarget ? targetWithdrawal
+                : currentBalance.max(BigDecimal.ZERO);
+
+        return SpendingPlan.builder()
+                .targetWithdrawal(targetWithdrawal)
+                .adjustedWithdrawal(actualWithdrawal)
+                .meetsTarget(meetsTarget)
+                .strategyUsed(getName())
+                .addMetadata("incomeGap", incomeGap.setScale(2, RoundingMode.HALF_UP).toPlainString())
+                .addMetadata("totalExpenses", context.totalExpenses().setScale(2, RoundingMode.HALF_UP).toPlainString())
+                .addMetadata("otherIncome", context.otherIncome().setScale(2, RoundingMode.HALF_UP).toPlainString())
+                .addMetadata("grossUpForTaxes", String.valueOf(grossUpForTaxes))
+                .addMetadata("marginalTaxRate", marginalTaxRate.toPlainString())
+                .build();
+    }
+
+    @Override
+    public String getName() {
+        return "Income Gap";
+    }
+
+    @Override
+    public String getDescription() {
+        String base = "Withdraws exactly the gap between expenses and other income";
+        if (grossUpForTaxes) {
+            return base + ", grossed up for " + marginalTaxRate.multiply(new BigDecimal("100"))
+                    .setScale(0, RoundingMode.HALF_UP) + "% taxes";
+        }
+        return base;
+    }
+
+    @Override
+    public boolean isDynamic() {
+        return false;
+    }
+
+    @Override
+    public boolean requiresPriorYearState() {
+        return false;
+    }
+
+    /**
+     * Returns the configured marginal tax rate.
+     *
+     * @return the marginal tax rate as a decimal
+     */
+    public BigDecimal getMarginalTaxRate() {
+        return marginalTaxRate;
+    }
+
+    /**
+     * Returns whether tax gross-up is enabled.
+     *
+     * @return true if grossing up for taxes
+     */
+    public boolean isGrossUpForTaxes() {
+        return grossUpForTaxes;
+    }
+}

--- a/src/test/java/io/github/xmljim/retirement/domain/calculator/impl/IncomeGapStrategyTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/calculator/impl/IncomeGapStrategyTest.java
@@ -1,0 +1,346 @@
+package io.github.xmljim.retirement.domain.calculator.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.github.xmljim.retirement.domain.calculator.StubSimulationView;
+import io.github.xmljim.retirement.domain.enums.AccountType;
+import io.github.xmljim.retirement.domain.value.SpendingContext;
+import io.github.xmljim.retirement.domain.value.SpendingPlan;
+
+@DisplayName("IncomeGapStrategy Tests")
+class IncomeGapStrategyTest {
+
+    private IncomeGapStrategy strategy;
+    private LocalDate retirementStart;
+
+    @BeforeEach
+    void setUp() {
+        strategy = new IncomeGapStrategy();
+        retirementStart = LocalDate.of(2020, 1, 1);
+    }
+
+    private SpendingContext createContext(BigDecimal balance, BigDecimal expenses, BigDecimal otherIncome) {
+        StubSimulationView simulation = StubSimulationView.builder()
+                .addAccount(StubSimulationView.createTestAccount(
+                        "Portfolio", AccountType.TRADITIONAL_401K, balance))
+                .build();
+
+        return SpendingContext.builder()
+                .simulation(simulation)
+                .date(LocalDate.now())
+                .retirementStartDate(retirementStart)
+                .totalExpenses(expenses)
+                .otherIncome(otherIncome)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("Basic Income Gap Tests")
+    class BasicGapTests {
+
+        @Test
+        @DisplayName("Should withdraw exact gap when expenses exceed income")
+        void withdrawsExactGap() {
+            // $5,000 expenses - $3,000 SS = $2,000 gap
+            SpendingContext context = createContext(
+                    new BigDecimal("500000"),
+                    new BigDecimal("5000"),
+                    new BigDecimal("3000")
+            );
+
+            SpendingPlan plan = strategy.calculateWithdrawal(context);
+
+            assertEquals(0, new BigDecimal("2000").compareTo(
+                    plan.targetWithdrawal().setScale(2, RoundingMode.HALF_UP)));
+            assertEquals(0, new BigDecimal("2000").compareTo(
+                    plan.adjustedWithdrawal().setScale(2, RoundingMode.HALF_UP)));
+            assertTrue(plan.meetsTarget());
+        }
+
+        @Test
+        @DisplayName("Should withdraw zero when income covers expenses")
+        void zeroWhenIncomeCoversExpenses() {
+            // $3,000 expenses - $4,000 SS = $0 gap (surplus)
+            SpendingContext context = createContext(
+                    new BigDecimal("500000"),
+                    new BigDecimal("3000"),
+                    new BigDecimal("4000")
+            );
+
+            SpendingPlan plan = strategy.calculateWithdrawal(context);
+
+            assertEquals(0, BigDecimal.ZERO.compareTo(plan.targetWithdrawal()));
+            assertEquals(0, BigDecimal.ZERO.compareTo(plan.adjustedWithdrawal()));
+            assertTrue(plan.meetsTarget());
+        }
+
+        @Test
+        @DisplayName("Should withdraw zero when income exactly equals expenses")
+        void zeroWhenIncomeEqualsExpenses() {
+            // $4,000 expenses - $4,000 SS = $0 gap
+            SpendingContext context = createContext(
+                    new BigDecimal("500000"),
+                    new BigDecimal("4000"),
+                    new BigDecimal("4000")
+            );
+
+            SpendingPlan plan = strategy.calculateWithdrawal(context);
+
+            assertEquals(0, BigDecimal.ZERO.compareTo(plan.targetWithdrawal()));
+            assertTrue(plan.meetsTarget());
+        }
+
+        @Test
+        @DisplayName("Should handle no other income (full expenses as gap)")
+        void fullExpensesWhenNoOtherIncome() {
+            // $5,000 expenses - $0 other income = $5,000 gap
+            SpendingContext context = createContext(
+                    new BigDecimal("500000"),
+                    new BigDecimal("5000"),
+                    BigDecimal.ZERO
+            );
+
+            SpendingPlan plan = strategy.calculateWithdrawal(context);
+
+            assertEquals(0, new BigDecimal("5000").compareTo(
+                    plan.targetWithdrawal().setScale(2, RoundingMode.HALF_UP)));
+        }
+    }
+
+    @Nested
+    @DisplayName("Tax Gross-Up Tests")
+    class TaxGrossUpTests {
+
+        @Test
+        @DisplayName("Should gross up for 22% tax rate")
+        void grossUpFor22Percent() {
+            IncomeGapStrategy taxAwareStrategy = new IncomeGapStrategy(new BigDecimal("0.22"));
+
+            // $5,000 expenses - $3,000 SS = $2,000 net gap
+            // Gross = $2,000 / (1 - 0.22) = $2,564.10
+            SpendingContext context = createContext(
+                    new BigDecimal("500000"),
+                    new BigDecimal("5000"),
+                    new BigDecimal("3000")
+            );
+
+            SpendingPlan plan = taxAwareStrategy.calculateWithdrawal(context);
+
+            BigDecimal expected = new BigDecimal("2000")
+                    .divide(new BigDecimal("0.78"), 2, RoundingMode.HALF_UP);
+            assertEquals(0, expected.compareTo(
+                    plan.targetWithdrawal().setScale(2, RoundingMode.HALF_UP)));
+        }
+
+        @Test
+        @DisplayName("Should gross up for 12% tax rate")
+        void grossUpFor12Percent() {
+            IncomeGapStrategy taxAwareStrategy = new IncomeGapStrategy(new BigDecimal("0.12"));
+
+            // $4,000 expenses - $2,500 SS = $1,500 net gap
+            // Gross = $1,500 / (1 - 0.12) = $1,704.55
+            SpendingContext context = createContext(
+                    new BigDecimal("500000"),
+                    new BigDecimal("4000"),
+                    new BigDecimal("2500")
+            );
+
+            SpendingPlan plan = taxAwareStrategy.calculateWithdrawal(context);
+
+            BigDecimal expected = new BigDecimal("1500")
+                    .divide(new BigDecimal("0.88"), 2, RoundingMode.HALF_UP);
+            assertEquals(0, expected.compareTo(
+                    plan.targetWithdrawal().setScale(2, RoundingMode.HALF_UP)));
+        }
+
+        @Test
+        @DisplayName("Should not gross up when gap is zero")
+        void noGrossUpWhenGapIsZero() {
+            IncomeGapStrategy taxAwareStrategy = new IncomeGapStrategy(new BigDecimal("0.22"));
+
+            SpendingContext context = createContext(
+                    new BigDecimal("500000"),
+                    new BigDecimal("3000"),
+                    new BigDecimal("4000")
+            );
+
+            SpendingPlan plan = taxAwareStrategy.calculateWithdrawal(context);
+
+            assertEquals(0, BigDecimal.ZERO.compareTo(plan.targetWithdrawal()));
+        }
+
+        @Test
+        @DisplayName("Should not gross up when tax rate is zero")
+        void noGrossUpWhenTaxRateIsZero() {
+            IncomeGapStrategy noTaxStrategy = new IncomeGapStrategy(BigDecimal.ZERO);
+
+            SpendingContext context = createContext(
+                    new BigDecimal("500000"),
+                    new BigDecimal("5000"),
+                    new BigDecimal("3000")
+            );
+
+            SpendingPlan plan = noTaxStrategy.calculateWithdrawal(context);
+
+            // No gross-up, just the net gap
+            assertEquals(0, new BigDecimal("2000").compareTo(
+                    plan.targetWithdrawal().setScale(2, RoundingMode.HALF_UP)));
+        }
+    }
+
+    @Nested
+    @DisplayName("Portfolio Constraint Tests")
+    class PortfolioConstraintTests {
+
+        @Test
+        @DisplayName("Should cap at portfolio balance when insufficient")
+        void capsAtPortfolioBalance() {
+            SpendingContext context = createContext(
+                    new BigDecimal("1000"),  // Only $1,000 in portfolio
+                    new BigDecimal("5000"),
+                    new BigDecimal("2000")   // Gap = $3,000
+            );
+
+            SpendingPlan plan = strategy.calculateWithdrawal(context);
+
+            assertEquals(0, new BigDecimal("3000").compareTo(
+                    plan.targetWithdrawal().setScale(2, RoundingMode.HALF_UP)));
+            assertEquals(0, new BigDecimal("1000").compareTo(
+                    plan.adjustedWithdrawal().setScale(2, RoundingMode.HALF_UP)));
+            assertFalse(plan.meetsTarget());
+        }
+
+        @Test
+        @DisplayName("Should return zero when portfolio is empty")
+        void zeroWhenPortfolioEmpty() {
+            SpendingContext context = createContext(
+                    BigDecimal.ZERO,
+                    new BigDecimal("5000"),
+                    new BigDecimal("3000")
+            );
+
+            SpendingPlan plan = strategy.calculateWithdrawal(context);
+
+            assertEquals(0, BigDecimal.ZERO.compareTo(plan.adjustedWithdrawal()));
+            assertFalse(plan.meetsTarget());
+        }
+    }
+
+    @Nested
+    @DisplayName("Metadata Tests")
+    class MetadataTests {
+
+        @Test
+        @DisplayName("Should include income and expense details in metadata")
+        void includesIncomeExpenseDetails() {
+            SpendingContext context = createContext(
+                    new BigDecimal("500000"),
+                    new BigDecimal("5000"),
+                    new BigDecimal("3000")
+            );
+
+            SpendingPlan plan = strategy.calculateWithdrawal(context);
+
+            assertEquals("5000.00", plan.metadata().get("totalExpenses"));
+            assertEquals("3000.00", plan.metadata().get("otherIncome"));
+            assertEquals("2000.00", plan.metadata().get("incomeGap"));
+        }
+
+        @Test
+        @DisplayName("Should include tax configuration in metadata")
+        void includesTaxConfig() {
+            IncomeGapStrategy taxAwareStrategy = new IncomeGapStrategy(new BigDecimal("0.22"));
+
+            SpendingContext context = createContext(
+                    new BigDecimal("500000"),
+                    new BigDecimal("5000"),
+                    new BigDecimal("3000")
+            );
+
+            SpendingPlan plan = taxAwareStrategy.calculateWithdrawal(context);
+
+            assertEquals("true", plan.metadata().get("grossUpForTaxes"));
+            assertEquals("0.22", plan.metadata().get("marginalTaxRate"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Strategy Properties Tests")
+    class StrategyPropertiesTests {
+
+        @Test
+        @DisplayName("Should have descriptive name")
+        void hasDescriptiveName() {
+            assertEquals("Income Gap", strategy.getName());
+        }
+
+        @Test
+        @DisplayName("Should have description without tax info when no gross-up")
+        void descriptionWithoutTax() {
+            String description = strategy.getDescription();
+            assertTrue(description.contains("gap between expenses and other income"));
+            assertFalse(description.contains("tax"));
+        }
+
+        @Test
+        @DisplayName("Should have description with tax info when gross-up enabled")
+        void descriptionWithTax() {
+            IncomeGapStrategy taxAwareStrategy = new IncomeGapStrategy(new BigDecimal("0.22"));
+            String description = taxAwareStrategy.getDescription();
+            assertTrue(description.contains("22%"));
+            assertTrue(description.contains("tax"));
+        }
+
+        @Test
+        @DisplayName("Should not be dynamic")
+        void isNotDynamic() {
+            assertFalse(strategy.isDynamic());
+        }
+
+        @Test
+        @DisplayName("Should not require prior year state")
+        void doesNotRequirePriorYearState() {
+            assertFalse(strategy.requiresPriorYearState());
+        }
+
+        @Test
+        @DisplayName("Should expose configuration via getters")
+        void exposesConfiguration() {
+            IncomeGapStrategy taxAwareStrategy = new IncomeGapStrategy(new BigDecimal("0.22"));
+            assertEquals(0, new BigDecimal("0.22").compareTo(taxAwareStrategy.getMarginalTaxRate()));
+            assertTrue(taxAwareStrategy.isGrossUpForTaxes());
+        }
+    }
+
+    @Nested
+    @DisplayName("Constructor Tests")
+    class ConstructorTests {
+
+        @Test
+        @DisplayName("Default constructor has no gross-up")
+        void defaultConstructorNoGrossUp() {
+            IncomeGapStrategy defaultStrategy = new IncomeGapStrategy();
+            assertEquals(0, BigDecimal.ZERO.compareTo(defaultStrategy.getMarginalTaxRate()));
+            assertFalse(defaultStrategy.isGrossUpForTaxes());
+        }
+
+        @Test
+        @DisplayName("Null tax rate treated as zero")
+        void nullTaxRateTreatedAsZero() {
+            IncomeGapStrategy nullTaxStrategy = new IncomeGapStrategy(null);
+            assertEquals(0, BigDecimal.ZERO.compareTo(nullTaxStrategy.getMarginalTaxRate()));
+            assertFalse(nullTaxStrategy.isGrossUpForTaxes());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements a spending strategy that withdraws exactly the gap between expenses and other income sources.

## Formula

- **Net Gap**: `totalExpenses - otherIncome`
- **Gross Withdrawal**: `netGap / (1 - marginalTaxRate)`

## Features

- Withdraws exactly what's needed to cover the gap
- Optional tax gross-up for pre-tax account withdrawals
- Returns $0 when income covers or exceeds expenses
- Caps withdrawal at portfolio balance when insufficient

## Tax Gross-Up Example

If you need $2,000 net and your marginal rate is 22%:
```
Gross = $2,000 / (1 - 0.22) = $2,564.10
Taxes = $2,564.10 × 0.22 = $564.10
Net = $2,564.10 - $564.10 = $2,000
```

## Use Cases

- Retirees who want to minimize portfolio withdrawals
- Those with significant guaranteed income (SS, pensions)
- Preserving portfolio for legacy or late-life expenses

## Tests

- Basic income gap scenarios (deficit, surplus, exact match)
- Tax gross-up at various rates (12%, 22%)
- Portfolio constraints (insufficient funds, empty)
- Metadata verification
- Strategy properties and constructors

## Test plan
- [x] All unit tests pass
- [x] Maven build passes
- [x] Checkstyle passes
- [x] PMD passes
- [x] SpotBugs passes

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)