### PR TITLE
refactor(#260): Remove Portfolio parameter from SpendingOrchestrator

### DIFF
--- a/src/main/java/io/github/xmljim/retirement/domain/calculator/AccountSequencer.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/calculator/AccountSequencer.java
@@ -2,8 +2,7 @@ package io.github.xmljim.retirement.domain.calculator;
 
 import java.util.List;
 
-import io.github.xmljim.retirement.domain.model.InvestmentAccount;
-import io.github.xmljim.retirement.domain.model.Portfolio;
+import io.github.xmljim.retirement.domain.value.AccountSnapshot;
 import io.github.xmljim.retirement.domain.value.SpendingContext;
 
 /**
@@ -21,13 +20,13 @@ import io.github.xmljim.retirement.domain.value.SpendingContext;
  * <p>Usage example:
  * <pre>{@code
  * AccountSequencer sequencer = new TaxEfficientSequencer();
- * List<InvestmentAccount> orderedAccounts = sequencer.sequence(portfolio, context);
+ * List<AccountSnapshot> orderedAccounts = sequencer.sequence(context);
  *
  * // Withdraw from accounts in order until target met
  * BigDecimal remaining = targetWithdrawal;
- * for (InvestmentAccount account : orderedAccounts) {
+ * for (AccountSnapshot account : orderedAccounts) {
  *     if (remaining.compareTo(BigDecimal.ZERO) <= 0) break;
- *     BigDecimal withdrawal = remaining.min(account.getBalance());
+ *     BigDecimal withdrawal = remaining.min(account.balance());
  *     remaining = remaining.subtract(withdrawal);
  * }
  * }</pre>
@@ -37,26 +36,29 @@ import io.github.xmljim.retirement.domain.value.SpendingContext;
  *
  * @see SpendingStrategy
  * @see SpendingContext
+ * @see AccountSnapshot
  */
 public interface AccountSequencer {
 
     /**
      * Returns accounts in withdrawal priority order.
      *
-     * <p>The returned list contains accounts from the portfolio ordered by
-     * withdrawal priority. Accounts earlier in the list should be drawn
-     * from before accounts later in the list.
+     * <p>The returned list contains account snapshots ordered by withdrawal
+     * priority. Accounts earlier in the list should be drawn from before
+     * accounts later in the list.
+     *
+     * <p>Account information is obtained from
+     * {@code context.simulation().getAccountSnapshots()}.
      *
      * <p>The list may exclude accounts that should not be used (e.g., accounts
      * with zero balance, or accounts reserved for specific purposes).
      *
-     * @param portfolio the portfolio containing accounts to sequence
-     * @param context the spending context (may affect ordering decisions)
-     * @return list of accounts in withdrawal priority order
+     * @param context the spending context containing simulation with accounts
+     * @return list of account snapshots in withdrawal priority order
      * @throws io.github.xmljim.retirement.domain.exception.MissingRequiredFieldException
-     *         if portfolio is null
+     *         if context or simulation is null
      */
-    List<InvestmentAccount> sequence(Portfolio portfolio, SpendingContext context);
+    List<AccountSnapshot> sequence(SpendingContext context);
 
     /**
      * Returns the sequencer name for identification.

--- a/src/main/java/io/github/xmljim/retirement/domain/value/AccountWithdrawal.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/value/AccountWithdrawal.java
@@ -4,7 +4,6 @@ import java.math.BigDecimal;
 
 import io.github.xmljim.retirement.domain.enums.AccountType;
 import io.github.xmljim.retirement.domain.exception.MissingRequiredFieldException;
-import io.github.xmljim.retirement.domain.model.InvestmentAccount;
 
 /**
  * Represents a withdrawal from a single investment account.
@@ -16,7 +15,7 @@ import io.github.xmljim.retirement.domain.model.InvestmentAccount;
  * <p>Tax treatment is included to support tax-efficient withdrawal sequencing
  * and tax liability calculations.
  *
- * @param account the investment account the withdrawal is from
+ * @param accountSnapshot the account snapshot the withdrawal is from
  * @param amount the withdrawal amount
  * @param priorBalance the account balance before withdrawal
  * @param newBalance the account balance after withdrawal
@@ -24,7 +23,7 @@ import io.github.xmljim.retirement.domain.model.InvestmentAccount;
  * @see io.github.xmljim.retirement.domain.value.SpendingPlan
  */
 public record AccountWithdrawal(
-        InvestmentAccount account,
+        AccountSnapshot accountSnapshot,
         BigDecimal amount,
         BigDecimal priorBalance,
         BigDecimal newBalance,
@@ -35,11 +34,11 @@ public record AccountWithdrawal(
      * Compact constructor with validation.
      */
     public AccountWithdrawal {
-        MissingRequiredFieldException.requireNonNull(account, "account");
+        MissingRequiredFieldException.requireNonNull(accountSnapshot, "accountSnapshot");
         amount = amount != null ? amount : BigDecimal.ZERO;
         priorBalance = priorBalance != null ? priorBalance : BigDecimal.ZERO;
         newBalance = newBalance != null ? newBalance : BigDecimal.ZERO;
-        taxTreatment = taxTreatment != null ? taxTreatment : account.getAccountType().getTaxTreatment();
+        taxTreatment = taxTreatment != null ? taxTreatment : accountSnapshot.taxTreatment();
     }
 
     /**
@@ -48,7 +47,7 @@ public record AccountWithdrawal(
      * @return the account's unique identifier
      */
     public String accountId() {
-        return account.getId();
+        return accountSnapshot.accountId();
     }
 
     /**
@@ -57,7 +56,7 @@ public record AccountWithdrawal(
      * @return the account's display name
      */
     public String accountName() {
-        return account.getName();
+        return accountSnapshot.accountName();
     }
 
     /**
@@ -66,7 +65,7 @@ public record AccountWithdrawal(
      * @return the type of account
      */
     public AccountType accountType() {
-        return account.getAccountType();
+        return accountSnapshot.accountType();
     }
 
     /**
@@ -116,20 +115,20 @@ public record AccountWithdrawal(
      * Builder for creating AccountWithdrawal instances.
      */
     public static class Builder {
-        private InvestmentAccount account;
+        private AccountSnapshot accountSnapshot;
         private BigDecimal amount = BigDecimal.ZERO;
         private BigDecimal priorBalance = BigDecimal.ZERO;
         private BigDecimal newBalance = BigDecimal.ZERO;
         private AccountType.TaxTreatment taxTreatment;
 
         /**
-         * Sets the investment account.
+         * Sets the account snapshot.
          *
-         * @param account the investment account
+         * @param accountSnapshot the account snapshot
          * @return this builder
          */
-        public Builder account(InvestmentAccount account) {
-            this.account = account;
+        public Builder accountSnapshot(AccountSnapshot accountSnapshot) {
+            this.accountSnapshot = accountSnapshot;
             return this;
         }
 
@@ -184,7 +183,7 @@ public record AccountWithdrawal(
          */
         public AccountWithdrawal build() {
             return new AccountWithdrawal(
-                    account,
+                    accountSnapshot,
                     amount,
                     priorBalance,
                     newBalance,

--- a/src/test/java/io/github/xmljim/retirement/domain/calculator/TaxEfficientSequencerTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/calculator/TaxEfficientSequencerTest.java
@@ -16,37 +16,23 @@ import org.junit.jupiter.api.Test;
 import io.github.xmljim.retirement.domain.calculator.impl.TaxEfficientSequencer;
 import io.github.xmljim.retirement.domain.enums.AccountType;
 import io.github.xmljim.retirement.domain.exception.MissingRequiredFieldException;
-import io.github.xmljim.retirement.domain.model.InvestmentAccount;
-import io.github.xmljim.retirement.domain.model.PersonProfile;
-import io.github.xmljim.retirement.domain.model.Portfolio;
-import io.github.xmljim.retirement.domain.value.AssetAllocation;
+import io.github.xmljim.retirement.domain.value.AccountSnapshot;
 import io.github.xmljim.retirement.domain.value.SpendingContext;
 
 @DisplayName("TaxEfficientSequencer Tests")
 class TaxEfficientSequencerTest {
 
     private TaxEfficientSequencer sequencer;
-    private PersonProfile owner;
-    private SpendingContext context;
     private LocalDate retirementStart;
 
     @BeforeEach
     void setUp() {
         sequencer = new TaxEfficientSequencer();
         retirementStart = LocalDate.of(2020, 1, 1);
-        owner = PersonProfile.builder()
-                .name("Test Owner")
-                .dateOfBirth(LocalDate.of(1960, 1, 1))
-                .retirementDate(LocalDate.of(2025, 1, 1))
-                .build();
     }
 
-    private SpendingContext createContext(Portfolio portfolio) {
-        StubSimulationView simulation = StubSimulationView.withAccounts(
-                portfolio.getAccounts().stream()
-                        .map(a -> StubSimulationView.createTestAccount(
-                                a.getName(), a.getAccountType(), a.getBalance()))
-                        .toList());
+    private SpendingContext createContext(AccountSnapshot... accounts) {
+        StubSimulationView simulation = StubSimulationView.withAccounts(List.of(accounts));
         return SpendingContext.builder()
                 .simulation(simulation)
                 .date(LocalDate.now())
@@ -54,14 +40,8 @@ class TaxEfficientSequencerTest {
                 .build();
     }
 
-    private InvestmentAccount createAccount(String name, AccountType type, BigDecimal balance) {
-        return InvestmentAccount.builder()
-                .name(name)
-                .accountType(type)
-                .balance(balance)
-                .allocation(AssetAllocation.of(60, 35, 5))
-                .preRetirementReturnRate(0.07)
-                .build();
+    private AccountSnapshot createAccount(String name, AccountType type, BigDecimal balance) {
+        return StubSimulationView.createTestAccount(name, type, balance);
     }
 
     @Nested
@@ -71,71 +51,63 @@ class TaxEfficientSequencerTest {
         @Test
         @DisplayName("Should order taxable accounts first")
         void taxableFirst() {
-            Portfolio portfolio = Portfolio.builder()
-                    .owner(owner)
-                    .addAccount(createAccount("Roth IRA", AccountType.ROTH_IRA, new BigDecimal("100000")))
-                    .addAccount(createAccount("Brokerage", AccountType.TAXABLE_BROKERAGE, new BigDecimal("50000")))
-                    .addAccount(createAccount("401k", AccountType.TRADITIONAL_401K, new BigDecimal("200000")))
-                    .build();
+            SpendingContext context = createContext(
+                    createAccount("Roth IRA", AccountType.ROTH_IRA, new BigDecimal("100000")),
+                    createAccount("Brokerage", AccountType.TAXABLE_BROKERAGE, new BigDecimal("50000")),
+                    createAccount("401k", AccountType.TRADITIONAL_401K, new BigDecimal("200000")));
 
-            List<InvestmentAccount> ordered = sequencer.sequence(portfolio, createContext(portfolio));
+            List<AccountSnapshot> ordered = sequencer.sequence(context);
 
             assertEquals(3, ordered.size());
-            assertEquals(AccountType.TAXABLE_BROKERAGE, ordered.getFirst().getAccountType());
+            assertEquals(AccountType.TAXABLE_BROKERAGE, ordered.getFirst().accountType());
         }
 
         @Test
         @DisplayName("Should order pre-tax before Roth")
         void preTaxBeforeRoth() {
-            Portfolio portfolio = Portfolio.builder()
-                    .owner(owner)
-                    .addAccount(createAccount("Roth IRA", AccountType.ROTH_IRA, new BigDecimal("100000")))
-                    .addAccount(createAccount("Traditional IRA", AccountType.TRADITIONAL_IRA, new BigDecimal("150000")))
-                    .build();
+            SpendingContext context = createContext(
+                    createAccount("Roth IRA", AccountType.ROTH_IRA, new BigDecimal("100000")),
+                    createAccount("Traditional IRA", AccountType.TRADITIONAL_IRA, new BigDecimal("150000")));
 
-            List<InvestmentAccount> ordered = sequencer.sequence(portfolio, createContext(portfolio));
+            List<AccountSnapshot> ordered = sequencer.sequence(context);
 
             assertEquals(2, ordered.size());
-            assertEquals(AccountType.TRADITIONAL_IRA, ordered.getFirst().getAccountType());
-            assertEquals(AccountType.ROTH_IRA, ordered.getLast().getAccountType());
+            assertEquals(AccountType.TRADITIONAL_IRA, ordered.getFirst().accountType());
+            assertEquals(AccountType.ROTH_IRA, ordered.getLast().accountType());
         }
 
         @Test
         @DisplayName("Should order HSA last")
         void hsaLast() {
-            Portfolio portfolio = Portfolio.builder()
-                    .owner(owner)
-                    .addAccount(createAccount("HSA", AccountType.HSA, new BigDecimal("30000")))
-                    .addAccount(createAccount("Roth IRA", AccountType.ROTH_IRA, new BigDecimal("100000")))
-                    .addAccount(createAccount("401k", AccountType.TRADITIONAL_401K, new BigDecimal("200000")))
-                    .addAccount(createAccount("Brokerage", AccountType.TAXABLE_BROKERAGE, new BigDecimal("50000")))
-                    .build();
+            SpendingContext context = createContext(
+                    createAccount("HSA", AccountType.HSA, new BigDecimal("30000")),
+                    createAccount("Roth IRA", AccountType.ROTH_IRA, new BigDecimal("100000")),
+                    createAccount("401k", AccountType.TRADITIONAL_401K, new BigDecimal("200000")),
+                    createAccount("Brokerage", AccountType.TAXABLE_BROKERAGE, new BigDecimal("50000")));
 
-            List<InvestmentAccount> ordered = sequencer.sequence(portfolio, createContext(portfolio));
+            List<AccountSnapshot> ordered = sequencer.sequence(context);
 
             assertEquals(4, ordered.size());
-            assertEquals(AccountType.HSA, ordered.getLast().getAccountType());
+            assertEquals(AccountType.HSA, ordered.getLast().accountType());
         }
 
         @Test
         @DisplayName("Should sequence all account types correctly")
         void fullSequence() {
-            Portfolio portfolio = Portfolio.builder()
-                    .owner(owner)
-                    .addAccount(createAccount("Roth IRA", AccountType.ROTH_IRA, new BigDecimal("100000")))
-                    .addAccount(createAccount("HSA", AccountType.HSA, new BigDecimal("30000")))
-                    .addAccount(createAccount("401k", AccountType.TRADITIONAL_401K, new BigDecimal("200000")))
-                    .addAccount(createAccount("Brokerage", AccountType.TAXABLE_BROKERAGE, new BigDecimal("50000")))
-                    .build();
+            SpendingContext context = createContext(
+                    createAccount("Roth IRA", AccountType.ROTH_IRA, new BigDecimal("100000")),
+                    createAccount("HSA", AccountType.HSA, new BigDecimal("30000")),
+                    createAccount("401k", AccountType.TRADITIONAL_401K, new BigDecimal("200000")),
+                    createAccount("Brokerage", AccountType.TAXABLE_BROKERAGE, new BigDecimal("50000")));
 
-            List<InvestmentAccount> ordered = sequencer.sequence(portfolio, createContext(portfolio));
+            List<AccountSnapshot> ordered = sequencer.sequence(context);
 
             assertEquals(4, ordered.size());
             // TAXABLE → PRE_TAX → ROTH → HSA
-            assertEquals(AccountType.TaxTreatment.TAXABLE, ordered.getFirst().getAccountType().getTaxTreatment());
-            assertEquals(AccountType.TaxTreatment.PRE_TAX, ordered.get(1).getAccountType().getTaxTreatment());
-            assertEquals(AccountType.TaxTreatment.ROTH, ordered.get(2).getAccountType().getTaxTreatment());
-            assertEquals(AccountType.TaxTreatment.HSA, ordered.getLast().getAccountType().getTaxTreatment());
+            assertEquals(AccountType.TaxTreatment.TAXABLE, ordered.getFirst().taxTreatment());
+            assertEquals(AccountType.TaxTreatment.PRE_TAX, ordered.get(1).taxTreatment());
+            assertEquals(AccountType.TaxTreatment.ROTH, ordered.get(2).taxTreatment());
+            assertEquals(AccountType.TaxTreatment.HSA, ordered.getLast().taxTreatment());
         }
     }
 
@@ -146,20 +118,18 @@ class TaxEfficientSequencerTest {
         @Test
         @DisplayName("Should sort same tax treatment by balance ascending")
         void sortsByBalanceWithinCategory() {
-            Portfolio portfolio = Portfolio.builder()
-                    .owner(owner)
-                    .addAccount(createAccount("Big 401k", AccountType.TRADITIONAL_401K, new BigDecimal("500000")))
-                    .addAccount(createAccount("Small 401k", AccountType.TRADITIONAL_401K, new BigDecimal("50000")))
-                    .addAccount(createAccount("Medium IRA", AccountType.TRADITIONAL_IRA, new BigDecimal("100000")))
-                    .build();
+            SpendingContext context = createContext(
+                    createAccount("Big 401k", AccountType.TRADITIONAL_401K, new BigDecimal("500000")),
+                    createAccount("Small 401k", AccountType.TRADITIONAL_401K, new BigDecimal("50000")),
+                    createAccount("Medium IRA", AccountType.TRADITIONAL_IRA, new BigDecimal("100000")));
 
-            List<InvestmentAccount> ordered = sequencer.sequence(portfolio, createContext(portfolio));
+            List<AccountSnapshot> ordered = sequencer.sequence(context);
 
             assertEquals(3, ordered.size());
             // All PRE_TAX, sorted by balance ascending
-            assertEquals("Small 401k", ordered.get(0).getName());
-            assertEquals("Medium IRA", ordered.get(1).getName());
-            assertEquals("Big 401k", ordered.get(2).getName());
+            assertEquals("Small 401k", ordered.get(0).accountName());
+            assertEquals("Medium IRA", ordered.get(1).accountName());
+            assertEquals("Big 401k", ordered.get(2).accountName());
         }
     }
 
@@ -170,26 +140,22 @@ class TaxEfficientSequencerTest {
         @Test
         @DisplayName("Should exclude zero balance accounts")
         void excludesZeroBalance() {
-            Portfolio portfolio = Portfolio.builder()
-                    .owner(owner)
-                    .addAccount(createAccount("Empty Brokerage", AccountType.TAXABLE_BROKERAGE, BigDecimal.ZERO))
-                    .addAccount(createAccount("401k", AccountType.TRADITIONAL_401K, new BigDecimal("200000")))
-                    .build();
+            SpendingContext context = createContext(
+                    createAccount("Empty Brokerage", AccountType.TAXABLE_BROKERAGE, BigDecimal.ZERO),
+                    createAccount("401k", AccountType.TRADITIONAL_401K, new BigDecimal("200000")));
 
-            List<InvestmentAccount> ordered = sequencer.sequence(portfolio, createContext(portfolio));
+            List<AccountSnapshot> ordered = sequencer.sequence(context);
 
             assertEquals(1, ordered.size());
-            assertEquals("401k", ordered.getFirst().getName());
+            assertEquals("401k", ordered.getFirst().accountName());
         }
 
         @Test
         @DisplayName("Should handle empty portfolio")
         void handlesEmptyPortfolio() {
-            Portfolio portfolio = Portfolio.builder()
-                    .owner(owner)
-                    .build();
+            SpendingContext context = createContext();
 
-            List<InvestmentAccount> ordered = sequencer.sequence(portfolio, createContext(portfolio));
+            List<AccountSnapshot> ordered = sequencer.sequence(context);
 
             assertTrue(ordered.isEmpty());
         }
@@ -197,22 +163,20 @@ class TaxEfficientSequencerTest {
         @Test
         @DisplayName("Should handle single account")
         void handlesSingleAccount() {
-            Portfolio portfolio = Portfolio.builder()
-                    .owner(owner)
-                    .addAccount(createAccount("Only Account", AccountType.ROTH_IRA, new BigDecimal("100000")))
-                    .build();
+            SpendingContext context = createContext(
+                    createAccount("Only Account", AccountType.ROTH_IRA, new BigDecimal("100000")));
 
-            List<InvestmentAccount> ordered = sequencer.sequence(portfolio, createContext(portfolio));
+            List<AccountSnapshot> ordered = sequencer.sequence(context);
 
             assertEquals(1, ordered.size());
-            assertEquals("Only Account", ordered.getFirst().getName());
+            assertEquals("Only Account", ordered.getFirst().accountName());
         }
 
         @Test
-        @DisplayName("Should throw for null portfolio")
-        void throwsForNullPortfolio() {
+        @DisplayName("Should throw for null context")
+        void throwsForNullContext() {
             assertThrows(MissingRequiredFieldException.class, () ->
-                    sequencer.sequence(null, context));
+                    sequencer.sequence(null));
         }
     }
 

--- a/src/test/java/io/github/xmljim/retirement/domain/calculator/impl/M6bStrategyIntegrationTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/calculator/impl/M6bStrategyIntegrationTest.java
@@ -14,10 +14,6 @@ import org.junit.jupiter.api.Test;
 
 import io.github.xmljim.retirement.domain.calculator.StubSimulationView;
 import io.github.xmljim.retirement.domain.enums.AccountType;
-import io.github.xmljim.retirement.domain.model.InvestmentAccount;
-import io.github.xmljim.retirement.domain.model.PersonProfile;
-import io.github.xmljim.retirement.domain.model.Portfolio;
-import io.github.xmljim.retirement.domain.value.AssetAllocation;
 import io.github.xmljim.retirement.domain.value.SpendingContext;
 import io.github.xmljim.retirement.domain.value.SpendingPlan;
 
@@ -28,37 +24,12 @@ import io.github.xmljim.retirement.domain.value.SpendingPlan;
 class M6bStrategyIntegrationTest {
 
     private DefaultSpendingOrchestrator orchestrator;
-    private Portfolio portfolio;
     private LocalDate retirementStart;
 
     @BeforeEach
     void setUp() {
         orchestrator = new DefaultSpendingOrchestrator(new DefaultRmdCalculator());
         retirementStart = LocalDate.of(2020, 1, 1);
-
-        PersonProfile owner = PersonProfile.builder()
-                .name("Test Retiree")
-                .dateOfBirth(LocalDate.of(1955, 6, 15))
-                .retirementDate(retirementStart)
-                .build();
-
-        portfolio = Portfolio.builder()
-                .owner(owner)
-                .addAccount(InvestmentAccount.builder()
-                        .name("401(k)")
-                        .accountType(AccountType.TRADITIONAL_401K)
-                        .balance(new BigDecimal("400000"))
-                        .allocation(AssetAllocation.of(60, 35, 5))
-                        .preRetirementReturnRate(0.07)
-                        .build())
-                .addAccount(InvestmentAccount.builder()
-                        .name("Roth IRA")
-                        .accountType(AccountType.ROTH_IRA)
-                        .balance(new BigDecimal("100000"))
-                        .allocation(AssetAllocation.of(70, 25, 5))
-                        .preRetirementReturnRate(0.07)
-                        .build())
-                .build();
     }
 
     private SpendingContext createContext(BigDecimal expenses, BigDecimal otherIncome, int yearsRetired) {
@@ -89,7 +60,7 @@ class M6bStrategyIntegrationTest {
             StaticSpendingStrategy strategy = new StaticSpendingStrategy();
             SpendingContext context = createContext(new BigDecimal("5000"), new BigDecimal("2000"), 0);
 
-            SpendingPlan plan = orchestrator.execute(portfolio, strategy, context);
+            SpendingPlan plan = orchestrator.execute(strategy, context);
 
             assertTrue(plan.meetsTarget());
             assertEquals("Static 4%", plan.strategyUsed());
@@ -102,7 +73,7 @@ class M6bStrategyIntegrationTest {
             StaticSpendingStrategy strategy = new StaticSpendingStrategy(new BigDecimal("0.10")); // 10% = $50k/yr
             SpendingContext context = createContext(new BigDecimal("10000"), BigDecimal.ZERO, 0);
 
-            SpendingPlan plan = orchestrator.execute(portfolio, strategy, context);
+            SpendingPlan plan = orchestrator.execute(strategy, context);
 
             assertTrue(plan.meetsTarget());
             assertTrue(plan.accountWithdrawals().size() >= 1);
@@ -119,7 +90,7 @@ class M6bStrategyIntegrationTest {
             IncomeGapStrategy strategy = new IncomeGapStrategy();
             SpendingContext context = createContext(new BigDecimal("5000"), new BigDecimal("3000"), 0);
 
-            SpendingPlan plan = orchestrator.execute(portfolio, strategy, context);
+            SpendingPlan plan = orchestrator.execute(strategy, context);
 
             assertTrue(plan.meetsTarget());
             assertEquals("Income Gap", plan.strategyUsed());
@@ -133,7 +104,7 @@ class M6bStrategyIntegrationTest {
             IncomeGapStrategy strategy = new IncomeGapStrategy();
             SpendingContext context = createContext(new BigDecimal("3000"), new BigDecimal("4000"), 0);
 
-            SpendingPlan plan = orchestrator.execute(portfolio, strategy, context);
+            SpendingPlan plan = orchestrator.execute(strategy, context);
 
             assertTrue(plan.meetsTarget());
             assertEquals(0, BigDecimal.ZERO.compareTo(plan.adjustedWithdrawal()));
@@ -146,7 +117,7 @@ class M6bStrategyIntegrationTest {
             IncomeGapStrategy strategy = new IncomeGapStrategy(new BigDecimal("0.22"));
             SpendingContext context = createContext(new BigDecimal("5000"), new BigDecimal("3000"), 0);
 
-            SpendingPlan plan = orchestrator.execute(portfolio, strategy, context);
+            SpendingPlan plan = orchestrator.execute(strategy, context);
 
             // $2000 gap / 0.78 = $2564.10
             BigDecimal expected = new BigDecimal("2000").divide(new BigDecimal("0.78"), 2, RoundingMode.HALF_UP);

--- a/src/test/java/io/github/xmljim/retirement/domain/value/SpendingPlanTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/value/SpendingPlanTest.java
@@ -12,8 +12,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import io.github.xmljim.retirement.domain.calculator.StubSimulationView;
 import io.github.xmljim.retirement.domain.enums.AccountType;
-import io.github.xmljim.retirement.domain.model.InvestmentAccount;
 
 @DisplayName("SpendingPlan Tests")
 class SpendingPlanTest {
@@ -219,19 +219,13 @@ class SpendingPlanTest {
 
     // Helper methods
 
-    private InvestmentAccount createAccount(AccountType type) {
-        return InvestmentAccount.builder()
-                .name("Test " + type.name())
-                .accountType(type)
-                .balance(new BigDecimal("100000.00"))
-                .allocation(AssetAllocation.of(60, 35, 5))
-                .preRetirementReturnRate(0.07)
-                .build();
+    private AccountSnapshot createAccountSnapshot(AccountType type) {
+        return StubSimulationView.createTestAccount("Test " + type.name(), type, new BigDecimal("100000.00"));
     }
 
     private AccountWithdrawal createWithdrawal(AccountType type, BigDecimal amount) {
         return AccountWithdrawal.builder()
-                .account(createAccount(type))
+                .accountSnapshot(createAccountSnapshot(type))
                 .amount(amount)
                 .build();
     }
@@ -242,7 +236,7 @@ class SpendingPlanTest {
             BigDecimal priorBalance,
             BigDecimal newBalance) {
         return AccountWithdrawal.builder()
-                .account(createAccount(type))
+                .accountSnapshot(createAccountSnapshot(type))
                 .amount(amount)
                 .priorBalance(priorBalance)
                 .newBalance(newBalance)


### PR DESCRIPTION
## Summary

- Removes redundant `Portfolio` parameter from `SpendingOrchestrator.execute()` methods
- `AccountSequencer.sequence()` now takes only `SpendingContext` (accounts from `context.simulation().getAccountSnapshots()`)
- `AccountSequencer` returns `List<AccountSnapshot>` instead of `List<InvestmentAccount>`
- `AccountWithdrawal` uses `AccountSnapshot` instead of `InvestmentAccount`
- Simplifies `RmdFirstSequencer` by removing portfolio subset creation

## Motivation

The Portfolio parameter was redundant because `SpendingContext` already contains a `SimulationView` that provides account information via `getAccountSnapshots()`. This refactoring:

1. Eliminates duplicate data passing
2. Improves separation of concerns (strategies/sequencers work with read-only snapshots)
3. Aligns with the SimulationView architecture from M6a

## Test plan

- [x] All existing tests updated and passing
- [x] Checkstyle clean
- [x] TaxEfficientSequencer tests verify ordering
- [x] RmdFirstSequencer tests verify RMD-first ordering
- [x] DefaultSpendingOrchestrator tests verify execution flow
- [x] M6bStrategyIntegrationTest verifies full orchestrator flow
- [x] AccountWithdrawalTest verifies snapshot-based withdrawals

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)