### PR TITLE
feat(#242): Implement RmdAwareOrchestrator

### DIFF
--- a/src/main/java/io/github/xmljim/retirement/domain/calculator/impl/RmdAwareOrchestrator.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/calculator/impl/RmdAwareOrchestrator.java
@@ -1,0 +1,258 @@
+package io.github.xmljim.retirement.domain.calculator.impl;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.github.xmljim.retirement.domain.calculator.AccountSequencer;
+import io.github.xmljim.retirement.domain.calculator.RmdCalculator;
+import io.github.xmljim.retirement.domain.calculator.SpendingOrchestrator;
+import io.github.xmljim.retirement.domain.calculator.SpendingStrategy;
+import io.github.xmljim.retirement.domain.exception.MissingRequiredFieldException;
+import io.github.xmljim.retirement.domain.value.AccountSnapshot;
+import io.github.xmljim.retirement.domain.value.AccountWithdrawal;
+import io.github.xmljim.retirement.domain.value.SpendingContext;
+import io.github.xmljim.retirement.domain.value.SpendingPlan;
+
+/**
+ * Orchestrator that ensures RMD compliance before applying spending strategies.
+ *
+ * <p>This orchestrator guarantees that Required Minimum Distributions are satisfied,
+ * preventing IRS penalties (25% of missed RMD under SECURE 2.0). It:
+ * <ol>
+ *   <li>Calculates required RMDs for all RMD-subject accounts</li>
+ *   <li>Forces RMD withdrawals even if strategy requests less</li>
+ *   <li>Applies strategy for any additional withdrawal needed beyond RMD</li>
+ *   <li>Tracks RMD vs discretionary withdrawals separately</li>
+ * </ol>
+ *
+ * <h2>RMD Logic</h2>
+ * <pre>
+ * If (Total RMD >= Strategy Withdrawal):
+ *   - Withdraw full RMD (forced)
+ *   - Excess RMD available for spending or reinvestment
+ *
+ * If (Total RMD < Strategy Withdrawal):
+ *   - Withdraw full RMD first
+ *   - Apply strategy for remaining (need - RMD)
+ * </pre>
+ *
+ * @see SpendingOrchestrator
+ * @see RmdCalculator
+ */
+public class RmdAwareOrchestrator implements SpendingOrchestrator {
+
+    private static final BigDecimal TWELVE = new BigDecimal("12");
+    private static final int SCALE = 2;
+
+    private final RmdCalculator rmdCalculator;
+    private final SpendingOrchestrator delegate;
+
+    /**
+     * Creates an RMD-aware orchestrator.
+     *
+     * @param rmdCalculator the RMD calculator
+     * @param delegate the delegate orchestrator for non-RMD withdrawals
+     */
+    public RmdAwareOrchestrator(RmdCalculator rmdCalculator, SpendingOrchestrator delegate) {
+        MissingRequiredFieldException.requireNonNull(rmdCalculator, "rmdCalculator");
+        MissingRequiredFieldException.requireNonNull(delegate, "delegate");
+        this.rmdCalculator = rmdCalculator;
+        this.delegate = delegate;
+    }
+
+    /**
+     * Creates an RMD-aware orchestrator with default delegate.
+     *
+     * @param rmdCalculator the RMD calculator
+     */
+    public RmdAwareOrchestrator(RmdCalculator rmdCalculator) {
+        MissingRequiredFieldException.requireNonNull(rmdCalculator, "rmdCalculator");
+        this.rmdCalculator = rmdCalculator;
+        this.delegate = new DefaultSpendingOrchestrator(rmdCalculator);
+    }
+
+    @Override
+    public SpendingPlan execute(
+            SpendingStrategy strategy,
+            AccountSequencer sequencer,
+            SpendingContext context) {
+
+        MissingRequiredFieldException.requireNonNull(strategy, "strategy");
+        MissingRequiredFieldException.requireNonNull(sequencer, "sequencer");
+        MissingRequiredFieldException.requireNonNull(context, "context");
+
+        // Check if RMDs apply
+        if (!rmdCalculator.isRmdRequired(context.age(), context.birthYear())) {
+            return delegate.execute(strategy, sequencer, context);
+        }
+
+        // Calculate strategy withdrawal target
+        SpendingPlan strategyPlan = strategy.calculateWithdrawal(context);
+        BigDecimal strategyTarget = strategyPlan.targetWithdrawal();
+
+        // Calculate total RMD requirement (monthly portion)
+        RmdRequirement rmdRequirement = calculateRmdRequirement(context);
+        BigDecimal monthlyRmd = rmdRequirement.totalMonthlyRmd();
+
+        // Determine effective withdrawal target (max of strategy and RMD)
+        BigDecimal effectiveTarget = strategyTarget.max(monthlyRmd);
+
+        // Execute withdrawals with RMD accounts first
+        List<AccountSnapshot> accounts = context.simulation().getAccountSnapshots();
+        WithdrawalResult result = executeWithdrawals(
+                accounts, effectiveTarget, rmdRequirement, context);
+
+        // Build spending plan with RMD metadata
+        boolean meetsTarget = result.totalWithdrawn().compareTo(effectiveTarget) >= 0;
+        BigDecimal shortfall = meetsTarget ? BigDecimal.ZERO
+                : effectiveTarget.subtract(result.totalWithdrawn());
+
+        return SpendingPlan.builder()
+                .targetWithdrawal(effectiveTarget)
+                .adjustedWithdrawal(result.totalWithdrawn())
+                .accountWithdrawals(result.withdrawals())
+                .meetsTarget(meetsTarget)
+                .shortfall(shortfall)
+                .strategyUsed(strategy.getName())
+                .addMetadata("sequencer", sequencer.getName())
+                .addMetadata("rmdRequired", monthlyRmd.setScale(SCALE, RoundingMode.HALF_UP).toPlainString())
+                .addMetadata("strategyTarget", strategyTarget.setScale(SCALE, RoundingMode.HALF_UP).toPlainString())
+                .addMetadata("rmdForced", String.valueOf(monthlyRmd.compareTo(strategyTarget) > 0))
+                .addMetadata("rmdWithdrawn",
+                        result.rmdWithdrawn().setScale(SCALE, RoundingMode.HALF_UP).toPlainString())
+                .addMetadata("discretionaryWithdrawn",
+                        result.discretionaryWithdrawn().setScale(SCALE, RoundingMode.HALF_UP).toPlainString())
+                .build();
+    }
+
+    @Override
+    public AccountSequencer selectDefaultSequencer(SpendingContext context) {
+        // Always use RMD-first when RMDs are required
+        if (rmdCalculator.isRmdRequired(context.age(), context.birthYear())) {
+            return new RmdFirstSequencer(rmdCalculator);
+        }
+        return delegate.selectDefaultSequencer(context);
+    }
+
+    private RmdRequirement calculateRmdRequirement(SpendingContext context) {
+        List<AccountSnapshot> accounts = context.simulation().getAccountSnapshots();
+        int age = context.age();
+
+        BigDecimal totalAnnualRmd = BigDecimal.ZERO;
+        List<AccountRmd> accountRmds = new ArrayList<>();
+
+        for (AccountSnapshot account : accounts) {
+            if (account.subjectToRmd() && account.hasBalance()) {
+                BigDecimal annualRmd = rmdCalculator.calculateRmd(account.balance(), age);
+                totalAnnualRmd = totalAnnualRmd.add(annualRmd);
+                accountRmds.add(new AccountRmd(account, annualRmd));
+            }
+        }
+
+        BigDecimal monthlyRmd = totalAnnualRmd.divide(TWELVE, SCALE, RoundingMode.HALF_UP);
+        return new RmdRequirement(monthlyRmd, totalAnnualRmd, accountRmds);
+    }
+
+    private WithdrawalResult executeWithdrawals(
+            List<AccountSnapshot> accounts,
+            BigDecimal target,
+            RmdRequirement rmdRequirement,
+            SpendingContext context) {
+
+        List<AccountWithdrawal> withdrawals = new ArrayList<>();
+        BigDecimal remaining = target;
+        BigDecimal totalWithdrawn = BigDecimal.ZERO;
+        BigDecimal rmdWithdrawn = BigDecimal.ZERO;
+        BigDecimal discretionaryWithdrawn = BigDecimal.ZERO;
+
+        // First, withdraw from RMD accounts (up to their monthly RMD portion)
+        for (AccountRmd accountRmd : rmdRequirement.accountRmds()) {
+            if (remaining.compareTo(BigDecimal.ZERO) <= 0) {
+                break;
+            }
+
+            AccountSnapshot account = accountRmd.account();
+            BigDecimal monthlyRmd = accountRmd.annualRmd().divide(TWELVE, SCALE, RoundingMode.HALF_UP);
+            BigDecimal withdrawAmount = remaining.min(monthlyRmd).min(account.balance());
+
+            if (withdrawAmount.compareTo(BigDecimal.ZERO) > 0) {
+                AccountWithdrawal withdrawal = createWithdrawal(account, withdrawAmount);
+                withdrawals.add(withdrawal);
+                remaining = remaining.subtract(withdrawAmount);
+                totalWithdrawn = totalWithdrawn.add(withdrawAmount);
+                rmdWithdrawn = rmdWithdrawn.add(withdrawAmount);
+            }
+        }
+
+        // If more needed, withdraw from remaining accounts (tax-efficient order)
+        if (remaining.compareTo(BigDecimal.ZERO) > 0) {
+            List<AccountSnapshot> nonRmdAccounts = accounts.stream()
+                    .filter(a -> !a.subjectToRmd() && a.hasBalance())
+                    .sorted((a, b) -> {
+                        // Tax-efficient: Roth last
+                        int taxOrder = Integer.compare(
+                                getTaxPriority(a), getTaxPriority(b));
+                        if (taxOrder != 0) {
+                            return taxOrder;
+                        }
+                        return b.balance().compareTo(a.balance());
+                    })
+                    .toList();
+
+            for (AccountSnapshot account : nonRmdAccounts) {
+                if (remaining.compareTo(BigDecimal.ZERO) <= 0) {
+                    break;
+                }
+
+                BigDecimal withdrawAmount = remaining.min(account.balance());
+                if (withdrawAmount.compareTo(BigDecimal.ZERO) > 0) {
+                    AccountWithdrawal withdrawal = createWithdrawal(account, withdrawAmount);
+                    withdrawals.add(withdrawal);
+                    remaining = remaining.subtract(withdrawAmount);
+                    totalWithdrawn = totalWithdrawn.add(withdrawAmount);
+                    discretionaryWithdrawn = discretionaryWithdrawn.add(withdrawAmount);
+                }
+            }
+        }
+
+        return new WithdrawalResult(withdrawals, totalWithdrawn, rmdWithdrawn, discretionaryWithdrawn);
+    }
+
+    private AccountWithdrawal createWithdrawal(AccountSnapshot account, BigDecimal amount) {
+        return AccountWithdrawal.builder()
+                .accountSnapshot(account)
+                .amount(amount)
+                .priorBalance(account.balance())
+                .newBalance(account.balance().subtract(amount))
+                .build();
+    }
+
+    private int getTaxPriority(AccountSnapshot account) {
+        return switch (account.taxTreatment()) {
+            case PRE_TAX -> 1;      // Traditional - withdraw early
+            case TAXABLE -> 2;       // Brokerage
+            case ROTH -> 3;          // Roth - preserve tax-free growth
+            case HSA -> 4;           // HSA - preserve for healthcare
+        };
+    }
+
+    private record RmdRequirement(
+            BigDecimal totalMonthlyRmd,
+            BigDecimal totalAnnualRmd,
+            List<AccountRmd> accountRmds
+    ) {}
+
+    private record AccountRmd(
+            AccountSnapshot account,
+            BigDecimal annualRmd
+    ) {}
+
+    private record WithdrawalResult(
+            List<AccountWithdrawal> withdrawals,
+            BigDecimal totalWithdrawn,
+            BigDecimal rmdWithdrawn,
+            BigDecimal discretionaryWithdrawn
+    ) {}
+}

--- a/src/test/java/io/github/xmljim/retirement/domain/calculator/impl/RmdAwareOrchestratorTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/calculator/impl/RmdAwareOrchestratorTest.java
@@ -1,0 +1,250 @@
+package io.github.xmljim.retirement.domain.calculator.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.github.xmljim.retirement.domain.calculator.SpendingStrategy;
+import io.github.xmljim.retirement.domain.calculator.StubSimulationView;
+import io.github.xmljim.retirement.domain.enums.AccountType;
+import io.github.xmljim.retirement.domain.value.SpendingContext;
+import io.github.xmljim.retirement.domain.value.SpendingPlan;
+
+@DisplayName("RmdAwareOrchestrator Tests")
+class RmdAwareOrchestratorTest {
+
+    private static final BigDecimal MILLION = new BigDecimal("1000000");
+    private StubRmdCalculator rmdCalculator;
+    private RmdAwareOrchestrator orchestrator;
+
+    @BeforeEach
+    void setUp() {
+        rmdCalculator = new StubRmdCalculator();
+        orchestrator = new RmdAwareOrchestrator(rmdCalculator);
+    }
+
+    /**
+     * Stub RMD calculator for testing that doesn't require Spring config.
+     */
+    static class StubRmdCalculator extends DefaultRmdCalculator {
+
+        @Override
+        public BigDecimal calculateRmd(BigDecimal priorYearEndBalance, int age) {
+            BigDecimal factor = getDistributionFactor(age);
+            if (factor.compareTo(BigDecimal.ZERO) == 0) {
+                return BigDecimal.ZERO;
+            }
+            return priorYearEndBalance.divide(factor, 2, java.math.RoundingMode.HALF_UP);
+        }
+
+        @Override
+        public BigDecimal getDistributionFactor(int age) {
+            // IRS Uniform Lifetime Table (simplified)
+            return switch (age) {
+                case 72 -> new BigDecimal("27.4");
+                case 73 -> new BigDecimal("26.5");
+                case 74 -> new BigDecimal("25.5");
+                case 75 -> new BigDecimal("24.6");
+                case 76 -> new BigDecimal("23.7");
+                case 77 -> new BigDecimal("22.9");
+                case 78 -> new BigDecimal("22.0");
+                case 79 -> new BigDecimal("21.1");
+                case 80 -> new BigDecimal("20.2");
+                default -> age >= 72 ? new BigDecimal("20.0") : BigDecimal.ZERO;
+            };
+        }
+
+        @Override
+        public int getRmdStartAge(int birthYear) {
+            if (birthYear <= 1950) {
+                return 72;
+            } else if (birthYear <= 1959) {
+                return 73;
+            } else {
+                return 75;
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Non-RMD Age Tests")
+    class NonRmdAgeTests {
+
+        @Test
+        @DisplayName("Delegates to default orchestrator when not RMD age")
+        void delegatesWhenNotRmdAge() {
+            SpendingContext context = createContext(65, 1960, MILLION); // Not RMD age yet
+            SpendingStrategy strategy = new StaticSpendingStrategy();
+
+            SpendingPlan plan = orchestrator.execute(strategy, context);
+
+            assertNotNull(plan);
+            assertTrue(plan.meetsTarget());
+        }
+    }
+
+    @Nested
+    @DisplayName("RMD Enforcement Tests")
+    class RmdEnforcementTests {
+
+        @Test
+        @DisplayName("Forces RMD when strategy requests less")
+        void forcesRmdWhenStrategyRequestsLess() {
+            // 76 year old with $1M in Traditional 401k
+            // RMD factor at 76 ~= 23.7, so annual RMD ~= $42,194, monthly ~= $3,516
+            SpendingContext context = createContext(76, 1949, MILLION);
+
+            // Strategy only wants $1000/month (less than RMD)
+            SpendingStrategy strategy = new IncomeGapStrategy();
+            SpendingContext lowExpenseContext = SpendingContext.builder()
+                    .simulation(context.simulation())
+                    .date(context.date())
+                    .retirementStartDate(context.retirementStartDate())
+                    .totalExpenses(new BigDecimal("2000"))
+                    .otherIncome(new BigDecimal("1000")) // Gap = $1000
+                    .age(76)
+                    .birthYear(1949)
+                    .build();
+
+            SpendingPlan plan = orchestrator.execute(strategy, lowExpenseContext);
+
+            assertNotNull(plan);
+            // Verify RMD metadata exists and target is higher than strategy gap
+            assertNotNull(plan.metadata().get("rmdRequired"));
+            BigDecimal rmdRequired = new BigDecimal((String) plan.metadata().get("rmdRequired"));
+            BigDecimal strategyTarget = new BigDecimal((String) plan.metadata().get("strategyTarget"));
+
+            // RMD should be higher than the $1000 gap
+            assertTrue(rmdRequired.compareTo(strategyTarget) > 0,
+                    "RMD " + rmdRequired + " should be > strategy " + strategyTarget);
+            // Target should be RMD (higher than $1000 gap)
+            assertTrue(plan.targetWithdrawal().compareTo(new BigDecimal("1000")) > 0);
+        }
+
+        @Test
+        @DisplayName("Uses strategy amount when higher than RMD")
+        void usesStrategyWhenHigherThanRmd() {
+            SpendingContext context = createContext(76, 1949, MILLION);
+
+            // Strategy wants $5000/month (more than monthly RMD)
+            SpendingStrategy strategy = new IncomeGapStrategy();
+            SpendingContext highExpenseContext = SpendingContext.builder()
+                    .simulation(context.simulation())
+                    .date(context.date())
+                    .retirementStartDate(context.retirementStartDate())
+                    .totalExpenses(new BigDecimal("6000"))
+                    .otherIncome(new BigDecimal("1000")) // Gap = $5000
+                    .age(76)
+                    .birthYear(1949)
+                    .build();
+
+            SpendingPlan plan = orchestrator.execute(strategy, highExpenseContext);
+
+            assertNotNull(plan);
+            assertEquals("false", plan.metadata().get("rmdForced"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Withdrawal Tracking Tests")
+    class WithdrawalTrackingTests {
+
+        @Test
+        @DisplayName("Tracks RMD vs discretionary withdrawals")
+        void tracksRmdVsDiscretionary() {
+            SpendingContext context = createContextWithMultipleAccounts(76, 1949);
+
+            SpendingStrategy strategy = new IncomeGapStrategy();
+            SpendingContext expenseContext = SpendingContext.builder()
+                    .simulation(context.simulation())
+                    .date(context.date())
+                    .retirementStartDate(context.retirementStartDate())
+                    .totalExpenses(new BigDecimal("8000"))
+                    .otherIncome(new BigDecimal("2000"))
+                    .age(76)
+                    .birthYear(1949)
+                    .build();
+
+            SpendingPlan plan = orchestrator.execute(strategy, expenseContext);
+
+            assertNotNull(plan.metadata().get("rmdWithdrawn"));
+            assertNotNull(plan.metadata().get("discretionaryWithdrawn"));
+            assertNotNull(plan.metadata().get("rmdRequired"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Sequencer Selection Tests")
+    class SequencerSelectionTests {
+
+        @Test
+        @DisplayName("Uses RMD-first sequencer when RMD required")
+        void usesRmdFirstSequencer() {
+            SpendingContext context = createContext(76, 1949, MILLION);
+
+            var sequencer = orchestrator.selectDefaultSequencer(context);
+
+            assertTrue(sequencer instanceof RmdFirstSequencer);
+        }
+
+        @Test
+        @DisplayName("Uses tax-efficient sequencer when no RMD")
+        void usesTaxEfficientSequencerWhenNoRmd() {
+            SpendingContext context = createContext(65, 1960, MILLION);
+
+            var sequencer = orchestrator.selectDefaultSequencer(context);
+
+            assertTrue(sequencer instanceof TaxEfficientSequencer);
+        }
+    }
+
+    // Helper methods
+
+    private SpendingContext createContext(int age, int birthYear, BigDecimal balance) {
+        StubSimulationView sim = StubSimulationView.builder()
+                .addAccount(StubSimulationView.createTestAccount(
+                        "Traditional 401k", AccountType.TRADITIONAL_401K, balance))
+                .initialPortfolioBalance(balance)
+                .build();
+
+        return SpendingContext.builder()
+                .simulation(sim)
+                .date(LocalDate.of(2025, 6, 1))
+                .retirementStartDate(LocalDate.of(2020, 1, 1))
+                .totalExpenses(new BigDecimal("5000"))
+                .otherIncome(new BigDecimal("2000"))
+                .age(age)
+                .birthYear(birthYear)
+                .build();
+    }
+
+    private SpendingContext createContextWithMultipleAccounts(int age, int birthYear) {
+        StubSimulationView sim = StubSimulationView.builder()
+                .addAccount(StubSimulationView.createTestAccount(
+                        "Traditional 401k", AccountType.TRADITIONAL_401K, new BigDecimal("500000")))
+                .addAccount(StubSimulationView.createTestAccount(
+                        "Roth IRA", AccountType.ROTH_IRA, new BigDecimal("200000")))
+                .addAccount(StubSimulationView.createTestAccount(
+                        "Brokerage", AccountType.TAXABLE_BROKERAGE, new BigDecimal("300000")))
+                .initialPortfolioBalance(MILLION)
+                .build();
+
+        return SpendingContext.builder()
+                .simulation(sim)
+                .date(LocalDate.of(2025, 6, 1))
+                .retirementStartDate(LocalDate.of(2020, 1, 1))
+                .totalExpenses(new BigDecimal("5000"))
+                .otherIncome(new BigDecimal("2000"))
+                .age(age)
+                .birthYear(birthYear)
+                .build();
+    }
+}

--- a/src/test/java/io/github/xmljim/retirement/domain/calculator/impl/RmdRulesTestLoader.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/calculator/impl/RmdRulesTestLoader.java
@@ -1,0 +1,76 @@
+package io.github.xmljim.retirement.domain.calculator.impl;
+
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+import org.yaml.snakeyaml.Yaml;
+
+import io.github.xmljim.retirement.domain.config.RmdRules;
+
+/**
+ * Utility to load RmdRules from application-rmd.yml for testing.
+ *
+ * <p>This ensures tests use the same configuration as production,
+ * preventing technical debt when IRS rules change.
+ */
+public final class RmdRulesTestLoader {
+
+    private RmdRulesTestLoader() {
+        // Utility class
+    }
+
+    /**
+     * Loads RmdRules from application-rmd.yml.
+     *
+     * @return configured RmdRules instance
+     */
+    @SuppressWarnings("unchecked")
+    public static RmdRules loadFromYaml() {
+        Yaml yaml = new Yaml();
+        InputStream inputStream = RmdRulesTestLoader.class.getClassLoader()
+                .getResourceAsStream("application-rmd.yml");
+
+        if (inputStream == null) {
+            throw new IllegalStateException("application-rmd.yml not found on classpath");
+        }
+
+        Map<String, Object> root = yaml.load(inputStream);
+        Map<String, Object> rmdConfig = (Map<String, Object>) root.get("rmd");
+
+        RmdRules rules = new RmdRules();
+
+        // Load start ages
+        List<Map<String, Object>> startAges =
+                (List<Map<String, Object>>) rmdConfig.get("start-age-by-birth-year");
+        for (Map<String, Object> entry : startAges) {
+            RmdRules.StartAgeEntry startAgeEntry = new RmdRules.StartAgeEntry();
+            if (entry.containsKey("birth-year-min")) {
+                startAgeEntry.setBirthYearMin((Integer) entry.get("birth-year-min"));
+            }
+            if (entry.containsKey("birth-year-max")) {
+                startAgeEntry.setBirthYearMax((Integer) entry.get("birth-year-max"));
+            }
+            startAgeEntry.setStartAge((Integer) entry.get("start-age"));
+            rules.getStartAgeByBirthYear().add(startAgeEntry);
+        }
+
+        // Load uniform lifetime table
+        List<Map<String, Object>> uniformTable =
+                (List<Map<String, Object>>) rmdConfig.get("uniform-lifetime-table");
+        for (Map<String, Object> entry : uniformTable) {
+            RmdRules.LifeTableEntry lifeEntry = new RmdRules.LifeTableEntry();
+            lifeEntry.setAge((Integer) entry.get("age"));
+            Object factor = entry.get("factor");
+            if (factor instanceof Double) {
+                lifeEntry.setFactor(BigDecimal.valueOf((Double) factor));
+            } else if (factor instanceof Integer) {
+                lifeEntry.setFactor(BigDecimal.valueOf((Integer) factor));
+            }
+            rules.getUniformLifetimeTable().add(lifeEntry);
+        }
+
+        return rules;
+    }
+}


### PR DESCRIPTION
## Summary
- Implements `RmdAwareOrchestrator` that ensures RMD compliance before applying spending strategies
- Forces RMD withdrawals even if the spending strategy requests less
- Tracks RMD vs discretionary withdrawals separately in SpendingPlan metadata
- Delegates to default orchestrator when person is not yet RMD age
- Prevents IRS penalties (25% of missed RMD under SECURE 2.0)

## RMD Logic Flow
```
If (Total RMD >= Strategy Withdrawal):
  - Withdraw full RMD (forced)
  - Excess RMD available for spending or reinvestment

If (Total RMD < Strategy Withdrawal):
  - Withdraw full RMD first
  - Apply strategy for remaining (need - RMD)
```

## Test plan
- [x] Non-RMD age delegates to default orchestrator
- [x] Forces RMD when strategy requests less
- [x] Uses strategy amount when higher than RMD
- [x] Tracks RMD vs discretionary withdrawals
- [x] Uses RmdFirstSequencer when RMD required
- [x] Uses TaxEfficientSequencer when no RMD
- [x] Coverage checks pass (80%+ branches)

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)