### PR TITLE
feat(#269): Create MonthlySnapshot and AccountMonthlyFlow records

### DIFF
--- a/src/main/java/io/github/xmljim/retirement/domain/enums/SimulationPhase.java
+++ b/src/main/java/io/github/xmljim/retirement/domain/enums/SimulationPhase.java
@@ -1,0 +1,128 @@
+package io.github.xmljim.retirement.domain.enums;
+
+/**
+ * Represents the current phase of a person within a retirement simulation.
+ *
+ * <p>Each person in a simulation progresses through phases based on their
+ * retirement date, withdrawal start date, and life status. In a couple
+ * simulation, each person may be in different phases (staggered retirement).
+ *
+ * <p>Phase transitions are typically triggered by events:
+ * <ul>
+ *   <li>Retirement date reached → ACCUMULATION to DISTRIBUTION (or TRANSITION)</li>
+ *   <li>Withdrawal start date reached → TRANSITION to DISTRIBUTION</li>
+ *   <li>Spouse death → SURVIVOR</li>
+ * </ul>
+ *
+ * @see io.github.xmljim.retirement.domain.value.MonthlySnapshot
+ */
+public enum SimulationPhase {
+
+    /**
+     * Working and contributing to retirement accounts.
+     *
+     * <p>During accumulation:
+     * <ul>
+     *   <li>Salary income is active</li>
+     *   <li>Contributions are made to retirement accounts</li>
+     *   <li>No withdrawals from retirement accounts</li>
+     *   <li>Employer match applies</li>
+     * </ul>
+     */
+    ACCUMULATION("Accumulation", "Working and contributing to retirement accounts"),
+
+    /**
+     * Retired but not yet withdrawing from portfolio.
+     *
+     * <p>This optional bridge period occurs when:
+     * <ul>
+     *   <li>Person has retired (no salary income)</li>
+     *   <li>But has other income covering expenses (pension, part-time, etc.)</li>
+     *   <li>Portfolio continues to grow without withdrawals</li>
+     * </ul>
+     *
+     * <p>Not all simulations have a transition phase; many go directly
+     * from ACCUMULATION to DISTRIBUTION.
+     */
+    TRANSITION("Transition", "Retired but not yet withdrawing from portfolio"),
+
+    /**
+     * Withdrawing from portfolio to fund retirement expenses.
+     *
+     * <p>During distribution:
+     * <ul>
+     *   <li>No salary income (retired)</li>
+     *   <li>Social Security, pension, annuity income may be active</li>
+     *   <li>Withdrawals from retirement accounts to cover income gap</li>
+     *   <li>RMDs apply if over RMD age</li>
+     *   <li>Spending strategy determines withdrawal amounts</li>
+     * </ul>
+     */
+    DISTRIBUTION("Distribution", "Withdrawing from portfolio to fund retirement"),
+
+    /**
+     * One spouse has deceased; survivor continues alone.
+     *
+     * <p>In survivor phase:
+     * <ul>
+     *   <li>Expense adjustments apply (housing 70%, food 60%, etc.)</li>
+     *   <li>Survivor Social Security benefits apply</li>
+     *   <li>Accounts may be inherited or rolled over</li>
+     *   <li>Single tax filing status</li>
+     * </ul>
+     */
+    SURVIVOR("Survivor", "One spouse deceased; survivor continues");
+
+    private final String displayName;
+    private final String description;
+
+    SimulationPhase(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+
+    /**
+     * Returns the human-readable display name.
+     *
+     * @return the display name
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * Returns a brief description of this phase.
+     *
+     * @return the description
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Indicates whether contributions are allowed in this phase.
+     *
+     * @return true if contributions can be made
+     */
+    public boolean allowsContributions() {
+        return this == ACCUMULATION;
+    }
+
+    /**
+     * Indicates whether withdrawals are expected in this phase.
+     *
+     * @return true if withdrawals typically occur
+     */
+    public boolean expectsWithdrawals() {
+        return this == DISTRIBUTION || this == SURVIVOR;
+    }
+
+    /**
+     * Indicates whether this is a retirement phase (not working).
+     *
+     * @return true if retired
+     */
+    public boolean isRetired() {
+        return this != ACCUMULATION;
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/simulation/result/AccountMonthlyFlow.java
+++ b/src/main/java/io/github/xmljim/retirement/simulation/result/AccountMonthlyFlow.java
@@ -1,0 +1,265 @@
+package io.github.xmljim.retirement.simulation.result;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.UUID;
+
+/**
+ * Captures the financial flows for a single account during one month.
+ *
+ * <p>This record is the source of truth for account-level changes within
+ * a simulation month. It tracks:
+ * <ul>
+ *   <li>Starting balance (beginning of month)</li>
+ *   <li>Contributions (deposits during month)</li>
+ *   <li>Withdrawals (distributions during month)</li>
+ *   <li>Investment returns (growth/loss during month)</li>
+ *   <li>Ending balance (end of month)</li>
+ * </ul>
+ *
+ * <p>The relationship between fields:
+ * <pre>
+ * endingBalance = startingBalance + contributions - withdrawals + returns
+ * </pre>
+ *
+ * <p>Note: Returns are calculated on post-transaction balances (conservative
+ * modeling - withdrawn money doesn't earn that month's return).
+ *
+ * @param accountId the unique identifier of the account
+ * @param accountName the human-readable account name
+ * @param startingBalance the balance at the beginning of the month
+ * @param contributions deposits made during the month (zero or positive)
+ * @param withdrawals distributions made during the month (zero or positive)
+ * @param returns investment returns for the month (can be negative)
+ * @param endingBalance the balance at the end of the month
+ *
+ * @see MonthlySnapshot
+ */
+public record AccountMonthlyFlow(
+        UUID accountId,
+        String accountName,
+        BigDecimal startingBalance,
+        BigDecimal contributions,
+        BigDecimal withdrawals,
+        BigDecimal returns,
+        BigDecimal endingBalance
+) {
+
+    private static final int SCALE = 2;
+    private static final RoundingMode ROUNDING = RoundingMode.HALF_UP;
+
+    /**
+     * Compact constructor with validation.
+     */
+    public AccountMonthlyFlow {
+        if (accountId == null) {
+            throw new IllegalArgumentException("accountId cannot be null");
+        }
+        if (accountName == null || accountName.isBlank()) {
+            throw new IllegalArgumentException("accountName cannot be null or blank");
+        }
+        if (startingBalance == null) {
+            startingBalance = BigDecimal.ZERO;
+        }
+        if (contributions == null) {
+            contributions = BigDecimal.ZERO;
+        }
+        if (withdrawals == null) {
+            withdrawals = BigDecimal.ZERO;
+        }
+        if (returns == null) {
+            returns = BigDecimal.ZERO;
+        }
+        if (endingBalance == null) {
+            endingBalance = BigDecimal.ZERO;
+        }
+    }
+
+    /**
+     * Calculates the net flow for this month.
+     *
+     * <p>Net flow represents the total change in account value:
+     * <pre>
+     * netFlow = contributions - withdrawals + returns
+     * </pre>
+     *
+     * <p>A positive net flow indicates the account grew; negative indicates shrinkage.
+     *
+     * @return the net flow amount
+     */
+    public BigDecimal netFlow() {
+        return contributions
+                .subtract(withdrawals)
+                .add(returns)
+                .setScale(SCALE, ROUNDING);
+    }
+
+    /**
+     * Calculates the net contribution (deposits minus withdrawals).
+     *
+     * <p>This excludes investment returns to show pure cash movement.
+     *
+     * @return contributions minus withdrawals
+     */
+    public BigDecimal netContribution() {
+        return contributions.subtract(withdrawals).setScale(SCALE, ROUNDING);
+    }
+
+    /**
+     * Indicates whether this account had any activity this month.
+     *
+     * @return true if there were contributions, withdrawals, or non-zero returns
+     */
+    public boolean hasActivity() {
+        return contributions.compareTo(BigDecimal.ZERO) != 0
+                || withdrawals.compareTo(BigDecimal.ZERO) != 0
+                || returns.compareTo(BigDecimal.ZERO) != 0;
+    }
+
+    /**
+     * Indicates whether the account balance increased this month.
+     *
+     * @return true if ending balance exceeds starting balance
+     */
+    public boolean hadGrowth() {
+        return endingBalance.compareTo(startingBalance) > 0;
+    }
+
+    /**
+     * Calculates the return percentage for this month.
+     *
+     * <p>Return percentage is calculated on the post-transaction balance
+     * (starting + contributions - withdrawals).
+     *
+     * @return the return as a decimal (e.g., 0.01 for 1%), or ZERO if no base
+     */
+    public BigDecimal returnPercentage() {
+        BigDecimal postTransactionBalance = startingBalance
+                .add(contributions)
+                .subtract(withdrawals);
+
+        if (postTransactionBalance.compareTo(BigDecimal.ZERO) == 0) {
+            return BigDecimal.ZERO;
+        }
+
+        return returns
+                .divide(postTransactionBalance, 6, ROUNDING)
+                .setScale(6, ROUNDING);
+    }
+
+    /**
+     * Creates a new flow with updated returns and ending balance.
+     *
+     * <p>This is used when returns are calculated after the initial flow is created.
+     *
+     * @param newReturns the calculated returns
+     * @param newEndingBalance the new ending balance after returns
+     * @return a new AccountMonthlyFlow with updated values
+     */
+    public AccountMonthlyFlow withReturns(BigDecimal newReturns, BigDecimal newEndingBalance) {
+        return new AccountMonthlyFlow(
+                accountId,
+                accountName,
+                startingBalance,
+                contributions,
+                withdrawals,
+                newReturns,
+                newEndingBalance
+        );
+    }
+
+    /**
+     * Creates a builder for constructing AccountMonthlyFlow instances.
+     *
+     * @param accountId the account identifier
+     * @param accountName the account name
+     * @return a new builder
+     */
+    public static Builder builder(UUID accountId, String accountName) {
+        return new Builder(accountId, accountName);
+    }
+
+    /**
+     * Builder for AccountMonthlyFlow.
+     */
+    public static final class Builder {
+        private final UUID accountId;
+        private final String accountName;
+        private BigDecimal startingBalance = BigDecimal.ZERO;
+        private BigDecimal contributions = BigDecimal.ZERO;
+        private BigDecimal withdrawals = BigDecimal.ZERO;
+        private BigDecimal returns = BigDecimal.ZERO;
+
+        private Builder(UUID accountId, String accountName) {
+            this.accountId = accountId;
+            this.accountName = accountName;
+        }
+
+        /**
+         * Sets the starting balance.
+         *
+         * @param balance the starting balance
+         * @return this builder
+         */
+        public Builder startingBalance(BigDecimal balance) {
+            this.startingBalance = balance;
+            return this;
+        }
+
+        /**
+         * Sets the contributions amount.
+         *
+         * @param amount the contributions
+         * @return this builder
+         */
+        public Builder contributions(BigDecimal amount) {
+            this.contributions = amount;
+            return this;
+        }
+
+        /**
+         * Sets the withdrawals amount.
+         *
+         * @param amount the withdrawals
+         * @return this builder
+         */
+        public Builder withdrawals(BigDecimal amount) {
+            this.withdrawals = amount;
+            return this;
+        }
+
+        /**
+         * Sets the returns amount.
+         *
+         * @param amount the returns
+         * @return this builder
+         */
+        public Builder returns(BigDecimal amount) {
+            this.returns = amount;
+            return this;
+        }
+
+        /**
+         * Builds the AccountMonthlyFlow, calculating endingBalance automatically.
+         *
+         * @return the constructed AccountMonthlyFlow
+         */
+        public AccountMonthlyFlow build() {
+            BigDecimal endingBalance = startingBalance
+                    .add(contributions)
+                    .subtract(withdrawals)
+                    .add(returns)
+                    .setScale(SCALE, ROUNDING);
+
+            return new AccountMonthlyFlow(
+                    accountId,
+                    accountName,
+                    startingBalance,
+                    contributions,
+                    withdrawals,
+                    returns,
+                    endingBalance
+            );
+        }
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/simulation/result/MonthlySnapshot.java
+++ b/src/main/java/io/github/xmljim/retirement/simulation/result/MonthlySnapshot.java
@@ -1,0 +1,512 @@
+package io.github.xmljim.retirement.simulation.result;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.github.xmljim.retirement.domain.enums.ExpenseCategoryGroup;
+import io.github.xmljim.retirement.domain.enums.SimulationPhase;
+
+/**
+ * Captures the complete state of a simulation for a single month.
+ *
+ * <p>MonthlySnapshot is the primary output record for each month of simulation.
+ * It aggregates all financial activity including:
+ * <ul>
+ *   <li>Account-level flows (contributions, withdrawals, returns)</li>
+ *   <li>Income from all sources</li>
+ *   <li>Expenses by category</li>
+ *   <li>Tax calculations</li>
+ *   <li>Cumulative metrics</li>
+ *   <li>Events that triggered during the month</li>
+ * </ul>
+ *
+ * <p>The {@code accountFlows} map is the source of truth for account balances.
+ * Aggregate portfolio totals are computed via methods like {@link #totalPortfolioBalance()}.
+ *
+ * @param month the year-month this snapshot represents
+ * @param accountFlows per-account financial flows (source of truth)
+ * @param salaryIncome salary/wages income this month
+ * @param socialSecurityIncome Social Security benefits this month
+ * @param pensionIncome pension income this month
+ * @param otherIncome other income (rental, part-time, etc.) this month
+ * @param totalExpenses total expenses this month
+ * @param expensesByCategory expenses broken down by category group
+ * @param taxes tax calculations for this month
+ * @param cumulativeContributions running total of all contributions since start
+ * @param cumulativeWithdrawals running total of all withdrawals since start
+ * @param cumulativeReturns running total of all investment returns since start
+ * @param cumulativeTaxesPaid running total of all taxes paid since start
+ * @param phase the simulation phase for this month
+ * @param eventsTriggered list of events that fired this month
+ *
+ * @see AccountMonthlyFlow
+ * @see TaxSummary
+ * @see SimulationPhase
+ */
+@SuppressFBWarnings(
+        value = "EI_EXPOSE_REP",
+        justification = "Collections are made unmodifiable in compact constructor"
+)
+public record MonthlySnapshot(
+        YearMonth month,
+        Map<UUID, AccountMonthlyFlow> accountFlows,
+        BigDecimal salaryIncome,
+        BigDecimal socialSecurityIncome,
+        BigDecimal pensionIncome,
+        BigDecimal otherIncome,
+        BigDecimal totalExpenses,
+        Map<ExpenseCategoryGroup, BigDecimal> expensesByCategory,
+        TaxSummary taxes,
+        BigDecimal cumulativeContributions,
+        BigDecimal cumulativeWithdrawals,
+        BigDecimal cumulativeReturns,
+        BigDecimal cumulativeTaxesPaid,
+        SimulationPhase phase,
+        List<String> eventsTriggered
+) {
+
+    private static final int SCALE = 2;
+    private static final RoundingMode ROUNDING = RoundingMode.HALF_UP;
+
+    /**
+     * Compact constructor with validation and defensive copying.
+     */
+    public MonthlySnapshot {
+        if (month == null) {
+            throw new IllegalArgumentException("month cannot be null");
+        }
+        // Defensive copies for mutable collections
+        accountFlows = accountFlows == null
+                ? Collections.emptyMap()
+                : Collections.unmodifiableMap(accountFlows);
+        expensesByCategory = expensesByCategory == null
+                ? Collections.emptyMap()
+                : Collections.unmodifiableMap(expensesByCategory);
+        eventsTriggered = eventsTriggered == null
+                ? Collections.emptyList()
+                : Collections.unmodifiableList(eventsTriggered);
+
+        // Null-safe defaults
+        if (salaryIncome == null) {
+            salaryIncome = BigDecimal.ZERO;
+        }
+        if (socialSecurityIncome == null) {
+            socialSecurityIncome = BigDecimal.ZERO;
+        }
+        if (pensionIncome == null) {
+            pensionIncome = BigDecimal.ZERO;
+        }
+        if (otherIncome == null) {
+            otherIncome = BigDecimal.ZERO;
+        }
+        if (totalExpenses == null) {
+            totalExpenses = BigDecimal.ZERO;
+        }
+        if (taxes == null) {
+            taxes = TaxSummary.empty();
+        }
+        if (cumulativeContributions == null) {
+            cumulativeContributions = BigDecimal.ZERO;
+        }
+        if (cumulativeWithdrawals == null) {
+            cumulativeWithdrawals = BigDecimal.ZERO;
+        }
+        if (cumulativeReturns == null) {
+            cumulativeReturns = BigDecimal.ZERO;
+        }
+        if (cumulativeTaxesPaid == null) {
+            cumulativeTaxesPaid = BigDecimal.ZERO;
+        }
+        if (phase == null) {
+            phase = SimulationPhase.ACCUMULATION;
+        }
+    }
+
+    // ─── Portfolio Aggregations ─────────────────────────────────────────────────
+
+    /**
+     * Calculates total portfolio balance across all accounts.
+     *
+     * @return sum of all account ending balances
+     */
+    public BigDecimal totalPortfolioBalance() {
+        return accountFlows.values().stream()
+                .map(AccountMonthlyFlow::endingBalance)
+                .reduce(BigDecimal.ZERO, BigDecimal::add)
+                .setScale(SCALE, ROUNDING);
+    }
+
+    /**
+     * Calculates total contributions this month across all accounts.
+     *
+     * @return sum of all account contributions
+     */
+    public BigDecimal totalContributions() {
+        return accountFlows.values().stream()
+                .map(AccountMonthlyFlow::contributions)
+                .reduce(BigDecimal.ZERO, BigDecimal::add)
+                .setScale(SCALE, ROUNDING);
+    }
+
+    /**
+     * Calculates total withdrawals this month across all accounts.
+     *
+     * @return sum of all account withdrawals
+     */
+    public BigDecimal totalWithdrawals() {
+        return accountFlows.values().stream()
+                .map(AccountMonthlyFlow::withdrawals)
+                .reduce(BigDecimal.ZERO, BigDecimal::add)
+                .setScale(SCALE, ROUNDING);
+    }
+
+    /**
+     * Calculates total investment returns this month across all accounts.
+     *
+     * @return sum of all account returns
+     */
+    public BigDecimal totalReturns() {
+        return accountFlows.values().stream()
+                .map(AccountMonthlyFlow::returns)
+                .reduce(BigDecimal.ZERO, BigDecimal::add)
+                .setScale(SCALE, ROUNDING);
+    }
+
+    // ─── Income Aggregations ────────────────────────────────────────────────────
+
+    /**
+     * Calculates total income from all sources this month.
+     *
+     * @return sum of salary, Social Security, pension, and other income
+     */
+    public BigDecimal totalIncome() {
+        return salaryIncome
+                .add(socialSecurityIncome)
+                .add(pensionIncome)
+                .add(otherIncome)
+                .setScale(SCALE, ROUNDING);
+    }
+
+    /**
+     * Calculates total non-salary income this month.
+     *
+     * <p>This represents retirement income sources (SS, pension, etc.)
+     * and is used for gap analysis during distribution phase.
+     *
+     * @return sum of Social Security, pension, and other income
+     */
+    public BigDecimal totalNonSalaryIncome() {
+        return socialSecurityIncome
+                .add(pensionIncome)
+                .add(otherIncome)
+                .setScale(SCALE, ROUNDING);
+    }
+
+    // ─── Cash Flow ──────────────────────────────────────────────────────────────
+
+    /**
+     * Calculates net cash flow (income minus expenses).
+     *
+     * <p>Positive indicates surplus; negative indicates gap requiring withdrawals.
+     *
+     * @return total income minus total expenses
+     */
+    public BigDecimal netCashFlow() {
+        return totalIncome().subtract(totalExpenses).setScale(SCALE, ROUNDING);
+    }
+
+    /**
+     * Calculates the income gap (expenses minus non-salary income).
+     *
+     * <p>This represents the amount needed from portfolio withdrawals
+     * during retirement.
+     *
+     * @return expenses minus non-salary income, or ZERO if no gap
+     */
+    public BigDecimal incomeGap() {
+        return totalExpenses
+                .subtract(totalNonSalaryIncome())
+                .max(BigDecimal.ZERO)
+                .setScale(SCALE, ROUNDING);
+    }
+
+    // ─── Convenience Methods ────────────────────────────────────────────────────
+
+    /**
+     * Returns the year portion of the month.
+     *
+     * @return the year
+     */
+    public int year() {
+        return month.getYear();
+    }
+
+    /**
+     * Returns the month-of-year (1-12).
+     *
+     * @return the month value
+     */
+    public int monthValue() {
+        return month.getMonthValue();
+    }
+
+    /**
+     * Indicates whether any events triggered this month.
+     *
+     * @return true if events list is not empty
+     */
+    public boolean hadEvents() {
+        return !eventsTriggered.isEmpty();
+    }
+
+    /**
+     * Returns the number of accounts in this snapshot.
+     *
+     * @return account count
+     */
+    public int accountCount() {
+        return accountFlows.size();
+    }
+
+    /**
+     * Gets the flow for a specific account.
+     *
+     * @param accountId the account identifier
+     * @return the account flow, or null if not found
+     */
+    public AccountMonthlyFlow getAccountFlow(UUID accountId) {
+        return accountFlows.get(accountId);
+    }
+
+    /**
+     * Gets expenses for a specific category group.
+     *
+     * @param group the expense category group
+     * @return the expense amount, or ZERO if not present
+     */
+    public BigDecimal getExpensesByGroup(ExpenseCategoryGroup group) {
+        return expensesByCategory.getOrDefault(group, BigDecimal.ZERO);
+    }
+
+    /**
+     * Creates a builder for constructing MonthlySnapshot instances.
+     *
+     * @param month the year-month
+     * @return a new builder
+     */
+    public static Builder builder(YearMonth month) {
+        return new Builder(month);
+    }
+
+    /**
+     * Builder for MonthlySnapshot.
+     */
+    public static final class Builder {
+        private final YearMonth month;
+        private Map<UUID, AccountMonthlyFlow> accountFlows = Collections.emptyMap();
+        private BigDecimal salaryIncome = BigDecimal.ZERO;
+        private BigDecimal socialSecurityIncome = BigDecimal.ZERO;
+        private BigDecimal pensionIncome = BigDecimal.ZERO;
+        private BigDecimal otherIncome = BigDecimal.ZERO;
+        private BigDecimal totalExpenses = BigDecimal.ZERO;
+        private Map<ExpenseCategoryGroup, BigDecimal> expensesByCategory = Collections.emptyMap();
+        private TaxSummary taxes = TaxSummary.empty();
+        private BigDecimal cumulativeContributions = BigDecimal.ZERO;
+        private BigDecimal cumulativeWithdrawals = BigDecimal.ZERO;
+        private BigDecimal cumulativeReturns = BigDecimal.ZERO;
+        private BigDecimal cumulativeTaxesPaid = BigDecimal.ZERO;
+        private SimulationPhase phase = SimulationPhase.ACCUMULATION;
+        private List<String> eventsTriggered = Collections.emptyList();
+
+        private Builder(YearMonth month) {
+            this.month = month;
+        }
+
+        /**
+         * Sets the per-account flows.
+         *
+         * @param flows the account flows map
+         * @return this builder
+         */
+        public Builder accountFlows(Map<UUID, AccountMonthlyFlow> flows) {
+            this.accountFlows = flows == null ? Collections.emptyMap() : new HashMap<>(flows);
+            return this;
+        }
+
+        /**
+         * Sets the salary income.
+         *
+         * @param amount the salary income
+         * @return this builder
+         */
+        public Builder salaryIncome(BigDecimal amount) {
+            this.salaryIncome = amount;
+            return this;
+        }
+
+        /**
+         * Sets the Social Security income.
+         *
+         * @param amount the Social Security income
+         * @return this builder
+         */
+        public Builder socialSecurityIncome(BigDecimal amount) {
+            this.socialSecurityIncome = amount;
+            return this;
+        }
+
+        /**
+         * Sets the pension income.
+         *
+         * @param amount the pension income
+         * @return this builder
+         */
+        public Builder pensionIncome(BigDecimal amount) {
+            this.pensionIncome = amount;
+            return this;
+        }
+
+        /**
+         * Sets the other income.
+         *
+         * @param amount the other income
+         * @return this builder
+         */
+        public Builder otherIncome(BigDecimal amount) {
+            this.otherIncome = amount;
+            return this;
+        }
+
+        /**
+         * Sets the total expenses.
+         *
+         * @param amount the total expenses
+         * @return this builder
+         */
+        public Builder totalExpenses(BigDecimal amount) {
+            this.totalExpenses = amount;
+            return this;
+        }
+
+        /**
+         * Sets the expenses by category.
+         *
+         * @param expenses the expenses by category group
+         * @return this builder
+         */
+        public Builder expensesByCategory(Map<ExpenseCategoryGroup, BigDecimal> expenses) {
+            this.expensesByCategory = expenses == null ? Collections.emptyMap() : new HashMap<>(expenses);
+            return this;
+        }
+
+        /**
+         * Sets the tax summary.
+         *
+         * @param taxes the tax summary
+         * @return this builder
+         */
+        public Builder taxes(TaxSummary taxes) {
+            this.taxes = taxes;
+            return this;
+        }
+
+        /**
+         * Sets the cumulative contributions.
+         *
+         * @param amount the cumulative contributions
+         * @return this builder
+         */
+        public Builder cumulativeContributions(BigDecimal amount) {
+            this.cumulativeContributions = amount;
+            return this;
+        }
+
+        /**
+         * Sets the cumulative withdrawals.
+         *
+         * @param amount the cumulative withdrawals
+         * @return this builder
+         */
+        public Builder cumulativeWithdrawals(BigDecimal amount) {
+            this.cumulativeWithdrawals = amount;
+            return this;
+        }
+
+        /**
+         * Sets the cumulative returns.
+         *
+         * @param amount the cumulative returns
+         * @return this builder
+         */
+        public Builder cumulativeReturns(BigDecimal amount) {
+            this.cumulativeReturns = amount;
+            return this;
+        }
+
+        /**
+         * Sets the cumulative taxes paid.
+         *
+         * @param amount the cumulative taxes paid
+         * @return this builder
+         */
+        public Builder cumulativeTaxesPaid(BigDecimal amount) {
+            this.cumulativeTaxesPaid = amount;
+            return this;
+        }
+
+        /**
+         * Sets the simulation phase.
+         *
+         * @param phase the simulation phase
+         * @return this builder
+         */
+        public Builder phase(SimulationPhase phase) {
+            this.phase = phase;
+            return this;
+        }
+
+        /**
+         * Sets the events triggered.
+         *
+         * @param events the events list
+         * @return this builder
+         */
+        public Builder eventsTriggered(List<String> events) {
+            this.eventsTriggered = events == null ? Collections.emptyList() : new ArrayList<>(events);
+            return this;
+        }
+
+        /**
+         * Builds the MonthlySnapshot.
+         *
+         * @return the constructed MonthlySnapshot
+         */
+        public MonthlySnapshot build() {
+            return new MonthlySnapshot(
+                    month,
+                    accountFlows,
+                    salaryIncome,
+                    socialSecurityIncome,
+                    pensionIncome,
+                    otherIncome,
+                    totalExpenses,
+                    expensesByCategory,
+                    taxes,
+                    cumulativeContributions,
+                    cumulativeWithdrawals,
+                    cumulativeReturns,
+                    cumulativeTaxesPaid,
+                    phase,
+                    eventsTriggered
+            );
+        }
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/simulation/result/TaxSummary.java
+++ b/src/main/java/io/github/xmljim/retirement/simulation/result/TaxSummary.java
@@ -1,0 +1,295 @@
+package io.github.xmljim.retirement.simulation.result;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+/**
+ * Captures tax-related information for a simulation month.
+ *
+ * <p>This record tracks taxable income components and calculated tax liability.
+ * It's designed to support future Roth conversion analysis by tracking
+ * marginal tax brackets.
+ *
+ * <p>Tax components include:
+ * <ul>
+ *   <li>Taxable withdrawals from pre-tax accounts (Traditional IRA/401k)</li>
+ *   <li>Tax-free withdrawals from Roth accounts</li>
+ *   <li>Taxable portion of Social Security benefits (0-85%)</li>
+ *   <li>Other taxable income (pension, annuity, etc.)</li>
+ * </ul>
+ *
+ * @param taxableIncome total taxable income this month
+ * @param taxableSSIncome portion of Social Security that's taxable (up to 85%)
+ * @param taxableWithdrawals pre-tax account withdrawals (Traditional IRA/401k)
+ * @param taxFreeWithdrawals Roth withdrawals (not taxable)
+ * @param federalTaxLiability calculated federal tax for the month
+ * @param effectiveTaxRate federal tax divided by taxable income
+ * @param marginalTaxBracket current marginal bracket (for Roth conversion decisions)
+ * @param rothConversionAmount Roth conversion amount if any this month
+ * @param rothConversionTax tax liability from Roth conversion
+ *
+ * @see MonthlySnapshot
+ */
+public record TaxSummary(
+        BigDecimal taxableIncome,
+        BigDecimal taxableSSIncome,
+        BigDecimal taxableWithdrawals,
+        BigDecimal taxFreeWithdrawals,
+        BigDecimal federalTaxLiability,
+        BigDecimal effectiveTaxRate,
+        BigDecimal marginalTaxBracket,
+        BigDecimal rothConversionAmount,
+        BigDecimal rothConversionTax
+) {
+
+    private static final int SCALE = 2;
+    private static final int RATE_SCALE = 4;
+    private static final RoundingMode ROUNDING = RoundingMode.HALF_UP;
+
+    /**
+     * Compact constructor with null-safe defaults.
+     */
+    public TaxSummary {
+        if (taxableIncome == null) {
+            taxableIncome = BigDecimal.ZERO;
+        }
+        if (taxableSSIncome == null) {
+            taxableSSIncome = BigDecimal.ZERO;
+        }
+        if (taxableWithdrawals == null) {
+            taxableWithdrawals = BigDecimal.ZERO;
+        }
+        if (taxFreeWithdrawals == null) {
+            taxFreeWithdrawals = BigDecimal.ZERO;
+        }
+        if (federalTaxLiability == null) {
+            federalTaxLiability = BigDecimal.ZERO;
+        }
+        if (effectiveTaxRate == null) {
+            effectiveTaxRate = BigDecimal.ZERO;
+        }
+        if (marginalTaxBracket == null) {
+            marginalTaxBracket = BigDecimal.ZERO;
+        }
+        if (rothConversionAmount == null) {
+            rothConversionAmount = BigDecimal.ZERO;
+        }
+        if (rothConversionTax == null) {
+            rothConversionTax = BigDecimal.ZERO;
+        }
+    }
+
+    /**
+     * Creates an empty TaxSummary with all zeros.
+     *
+     * @return a zero-valued TaxSummary
+     */
+    public static TaxSummary empty() {
+        return new TaxSummary(
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO
+        );
+    }
+
+    /**
+     * Calculates total withdrawals (taxable + tax-free).
+     *
+     * @return sum of all withdrawals
+     */
+    public BigDecimal totalWithdrawals() {
+        return taxableWithdrawals.add(taxFreeWithdrawals).setScale(SCALE, ROUNDING);
+    }
+
+    /**
+     * Calculates the total tax liability (federal + Roth conversion).
+     *
+     * @return combined tax liability
+     */
+    public BigDecimal totalTaxLiability() {
+        return federalTaxLiability.add(rothConversionTax).setScale(SCALE, ROUNDING);
+    }
+
+    /**
+     * Indicates whether a Roth conversion occurred this month.
+     *
+     * @return true if rothConversionAmount is greater than zero
+     */
+    public boolean hadRothConversion() {
+        return rothConversionAmount.compareTo(BigDecimal.ZERO) > 0;
+    }
+
+    /**
+     * Indicates whether any taxes are owed this month.
+     *
+     * @return true if total tax liability is greater than zero
+     */
+    public boolean hasTaxLiability() {
+        return totalTaxLiability().compareTo(BigDecimal.ZERO) > 0;
+    }
+
+    /**
+     * Calculates the percentage of withdrawals that are taxable.
+     *
+     * @return taxable withdrawals as a percentage of total, or ZERO if no withdrawals
+     */
+    public BigDecimal taxableWithdrawalPercentage() {
+        BigDecimal total = totalWithdrawals();
+        if (total.compareTo(BigDecimal.ZERO) == 0) {
+            return BigDecimal.ZERO;
+        }
+        return taxableWithdrawals
+                .divide(total, RATE_SCALE, ROUNDING);
+    }
+
+    /**
+     * Creates a builder for constructing TaxSummary instances.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for TaxSummary.
+     */
+    public static final class Builder {
+        private BigDecimal taxableIncome = BigDecimal.ZERO;
+        private BigDecimal taxableSSIncome = BigDecimal.ZERO;
+        private BigDecimal taxableWithdrawals = BigDecimal.ZERO;
+        private BigDecimal taxFreeWithdrawals = BigDecimal.ZERO;
+        private BigDecimal federalTaxLiability = BigDecimal.ZERO;
+        private BigDecimal effectiveTaxRate = BigDecimal.ZERO;
+        private BigDecimal marginalTaxBracket = BigDecimal.ZERO;
+        private BigDecimal rothConversionAmount = BigDecimal.ZERO;
+        private BigDecimal rothConversionTax = BigDecimal.ZERO;
+
+        private Builder() {
+        }
+
+        /**
+         * Sets the taxable income.
+         *
+         * @param amount the taxable income
+         * @return this builder
+         */
+        public Builder taxableIncome(BigDecimal amount) {
+            this.taxableIncome = amount;
+            return this;
+        }
+
+        /**
+         * Sets the taxable Social Security income.
+         *
+         * @param amount the taxable SS income
+         * @return this builder
+         */
+        public Builder taxableSSIncome(BigDecimal amount) {
+            this.taxableSSIncome = amount;
+            return this;
+        }
+
+        /**
+         * Sets the taxable withdrawals.
+         *
+         * @param amount the taxable withdrawals
+         * @return this builder
+         */
+        public Builder taxableWithdrawals(BigDecimal amount) {
+            this.taxableWithdrawals = amount;
+            return this;
+        }
+
+        /**
+         * Sets the tax-free withdrawals.
+         *
+         * @param amount the tax-free withdrawals
+         * @return this builder
+         */
+        public Builder taxFreeWithdrawals(BigDecimal amount) {
+            this.taxFreeWithdrawals = amount;
+            return this;
+        }
+
+        /**
+         * Sets the federal tax liability.
+         *
+         * @param amount the federal tax
+         * @return this builder
+         */
+        public Builder federalTaxLiability(BigDecimal amount) {
+            this.federalTaxLiability = amount;
+            return this;
+        }
+
+        /**
+         * Sets the effective tax rate.
+         *
+         * @param rate the effective rate as decimal
+         * @return this builder
+         */
+        public Builder effectiveTaxRate(BigDecimal rate) {
+            this.effectiveTaxRate = rate;
+            return this;
+        }
+
+        /**
+         * Sets the marginal tax bracket.
+         *
+         * @param bracket the marginal bracket as decimal
+         * @return this builder
+         */
+        public Builder marginalTaxBracket(BigDecimal bracket) {
+            this.marginalTaxBracket = bracket;
+            return this;
+        }
+
+        /**
+         * Sets the Roth conversion amount.
+         *
+         * @param amount the conversion amount
+         * @return this builder
+         */
+        public Builder rothConversionAmount(BigDecimal amount) {
+            this.rothConversionAmount = amount;
+            return this;
+        }
+
+        /**
+         * Sets the Roth conversion tax.
+         *
+         * @param amount the tax on conversion
+         * @return this builder
+         */
+        public Builder rothConversionTax(BigDecimal amount) {
+            this.rothConversionTax = amount;
+            return this;
+        }
+
+        /**
+         * Builds the TaxSummary.
+         *
+         * @return the constructed TaxSummary
+         */
+        public TaxSummary build() {
+            return new TaxSummary(
+                    taxableIncome,
+                    taxableSSIncome,
+                    taxableWithdrawals,
+                    taxFreeWithdrawals,
+                    federalTaxLiability,
+                    effectiveTaxRate,
+                    marginalTaxBracket,
+                    rothConversionAmount,
+                    rothConversionTax
+            );
+        }
+    }
+}

--- a/src/test/java/io/github/xmljim/retirement/domain/enums/SimulationPhaseTest.java
+++ b/src/test/java/io/github/xmljim/retirement/domain/enums/SimulationPhaseTest.java
@@ -1,0 +1,176 @@
+package io.github.xmljim.retirement.domain.enums;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+@DisplayName("SimulationPhase")
+class SimulationPhaseTest {
+
+    @Nested
+    @DisplayName("Enum Values")
+    class EnumValues {
+
+        @Test
+        @DisplayName("should have exactly 4 phases")
+        void shouldHaveExactlyFourPhases() {
+            assertEquals(4, SimulationPhase.values().length);
+        }
+
+        @Test
+        @DisplayName("should have expected phases")
+        void shouldHaveExpectedPhases() {
+            Set<String> phases = Arrays.stream(SimulationPhase.values())
+                    .map(Enum::name)
+                    .collect(Collectors.toSet());
+
+            assertTrue(phases.contains("ACCUMULATION"));
+            assertTrue(phases.contains("TRANSITION"));
+            assertTrue(phases.contains("DISTRIBUTION"));
+            assertTrue(phases.contains("SURVIVOR"));
+        }
+
+        @ParameterizedTest
+        @EnumSource(SimulationPhase.class)
+        @DisplayName("all phases should have display names")
+        void allPhasesShouldHaveDisplayNames(SimulationPhase phase) {
+            assertNotNull(phase.getDisplayName());
+            assertFalse(phase.getDisplayName().isBlank());
+        }
+
+        @ParameterizedTest
+        @EnumSource(SimulationPhase.class)
+        @DisplayName("all phases should have descriptions")
+        void allPhasesShouldHaveDescriptions(SimulationPhase phase) {
+            assertNotNull(phase.getDescription());
+            assertFalse(phase.getDescription().isBlank());
+        }
+    }
+
+    @Nested
+    @DisplayName("allowsContributions")
+    class AllowsContributions {
+
+        @Test
+        @DisplayName("ACCUMULATION should allow contributions")
+        void accumulationAllowsContributions() {
+            assertTrue(SimulationPhase.ACCUMULATION.allowsContributions());
+        }
+
+        @Test
+        @DisplayName("TRANSITION should not allow contributions")
+        void transitionDisallowsContributions() {
+            assertFalse(SimulationPhase.TRANSITION.allowsContributions());
+        }
+
+        @Test
+        @DisplayName("DISTRIBUTION should not allow contributions")
+        void distributionDisallowsContributions() {
+            assertFalse(SimulationPhase.DISTRIBUTION.allowsContributions());
+        }
+
+        @Test
+        @DisplayName("SURVIVOR should not allow contributions")
+        void survivorDisallowsContributions() {
+            assertFalse(SimulationPhase.SURVIVOR.allowsContributions());
+        }
+    }
+
+    @Nested
+    @DisplayName("expectsWithdrawals")
+    class ExpectsWithdrawals {
+
+        @Test
+        @DisplayName("ACCUMULATION should not expect withdrawals")
+        void accumulationDoesNotExpectWithdrawals() {
+            assertFalse(SimulationPhase.ACCUMULATION.expectsWithdrawals());
+        }
+
+        @Test
+        @DisplayName("TRANSITION should not expect withdrawals")
+        void transitionDoesNotExpectWithdrawals() {
+            assertFalse(SimulationPhase.TRANSITION.expectsWithdrawals());
+        }
+
+        @Test
+        @DisplayName("DISTRIBUTION should expect withdrawals")
+        void distributionExpectsWithdrawals() {
+            assertTrue(SimulationPhase.DISTRIBUTION.expectsWithdrawals());
+        }
+
+        @Test
+        @DisplayName("SURVIVOR should expect withdrawals")
+        void survivorExpectsWithdrawals() {
+            assertTrue(SimulationPhase.SURVIVOR.expectsWithdrawals());
+        }
+    }
+
+    @Nested
+    @DisplayName("isRetired")
+    class IsRetired {
+
+        @Test
+        @DisplayName("ACCUMULATION should not be retired")
+        void accumulationIsNotRetired() {
+            assertFalse(SimulationPhase.ACCUMULATION.isRetired());
+        }
+
+        @Test
+        @DisplayName("TRANSITION should be retired")
+        void transitionIsRetired() {
+            assertTrue(SimulationPhase.TRANSITION.isRetired());
+        }
+
+        @Test
+        @DisplayName("DISTRIBUTION should be retired")
+        void distributionIsRetired() {
+            assertTrue(SimulationPhase.DISTRIBUTION.isRetired());
+        }
+
+        @Test
+        @DisplayName("SURVIVOR should be retired")
+        void survivorIsRetired() {
+            assertTrue(SimulationPhase.SURVIVOR.isRetired());
+        }
+    }
+
+    @Nested
+    @DisplayName("Display and Description")
+    class DisplayAndDescription {
+
+        @Test
+        @DisplayName("ACCUMULATION display name should be 'Accumulation'")
+        void accumulationDisplayName() {
+            assertEquals("Accumulation", SimulationPhase.ACCUMULATION.getDisplayName());
+        }
+
+        @Test
+        @DisplayName("TRANSITION display name should be 'Transition'")
+        void transitionDisplayName() {
+            assertEquals("Transition", SimulationPhase.TRANSITION.getDisplayName());
+        }
+
+        @Test
+        @DisplayName("DISTRIBUTION display name should be 'Distribution'")
+        void distributionDisplayName() {
+            assertEquals("Distribution", SimulationPhase.DISTRIBUTION.getDisplayName());
+        }
+
+        @Test
+        @DisplayName("SURVIVOR display name should be 'Survivor'")
+        void survivorDisplayName() {
+            assertEquals("Survivor", SimulationPhase.SURVIVOR.getDisplayName());
+        }
+    }
+}

--- a/src/test/java/io/github/xmljim/retirement/simulation/result/AccountMonthlyFlowTest.java
+++ b/src/test/java/io/github/xmljim/retirement/simulation/result/AccountMonthlyFlowTest.java
@@ -1,0 +1,280 @@
+package io.github.xmljim.retirement.simulation.result;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("AccountMonthlyFlow")
+class AccountMonthlyFlowTest {
+
+    private static final UUID ACCOUNT_ID = UUID.randomUUID();
+    private static final String ACCOUNT_NAME = "Traditional 401k";
+
+    @Nested
+    @DisplayName("Construction")
+    class Construction {
+
+        @Test
+        @DisplayName("should create with all values")
+        void shouldCreateWithAllValues() {
+            AccountMonthlyFlow flow = new AccountMonthlyFlow(
+                    ACCOUNT_ID,
+                    ACCOUNT_NAME,
+                    new BigDecimal("100000.00"),
+                    new BigDecimal("1000.00"),
+                    BigDecimal.ZERO,
+                    new BigDecimal("500.00"),
+                    new BigDecimal("101500.00")
+            );
+
+            assertEquals(ACCOUNT_ID, flow.accountId());
+            assertEquals(ACCOUNT_NAME, flow.accountName());
+            assertEquals(new BigDecimal("100000.00"), flow.startingBalance());
+            assertEquals(new BigDecimal("1000.00"), flow.contributions());
+            assertEquals(BigDecimal.ZERO, flow.withdrawals());
+            assertEquals(new BigDecimal("500.00"), flow.returns());
+            assertEquals(new BigDecimal("101500.00"), flow.endingBalance());
+        }
+
+        @Test
+        @DisplayName("should default null amounts to zero")
+        void shouldDefaultNullAmountsToZero() {
+            AccountMonthlyFlow flow = new AccountMonthlyFlow(
+                    ACCOUNT_ID,
+                    ACCOUNT_NAME,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+            );
+
+            assertEquals(BigDecimal.ZERO, flow.startingBalance());
+            assertEquals(BigDecimal.ZERO, flow.contributions());
+            assertEquals(BigDecimal.ZERO, flow.withdrawals());
+            assertEquals(BigDecimal.ZERO, flow.returns());
+            assertEquals(BigDecimal.ZERO, flow.endingBalance());
+        }
+
+        @Test
+        @DisplayName("should reject null accountId")
+        void shouldRejectNullAccountId() {
+            assertThrows(IllegalArgumentException.class, () ->
+                    new AccountMonthlyFlow(null, ACCOUNT_NAME, BigDecimal.ZERO,
+                            BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO));
+        }
+
+        @Test
+        @DisplayName("should reject null accountName")
+        void shouldRejectNullAccountName() {
+            assertThrows(IllegalArgumentException.class, () ->
+                    new AccountMonthlyFlow(ACCOUNT_ID, null, BigDecimal.ZERO,
+                            BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO));
+        }
+
+        @Test
+        @DisplayName("should reject blank accountName")
+        void shouldRejectBlankAccountName() {
+            assertThrows(IllegalArgumentException.class, () ->
+                    new AccountMonthlyFlow(ACCOUNT_ID, "  ", BigDecimal.ZERO,
+                            BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO));
+        }
+    }
+
+    @Nested
+    @DisplayName("Builder")
+    class BuilderTests {
+
+        @Test
+        @DisplayName("should build with calculated ending balance")
+        void shouldBuildWithCalculatedEndingBalance() {
+            AccountMonthlyFlow flow = AccountMonthlyFlow.builder(ACCOUNT_ID, ACCOUNT_NAME)
+                    .startingBalance(new BigDecimal("100000"))
+                    .contributions(new BigDecimal("1000"))
+                    .withdrawals(BigDecimal.ZERO)
+                    .returns(new BigDecimal("500"))
+                    .build();
+
+            assertEquals(new BigDecimal("101500.00"), flow.endingBalance());
+        }
+
+        @Test
+        @DisplayName("should calculate ending balance with withdrawal")
+        void shouldCalculateEndingBalanceWithWithdrawal() {
+            AccountMonthlyFlow flow = AccountMonthlyFlow.builder(ACCOUNT_ID, ACCOUNT_NAME)
+                    .startingBalance(new BigDecimal("100000"))
+                    .withdrawals(new BigDecimal("5000"))
+                    .returns(new BigDecimal("400"))
+                    .build();
+
+            // 100000 - 5000 + 400 = 95400
+            assertEquals(new BigDecimal("95400.00"), flow.endingBalance());
+        }
+    }
+
+    @Nested
+    @DisplayName("Calculations")
+    class Calculations {
+
+        @Test
+        @DisplayName("netFlow should be contributions - withdrawals + returns")
+        void netFlowCalculation() {
+            AccountMonthlyFlow flow = AccountMonthlyFlow.builder(ACCOUNT_ID, ACCOUNT_NAME)
+                    .startingBalance(new BigDecimal("100000"))
+                    .contributions(new BigDecimal("1000"))
+                    .withdrawals(new BigDecimal("500"))
+                    .returns(new BigDecimal("300"))
+                    .build();
+
+            // 1000 - 500 + 300 = 800
+            assertEquals(new BigDecimal("800.00"), flow.netFlow());
+        }
+
+        @Test
+        @DisplayName("netContribution should be contributions - withdrawals")
+        void netContributionCalculation() {
+            AccountMonthlyFlow flow = AccountMonthlyFlow.builder(ACCOUNT_ID, ACCOUNT_NAME)
+                    .startingBalance(new BigDecimal("100000"))
+                    .contributions(new BigDecimal("1000"))
+                    .withdrawals(new BigDecimal("300"))
+                    .returns(new BigDecimal("500"))
+                    .build();
+
+            // 1000 - 300 = 700
+            assertEquals(new BigDecimal("700.00"), flow.netContribution());
+        }
+
+        @Test
+        @DisplayName("returnPercentage should calculate correctly")
+        void returnPercentageCalculation() {
+            AccountMonthlyFlow flow = AccountMonthlyFlow.builder(ACCOUNT_ID, ACCOUNT_NAME)
+                    .startingBalance(new BigDecimal("100000"))
+                    .contributions(BigDecimal.ZERO)
+                    .withdrawals(BigDecimal.ZERO)
+                    .returns(new BigDecimal("1000"))
+                    .build();
+
+            // 1000 / 100000 = 0.01 (1%)
+            assertEquals(new BigDecimal("0.010000"), flow.returnPercentage());
+        }
+
+        @Test
+        @DisplayName("returnPercentage should return zero when no base balance")
+        void returnPercentageZeroBase() {
+            AccountMonthlyFlow flow = AccountMonthlyFlow.builder(ACCOUNT_ID, ACCOUNT_NAME)
+                    .startingBalance(BigDecimal.ZERO)
+                    .build();
+
+            assertEquals(BigDecimal.ZERO, flow.returnPercentage());
+        }
+    }
+
+    @Nested
+    @DisplayName("Activity Detection")
+    class ActivityDetection {
+
+        @Test
+        @DisplayName("hasActivity should return true with contributions")
+        void hasActivityWithContributions() {
+            AccountMonthlyFlow flow = AccountMonthlyFlow.builder(ACCOUNT_ID, ACCOUNT_NAME)
+                    .startingBalance(new BigDecimal("100000"))
+                    .contributions(new BigDecimal("1000"))
+                    .build();
+
+            assertTrue(flow.hasActivity());
+        }
+
+        @Test
+        @DisplayName("hasActivity should return true with withdrawals")
+        void hasActivityWithWithdrawals() {
+            AccountMonthlyFlow flow = AccountMonthlyFlow.builder(ACCOUNT_ID, ACCOUNT_NAME)
+                    .startingBalance(new BigDecimal("100000"))
+                    .withdrawals(new BigDecimal("1000"))
+                    .build();
+
+            assertTrue(flow.hasActivity());
+        }
+
+        @Test
+        @DisplayName("hasActivity should return true with returns")
+        void hasActivityWithReturns() {
+            AccountMonthlyFlow flow = AccountMonthlyFlow.builder(ACCOUNT_ID, ACCOUNT_NAME)
+                    .startingBalance(new BigDecimal("100000"))
+                    .returns(new BigDecimal("500"))
+                    .build();
+
+            assertTrue(flow.hasActivity());
+        }
+
+        @Test
+        @DisplayName("hasActivity should return false with no activity")
+        void hasActivityNoActivity() {
+            AccountMonthlyFlow flow = AccountMonthlyFlow.builder(ACCOUNT_ID, ACCOUNT_NAME)
+                    .startingBalance(new BigDecimal("100000"))
+                    .build();
+
+            assertFalse(flow.hasActivity());
+        }
+
+        @Test
+        @DisplayName("hadGrowth should return true when ending > starting")
+        void hadGrowthTrue() {
+            AccountMonthlyFlow flow = AccountMonthlyFlow.builder(ACCOUNT_ID, ACCOUNT_NAME)
+                    .startingBalance(new BigDecimal("100000"))
+                    .returns(new BigDecimal("500"))
+                    .build();
+
+            assertTrue(flow.hadGrowth());
+        }
+
+        @Test
+        @DisplayName("hadGrowth should return false when ending <= starting")
+        void hadGrowthFalse() {
+            AccountMonthlyFlow flow = AccountMonthlyFlow.builder(ACCOUNT_ID, ACCOUNT_NAME)
+                    .startingBalance(new BigDecimal("100000"))
+                    .withdrawals(new BigDecimal("5000"))
+                    .build();
+
+            assertFalse(flow.hadGrowth());
+        }
+    }
+
+    @Nested
+    @DisplayName("withReturns")
+    class WithReturns {
+
+        @Test
+        @DisplayName("should create new instance with updated returns")
+        void shouldCreateNewInstance() {
+            AccountMonthlyFlow original = AccountMonthlyFlow.builder(ACCOUNT_ID, ACCOUNT_NAME)
+                    .startingBalance(new BigDecimal("100000"))
+                    .contributions(new BigDecimal("1000"))
+                    .build();
+
+            AccountMonthlyFlow updated = original.withReturns(
+                    new BigDecimal("800"),
+                    new BigDecimal("101800")
+            );
+
+            // Original unchanged
+            assertEquals(BigDecimal.ZERO, original.returns());
+            assertEquals(new BigDecimal("101000.00"), original.endingBalance());
+
+            // Updated has new values
+            assertEquals(new BigDecimal("800"), updated.returns());
+            assertEquals(new BigDecimal("101800"), updated.endingBalance());
+
+            // Other fields unchanged
+            assertEquals(original.accountId(), updated.accountId());
+            assertEquals(original.contributions(), updated.contributions());
+        }
+    }
+}

--- a/src/test/java/io/github/xmljim/retirement/simulation/result/MonthlySnapshotTest.java
+++ b/src/test/java/io/github/xmljim/retirement/simulation/result/MonthlySnapshotTest.java
@@ -1,0 +1,326 @@
+package io.github.xmljim.retirement.simulation.result;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.github.xmljim.retirement.domain.enums.ExpenseCategoryGroup;
+import io.github.xmljim.retirement.domain.enums.SimulationPhase;
+
+@DisplayName("MonthlySnapshot")
+class MonthlySnapshotTest {
+
+    private static final YearMonth TEST_MONTH = YearMonth.of(2025, 6);
+    private static final UUID ACCOUNT_1_ID = UUID.randomUUID();
+    private static final UUID ACCOUNT_2_ID = UUID.randomUUID();
+
+    @Nested
+    @DisplayName("Construction")
+    class Construction {
+
+        @Test
+        @DisplayName("should create with required month")
+        void shouldCreateWithMonth() {
+            MonthlySnapshot snapshot = MonthlySnapshot.builder(TEST_MONTH).build();
+
+            assertEquals(TEST_MONTH, snapshot.month());
+            assertEquals(2025, snapshot.year());
+            assertEquals(6, snapshot.monthValue());
+        }
+
+        @Test
+        @DisplayName("should reject null month")
+        void shouldRejectNullMonth() {
+            assertThrows(IllegalArgumentException.class, () ->
+                    MonthlySnapshot.builder(null).build());
+        }
+
+        @Test
+        @DisplayName("should default null values appropriately")
+        void shouldDefaultNullValues() {
+            MonthlySnapshot snapshot = new MonthlySnapshot(
+                    TEST_MONTH,
+                    null, null, null, null, null, null,
+                    null, null, null, null, null, null, null, null
+            );
+
+            assertTrue(snapshot.accountFlows().isEmpty());
+            assertEquals(BigDecimal.ZERO, snapshot.salaryIncome());
+            assertEquals(BigDecimal.ZERO, snapshot.totalExpenses());
+            assertNotNull(snapshot.taxes());
+            assertEquals(SimulationPhase.ACCUMULATION, snapshot.phase());
+            assertTrue(snapshot.eventsTriggered().isEmpty());
+        }
+
+        @Test
+        @DisplayName("should create immutable account flows map")
+        void shouldCreateImmutableAccountFlows() {
+            AccountMonthlyFlow flow = AccountMonthlyFlow.builder(ACCOUNT_1_ID, "Test Account")
+                    .startingBalance(new BigDecimal("100000"))
+                    .build();
+
+            MonthlySnapshot snapshot = MonthlySnapshot.builder(TEST_MONTH)
+                    .accountFlows(Map.of(ACCOUNT_1_ID, flow))
+                    .build();
+
+            assertThrows(UnsupportedOperationException.class, () ->
+                    snapshot.accountFlows().put(ACCOUNT_2_ID, flow));
+        }
+
+        @Test
+        @DisplayName("should create immutable events list")
+        void shouldCreateImmutableEventsList() {
+            MonthlySnapshot snapshot = MonthlySnapshot.builder(TEST_MONTH)
+                    .eventsTriggered(List.of("Event1", "Event2"))
+                    .build();
+
+            assertThrows(UnsupportedOperationException.class, () ->
+                    snapshot.eventsTriggered().add("Event3"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Portfolio Aggregations")
+    class PortfolioAggregations {
+
+        @Test
+        @DisplayName("totalPortfolioBalance should sum all account ending balances")
+        void totalPortfolioBalance() {
+            AccountMonthlyFlow flow1 = AccountMonthlyFlow.builder(ACCOUNT_1_ID, "Account 1")
+                    .startingBalance(new BigDecimal("100000"))
+                    .returns(new BigDecimal("500"))
+                    .build();
+
+            AccountMonthlyFlow flow2 = AccountMonthlyFlow.builder(ACCOUNT_2_ID, "Account 2")
+                    .startingBalance(new BigDecimal("50000"))
+                    .returns(new BigDecimal("250"))
+                    .build();
+
+            MonthlySnapshot snapshot = MonthlySnapshot.builder(TEST_MONTH)
+                    .accountFlows(Map.of(ACCOUNT_1_ID, flow1, ACCOUNT_2_ID, flow2))
+                    .build();
+
+            // 100500 + 50250 = 150750
+            assertEquals(new BigDecimal("150750.00"), snapshot.totalPortfolioBalance());
+        }
+
+        @Test
+        @DisplayName("totalContributions should sum all account contributions")
+        void totalContributions() {
+            AccountMonthlyFlow flow1 = AccountMonthlyFlow.builder(ACCOUNT_1_ID, "Account 1")
+                    .startingBalance(new BigDecimal("100000"))
+                    .contributions(new BigDecimal("1000"))
+                    .build();
+
+            AccountMonthlyFlow flow2 = AccountMonthlyFlow.builder(ACCOUNT_2_ID, "Account 2")
+                    .startingBalance(new BigDecimal("50000"))
+                    .contributions(new BigDecimal("500"))
+                    .build();
+
+            MonthlySnapshot snapshot = MonthlySnapshot.builder(TEST_MONTH)
+                    .accountFlows(Map.of(ACCOUNT_1_ID, flow1, ACCOUNT_2_ID, flow2))
+                    .build();
+
+            assertEquals(new BigDecimal("1500.00"), snapshot.totalContributions());
+        }
+
+        @Test
+        @DisplayName("totalWithdrawals should sum all account withdrawals")
+        void totalWithdrawals() {
+            AccountMonthlyFlow flow1 = AccountMonthlyFlow.builder(ACCOUNT_1_ID, "Account 1")
+                    .startingBalance(new BigDecimal("100000"))
+                    .withdrawals(new BigDecimal("3000"))
+                    .build();
+
+            AccountMonthlyFlow flow2 = AccountMonthlyFlow.builder(ACCOUNT_2_ID, "Account 2")
+                    .startingBalance(new BigDecimal("50000"))
+                    .withdrawals(new BigDecimal("2000"))
+                    .build();
+
+            MonthlySnapshot snapshot = MonthlySnapshot.builder(TEST_MONTH)
+                    .accountFlows(Map.of(ACCOUNT_1_ID, flow1, ACCOUNT_2_ID, flow2))
+                    .build();
+
+            assertEquals(new BigDecimal("5000.00"), snapshot.totalWithdrawals());
+        }
+
+        @Test
+        @DisplayName("totalReturns should sum all account returns")
+        void totalReturns() {
+            AccountMonthlyFlow flow1 = AccountMonthlyFlow.builder(ACCOUNT_1_ID, "Account 1")
+                    .startingBalance(new BigDecimal("100000"))
+                    .returns(new BigDecimal("800"))
+                    .build();
+
+            AccountMonthlyFlow flow2 = AccountMonthlyFlow.builder(ACCOUNT_2_ID, "Account 2")
+                    .startingBalance(new BigDecimal("50000"))
+                    .returns(new BigDecimal("-200"))
+                    .build();
+
+            MonthlySnapshot snapshot = MonthlySnapshot.builder(TEST_MONTH)
+                    .accountFlows(Map.of(ACCOUNT_1_ID, flow1, ACCOUNT_2_ID, flow2))
+                    .build();
+
+            assertEquals(new BigDecimal("600.00"), snapshot.totalReturns());
+        }
+    }
+
+    @Nested
+    @DisplayName("Income Aggregations")
+    class IncomeAggregations {
+
+        @Test
+        @DisplayName("totalIncome should sum all income sources")
+        void totalIncome() {
+            MonthlySnapshot snapshot = MonthlySnapshot.builder(TEST_MONTH)
+                    .salaryIncome(new BigDecimal("5000"))
+                    .socialSecurityIncome(new BigDecimal("2000"))
+                    .pensionIncome(new BigDecimal("1500"))
+                    .otherIncome(new BigDecimal("500"))
+                    .build();
+
+            assertEquals(new BigDecimal("9000.00"), snapshot.totalIncome());
+        }
+
+        @Test
+        @DisplayName("totalNonSalaryIncome should exclude salary")
+        void totalNonSalaryIncome() {
+            MonthlySnapshot snapshot = MonthlySnapshot.builder(TEST_MONTH)
+                    .salaryIncome(new BigDecimal("5000"))
+                    .socialSecurityIncome(new BigDecimal("2000"))
+                    .pensionIncome(new BigDecimal("1500"))
+                    .otherIncome(new BigDecimal("500"))
+                    .build();
+
+            assertEquals(new BigDecimal("4000.00"), snapshot.totalNonSalaryIncome());
+        }
+    }
+
+    @Nested
+    @DisplayName("Cash Flow")
+    class CashFlow {
+
+        @Test
+        @DisplayName("netCashFlow should be income minus expenses")
+        void netCashFlow() {
+            MonthlySnapshot snapshot = MonthlySnapshot.builder(TEST_MONTH)
+                    .salaryIncome(new BigDecimal("5000"))
+                    .socialSecurityIncome(new BigDecimal("2000"))
+                    .totalExpenses(new BigDecimal("6000"))
+                    .build();
+
+            // 7000 - 6000 = 1000
+            assertEquals(new BigDecimal("1000.00"), snapshot.netCashFlow());
+        }
+
+        @Test
+        @DisplayName("incomeGap should be expenses minus non-salary income")
+        void incomeGap() {
+            MonthlySnapshot snapshot = MonthlySnapshot.builder(TEST_MONTH)
+                    .socialSecurityIncome(new BigDecimal("2000"))
+                    .pensionIncome(new BigDecimal("1000"))
+                    .totalExpenses(new BigDecimal("5000"))
+                    .build();
+
+            // 5000 - 3000 = 2000
+            assertEquals(new BigDecimal("2000.00"), snapshot.incomeGap());
+        }
+
+        @Test
+        @DisplayName("incomeGap should return zero when no gap")
+        void incomeGapZero() {
+            MonthlySnapshot snapshot = MonthlySnapshot.builder(TEST_MONTH)
+                    .socialSecurityIncome(new BigDecimal("3000"))
+                    .pensionIncome(new BigDecimal("2000"))
+                    .totalExpenses(new BigDecimal("4000"))
+                    .build();
+
+            // 4000 - 5000 = -1000, but capped at 0
+            assertEquals(new BigDecimal("0.00"), snapshot.incomeGap());
+        }
+    }
+
+    @Nested
+    @DisplayName("Convenience Methods")
+    class ConvenienceMethods {
+
+        @Test
+        @DisplayName("hadEvents should return true when events exist")
+        void hadEventsTrue() {
+            MonthlySnapshot snapshot = MonthlySnapshot.builder(TEST_MONTH)
+                    .eventsTriggered(List.of("RetirementStart"))
+                    .build();
+
+            assertTrue(snapshot.hadEvents());
+        }
+
+        @Test
+        @DisplayName("hadEvents should return false when no events")
+        void hadEventsFalse() {
+            MonthlySnapshot snapshot = MonthlySnapshot.builder(TEST_MONTH).build();
+
+            assertFalse(snapshot.hadEvents());
+        }
+
+        @Test
+        @DisplayName("accountCount should return number of accounts")
+        void accountCount() {
+            AccountMonthlyFlow flow1 = AccountMonthlyFlow.builder(ACCOUNT_1_ID, "Account 1")
+                    .startingBalance(new BigDecimal("100000"))
+                    .build();
+
+            AccountMonthlyFlow flow2 = AccountMonthlyFlow.builder(ACCOUNT_2_ID, "Account 2")
+                    .startingBalance(new BigDecimal("50000"))
+                    .build();
+
+            MonthlySnapshot snapshot = MonthlySnapshot.builder(TEST_MONTH)
+                    .accountFlows(Map.of(ACCOUNT_1_ID, flow1, ACCOUNT_2_ID, flow2))
+                    .build();
+
+            assertEquals(2, snapshot.accountCount());
+        }
+
+        @Test
+        @DisplayName("getAccountFlow should return flow for account")
+        void getAccountFlow() {
+            AccountMonthlyFlow flow = AccountMonthlyFlow.builder(ACCOUNT_1_ID, "Account 1")
+                    .startingBalance(new BigDecimal("100000"))
+                    .build();
+
+            MonthlySnapshot snapshot = MonthlySnapshot.builder(TEST_MONTH)
+                    .accountFlows(Map.of(ACCOUNT_1_ID, flow))
+                    .build();
+
+            assertEquals(flow, snapshot.getAccountFlow(ACCOUNT_1_ID));
+            assertNull(snapshot.getAccountFlow(ACCOUNT_2_ID));
+        }
+
+        @Test
+        @DisplayName("getExpensesByGroup should return amount for group")
+        void getExpensesByGroup() {
+            MonthlySnapshot snapshot = MonthlySnapshot.builder(TEST_MONTH)
+                    .expensesByCategory(Map.of(
+                            ExpenseCategoryGroup.ESSENTIAL, new BigDecimal("3000"),
+                            ExpenseCategoryGroup.HEALTHCARE, new BigDecimal("500")
+                    ))
+                    .build();
+
+            assertEquals(new BigDecimal("3000"), snapshot.getExpensesByGroup(ExpenseCategoryGroup.ESSENTIAL));
+            assertEquals(new BigDecimal("500"), snapshot.getExpensesByGroup(ExpenseCategoryGroup.HEALTHCARE));
+            assertEquals(BigDecimal.ZERO, snapshot.getExpensesByGroup(ExpenseCategoryGroup.DISCRETIONARY));
+        }
+    }
+}

--- a/src/test/java/io/github/xmljim/retirement/simulation/result/TaxSummaryTest.java
+++ b/src/test/java/io/github/xmljim/retirement/simulation/result/TaxSummaryTest.java
@@ -1,0 +1,167 @@
+package io.github.xmljim.retirement.simulation.result;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("TaxSummary")
+class TaxSummaryTest {
+
+    @Nested
+    @DisplayName("Construction")
+    class Construction {
+
+        @Test
+        @DisplayName("should create empty summary with all zeros")
+        void shouldCreateEmpty() {
+            TaxSummary summary = TaxSummary.empty();
+
+            assertEquals(BigDecimal.ZERO, summary.taxableIncome());
+            assertEquals(BigDecimal.ZERO, summary.taxableSSIncome());
+            assertEquals(BigDecimal.ZERO, summary.taxableWithdrawals());
+            assertEquals(BigDecimal.ZERO, summary.taxFreeWithdrawals());
+            assertEquals(BigDecimal.ZERO, summary.federalTaxLiability());
+            assertEquals(BigDecimal.ZERO, summary.effectiveTaxRate());
+            assertEquals(BigDecimal.ZERO, summary.marginalTaxBracket());
+            assertEquals(BigDecimal.ZERO, summary.rothConversionAmount());
+            assertEquals(BigDecimal.ZERO, summary.rothConversionTax());
+        }
+
+        @Test
+        @DisplayName("should default null values to zero")
+        void shouldDefaultNullsToZero() {
+            TaxSummary summary = new TaxSummary(
+                    null, null, null, null, null,
+                    null, null, null, null
+            );
+
+            assertEquals(BigDecimal.ZERO, summary.taxableIncome());
+            assertEquals(BigDecimal.ZERO, summary.federalTaxLiability());
+        }
+    }
+
+    @Nested
+    @DisplayName("Builder")
+    class BuilderTests {
+
+        @Test
+        @DisplayName("should build with all values")
+        void shouldBuildWithAllValues() {
+            TaxSummary summary = TaxSummary.builder()
+                    .taxableIncome(new BigDecimal("50000"))
+                    .taxableSSIncome(new BigDecimal("15000"))
+                    .taxableWithdrawals(new BigDecimal("20000"))
+                    .taxFreeWithdrawals(new BigDecimal("5000"))
+                    .federalTaxLiability(new BigDecimal("8000"))
+                    .effectiveTaxRate(new BigDecimal("0.16"))
+                    .marginalTaxBracket(new BigDecimal("0.22"))
+                    .rothConversionAmount(new BigDecimal("10000"))
+                    .rothConversionTax(new BigDecimal("2200"))
+                    .build();
+
+            assertEquals(new BigDecimal("50000"), summary.taxableIncome());
+            assertEquals(new BigDecimal("15000"), summary.taxableSSIncome());
+            assertEquals(new BigDecimal("20000"), summary.taxableWithdrawals());
+            assertEquals(new BigDecimal("5000"), summary.taxFreeWithdrawals());
+            assertEquals(new BigDecimal("8000"), summary.federalTaxLiability());
+            assertEquals(new BigDecimal("0.16"), summary.effectiveTaxRate());
+            assertEquals(new BigDecimal("0.22"), summary.marginalTaxBracket());
+            assertEquals(new BigDecimal("10000"), summary.rothConversionAmount());
+            assertEquals(new BigDecimal("2200"), summary.rothConversionTax());
+        }
+    }
+
+    @Nested
+    @DisplayName("Calculations")
+    class Calculations {
+
+        @Test
+        @DisplayName("totalWithdrawals should sum taxable and tax-free")
+        void totalWithdrawalsCalculation() {
+            TaxSummary summary = TaxSummary.builder()
+                    .taxableWithdrawals(new BigDecimal("20000"))
+                    .taxFreeWithdrawals(new BigDecimal("5000"))
+                    .build();
+
+            assertEquals(new BigDecimal("25000.00"), summary.totalWithdrawals());
+        }
+
+        @Test
+        @DisplayName("totalTaxLiability should sum federal and Roth conversion")
+        void totalTaxLiabilityCalculation() {
+            TaxSummary summary = TaxSummary.builder()
+                    .federalTaxLiability(new BigDecimal("8000"))
+                    .rothConversionTax(new BigDecimal("2200"))
+                    .build();
+
+            assertEquals(new BigDecimal("10200.00"), summary.totalTaxLiability());
+        }
+
+        @Test
+        @DisplayName("taxableWithdrawalPercentage should calculate correctly")
+        void taxableWithdrawalPercentage() {
+            TaxSummary summary = TaxSummary.builder()
+                    .taxableWithdrawals(new BigDecimal("15000"))
+                    .taxFreeWithdrawals(new BigDecimal("5000"))
+                    .build();
+
+            // 15000 / 20000 = 0.75
+            assertEquals(new BigDecimal("0.7500"), summary.taxableWithdrawalPercentage());
+        }
+
+        @Test
+        @DisplayName("taxableWithdrawalPercentage should return zero when no withdrawals")
+        void taxableWithdrawalPercentageNoWithdrawals() {
+            TaxSummary summary = TaxSummary.empty();
+
+            assertEquals(BigDecimal.ZERO, summary.taxableWithdrawalPercentage());
+        }
+    }
+
+    @Nested
+    @DisplayName("Status Checks")
+    class StatusChecks {
+
+        @Test
+        @DisplayName("hadRothConversion should return true when amount > 0")
+        void hadRothConversionTrue() {
+            TaxSummary summary = TaxSummary.builder()
+                    .rothConversionAmount(new BigDecimal("10000"))
+                    .build();
+
+            assertTrue(summary.hadRothConversion());
+        }
+
+        @Test
+        @DisplayName("hadRothConversion should return false when amount = 0")
+        void hadRothConversionFalse() {
+            TaxSummary summary = TaxSummary.empty();
+
+            assertFalse(summary.hadRothConversion());
+        }
+
+        @Test
+        @DisplayName("hasTaxLiability should return true when tax > 0")
+        void hasTaxLiabilityTrue() {
+            TaxSummary summary = TaxSummary.builder()
+                    .federalTaxLiability(new BigDecimal("5000"))
+                    .build();
+
+            assertTrue(summary.hasTaxLiability());
+        }
+
+        @Test
+        @DisplayName("hasTaxLiability should return false when tax = 0")
+        void hasTaxLiabilityFalse() {
+            TaxSummary summary = TaxSummary.empty();
+
+            assertFalse(summary.hasTaxLiability());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Implement `SimulationPhase` enum with ACCUMULATION, TRANSITION, DISTRIBUTION, SURVIVOR phases
- Create `AccountMonthlyFlow` record for per-account monthly tracking
- Create `TaxSummary` record for tax calculations and Roth conversion tracking
- Create `MonthlySnapshot` record aggregating all monthly simulation data

## Implementation Details

### SimulationPhase Enum
- Four phases with display names and descriptions
- Helper methods: `allowsContributions()`, `expectsWithdrawals()`, `isRetired()`

### AccountMonthlyFlow Record
- Tracks startingBalance, contributions, withdrawals, returns, endingBalance
- Builder with automatic endingBalance calculation
- Computed methods: `netFlow()`, `netContribution()`, `returnPercentage()`

### TaxSummary Record
- Tracks taxable income, SS income, withdrawals (taxable/tax-free)
- Supports federal tax liability and Roth conversion tracking
- Includes effective tax rate and marginal bracket for future optimization

### MonthlySnapshot Record
- Per-account flows map (source of truth for balances)
- Income by source (salary, SS, pension, other)
- Expenses by category group
- Cumulative metrics (contributions, withdrawals, returns, taxes)
- Events triggered list

## Test plan
- [x] AccountMonthlyFlowTest (18 tests)
- [x] TaxSummaryTest (11 tests)
- [x] MonthlySnapshotTest (19 tests)
- [x] SimulationPhaseTest (26 tests)
- [x] Build passes with checkstyle and SpotBugs

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)