### PR TITLE
feat(#270): Create TimeSeries with annual aggregation

### DIFF
--- a/src/main/java/io/github/xmljim/retirement/simulation/result/AnnualSummary.java
+++ b/src/main/java/io/github/xmljim/retirement/simulation/result/AnnualSummary.java
@@ -1,0 +1,341 @@
+package io.github.xmljim.retirement.simulation.result;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * Aggregated summary of simulation results for a single calendar year.
+ *
+ * <p>AnnualSummary is computed from the monthly snapshots within a year,
+ * providing key metrics for year-over-year analysis:
+ * <ul>
+ *   <li>Portfolio balance change (start to end)</li>
+ *   <li>Total contributions and withdrawals</li>
+ *   <li>Total income and expenses</li>
+ *   <li>Investment returns (absolute and percentage)</li>
+ *   <li>Significant events that occurred during the year</li>
+ * </ul>
+ *
+ * @param year the calendar year
+ * @param startingBalance portfolio balance at start of year (January)
+ * @param endingBalance portfolio balance at end of year (December)
+ * @param totalContributions sum of all contributions during the year
+ * @param totalWithdrawals sum of all withdrawals during the year
+ * @param totalIncome sum of all income during the year
+ * @param totalExpenses sum of all expenses during the year
+ * @param totalTaxesPaid sum of all taxes paid during the year
+ * @param annualReturn absolute investment return for the year
+ * @param annualReturnPercent return as percentage of average balance
+ * @param significantEvents list of notable events during the year
+ *
+ * @see TimeSeries
+ * @see MonthlySnapshot
+ */
+@SuppressFBWarnings(
+        value = "EI_EXPOSE_REP",
+        justification = "List is made unmodifiable in compact constructor"
+)
+public record AnnualSummary(
+        int year,
+        BigDecimal startingBalance,
+        BigDecimal endingBalance,
+        BigDecimal totalContributions,
+        BigDecimal totalWithdrawals,
+        BigDecimal totalIncome,
+        BigDecimal totalExpenses,
+        BigDecimal totalTaxesPaid,
+        BigDecimal annualReturn,
+        BigDecimal annualReturnPercent,
+        List<String> significantEvents
+) {
+
+    private static final int SCALE = 2;
+    private static final int PERCENT_SCALE = 4;
+    private static final RoundingMode ROUNDING = RoundingMode.HALF_UP;
+
+    /**
+     * Compact constructor with validation and defensive copying.
+     */
+    public AnnualSummary {
+        if (year < 1900 || year > 2200) {
+            throw new IllegalArgumentException("year must be between 1900 and 2200");
+        }
+        if (startingBalance == null) {
+            startingBalance = BigDecimal.ZERO;
+        }
+        if (endingBalance == null) {
+            endingBalance = BigDecimal.ZERO;
+        }
+        if (totalContributions == null) {
+            totalContributions = BigDecimal.ZERO;
+        }
+        if (totalWithdrawals == null) {
+            totalWithdrawals = BigDecimal.ZERO;
+        }
+        if (totalIncome == null) {
+            totalIncome = BigDecimal.ZERO;
+        }
+        if (totalExpenses == null) {
+            totalExpenses = BigDecimal.ZERO;
+        }
+        if (totalTaxesPaid == null) {
+            totalTaxesPaid = BigDecimal.ZERO;
+        }
+        if (annualReturn == null) {
+            annualReturn = BigDecimal.ZERO;
+        }
+        if (annualReturnPercent == null) {
+            annualReturnPercent = BigDecimal.ZERO;
+        }
+        significantEvents = significantEvents == null
+                ? Collections.emptyList()
+                : Collections.unmodifiableList(significantEvents);
+    }
+
+    // ─── Computed Metrics ──────────────────────────────────────────────────────
+
+    /**
+     * Calculates the net change in portfolio balance.
+     *
+     * @return ending balance minus starting balance
+     */
+    public BigDecimal netBalanceChange() {
+        return endingBalance.subtract(startingBalance).setScale(SCALE, ROUNDING);
+    }
+
+    /**
+     * Calculates the net cash flow (contributions minus withdrawals).
+     *
+     * @return total contributions minus total withdrawals
+     */
+    public BigDecimal netContributions() {
+        return totalContributions.subtract(totalWithdrawals).setScale(SCALE, ROUNDING);
+    }
+
+    /**
+     * Calculates the savings rate (income minus expenses).
+     *
+     * @return total income minus total expenses
+     */
+    public BigDecimal netSavings() {
+        return totalIncome.subtract(totalExpenses).setScale(SCALE, ROUNDING);
+    }
+
+    /**
+     * Calculates the effective tax rate for the year.
+     *
+     * @return taxes paid divided by total income, or ZERO if no income
+     */
+    public BigDecimal effectiveTaxRate() {
+        if (totalIncome.compareTo(BigDecimal.ZERO) == 0) {
+            return BigDecimal.ZERO;
+        }
+        return totalTaxesPaid
+                .divide(totalIncome, PERCENT_SCALE, ROUNDING);
+    }
+
+    // ─── Status Checks ─────────────────────────────────────────────────────────
+
+    /**
+     * Indicates whether any significant events occurred this year.
+     *
+     * @return true if events list is not empty
+     */
+    public boolean hadSignificantEvents() {
+        return !significantEvents.isEmpty();
+    }
+
+    /**
+     * Indicates whether the portfolio grew this year.
+     *
+     * @return true if ending balance exceeds starting balance
+     */
+    public boolean hadGrowth() {
+        return endingBalance.compareTo(startingBalance) > 0;
+    }
+
+    /**
+     * Indicates whether there was net accumulation (contributions > withdrawals).
+     *
+     * @return true if contributions exceed withdrawals
+     */
+    public boolean isAccumulating() {
+        return totalContributions.compareTo(totalWithdrawals) > 0;
+    }
+
+    /**
+     * Indicates whether there was net distribution (withdrawals > contributions).
+     *
+     * @return true if withdrawals exceed contributions
+     */
+    public boolean isDistributing() {
+        return totalWithdrawals.compareTo(totalContributions) > 0;
+    }
+
+    /**
+     * Creates a builder for constructing AnnualSummary instances.
+     *
+     * @param year the calendar year
+     * @return a new builder
+     */
+    public static Builder builder(int year) {
+        return new Builder(year);
+    }
+
+    /**
+     * Builder for AnnualSummary.
+     */
+    public static final class Builder {
+        private final int year;
+        private BigDecimal startingBalance = BigDecimal.ZERO;
+        private BigDecimal endingBalance = BigDecimal.ZERO;
+        private BigDecimal totalContributions = BigDecimal.ZERO;
+        private BigDecimal totalWithdrawals = BigDecimal.ZERO;
+        private BigDecimal totalIncome = BigDecimal.ZERO;
+        private BigDecimal totalExpenses = BigDecimal.ZERO;
+        private BigDecimal totalTaxesPaid = BigDecimal.ZERO;
+        private BigDecimal annualReturn = BigDecimal.ZERO;
+        private BigDecimal annualReturnPercent = BigDecimal.ZERO;
+        private List<String> significantEvents = Collections.emptyList();
+
+        private Builder(int year) {
+            this.year = year;
+        }
+
+        /**
+         * Sets the starting balance.
+         *
+         * @param balance the starting balance
+         * @return this builder
+         */
+        public Builder startingBalance(BigDecimal balance) {
+            this.startingBalance = balance;
+            return this;
+        }
+
+        /**
+         * Sets the ending balance.
+         *
+         * @param balance the ending balance
+         * @return this builder
+         */
+        public Builder endingBalance(BigDecimal balance) {
+            this.endingBalance = balance;
+            return this;
+        }
+
+        /**
+         * Sets the total contributions.
+         *
+         * @param amount the total contributions
+         * @return this builder
+         */
+        public Builder totalContributions(BigDecimal amount) {
+            this.totalContributions = amount;
+            return this;
+        }
+
+        /**
+         * Sets the total withdrawals.
+         *
+         * @param amount the total withdrawals
+         * @return this builder
+         */
+        public Builder totalWithdrawals(BigDecimal amount) {
+            this.totalWithdrawals = amount;
+            return this;
+        }
+
+        /**
+         * Sets the total income.
+         *
+         * @param amount the total income
+         * @return this builder
+         */
+        public Builder totalIncome(BigDecimal amount) {
+            this.totalIncome = amount;
+            return this;
+        }
+
+        /**
+         * Sets the total expenses.
+         *
+         * @param amount the total expenses
+         * @return this builder
+         */
+        public Builder totalExpenses(BigDecimal amount) {
+            this.totalExpenses = amount;
+            return this;
+        }
+
+        /**
+         * Sets the total taxes paid.
+         *
+         * @param amount the total taxes paid
+         * @return this builder
+         */
+        public Builder totalTaxesPaid(BigDecimal amount) {
+            this.totalTaxesPaid = amount;
+            return this;
+        }
+
+        /**
+         * Sets the annual return.
+         *
+         * @param amount the annual return
+         * @return this builder
+         */
+        public Builder annualReturn(BigDecimal amount) {
+            this.annualReturn = amount;
+            return this;
+        }
+
+        /**
+         * Sets the annual return percentage.
+         *
+         * @param percent the return percentage as decimal
+         * @return this builder
+         */
+        public Builder annualReturnPercent(BigDecimal percent) {
+            this.annualReturnPercent = percent;
+            return this;
+        }
+
+        /**
+         * Sets the significant events.
+         *
+         * @param events the list of events
+         * @return this builder
+         */
+        public Builder significantEvents(List<String> events) {
+            this.significantEvents = events == null ? Collections.emptyList() : new ArrayList<>(events);
+            return this;
+        }
+
+        /**
+         * Builds the AnnualSummary.
+         *
+         * @return the constructed AnnualSummary
+         */
+        public AnnualSummary build() {
+            return new AnnualSummary(
+                    year,
+                    startingBalance,
+                    endingBalance,
+                    totalContributions,
+                    totalWithdrawals,
+                    totalIncome,
+                    totalExpenses,
+                    totalTaxesPaid,
+                    annualReturn,
+                    annualReturnPercent,
+                    significantEvents
+            );
+        }
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/simulation/result/TimeSeries.java
+++ b/src/main/java/io/github/xmljim/retirement/simulation/result/TimeSeries.java
@@ -1,0 +1,367 @@
+package io.github.xmljim.retirement.simulation.result;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.github.xmljim.retirement.domain.exception.InvalidDateRangeException;
+import io.github.xmljim.retirement.domain.exception.MissingRequiredFieldException;
+import io.github.xmljim.retirement.domain.exception.ValidationException;
+
+/**
+ * Generic container for storing monthly simulation snapshots with query and aggregation methods.
+ *
+ * <p>TimeSeries provides:
+ * <ul>
+ *   <li>Efficient monthly access via {@link #getSnapshot(YearMonth)}</li>
+ *   <li>Range queries via {@link #getRange(YearMonth, YearMonth)}</li>
+ *   <li>Annual aggregation via {@link #getAnnualSummary(int)}</li>
+ *   <li>Stream-based iteration for functional processing</li>
+ * </ul>
+ *
+ * <p>The time series is immutable after construction. Use {@link Builder} to create instances.
+ *
+ * <p>Example usage:
+ * <pre>{@code
+ * TimeSeries<MonthlySnapshot> series = TimeSeries.<MonthlySnapshot>builder()
+ *     .add(snapshot1)
+ *     .add(snapshot2)
+ *     .build();
+ *
+ * // Monthly access
+ * MonthlySnapshot jan2025 = series.getSnapshot(YearMonth.of(2025, 1));
+ *
+ * // Annual summary
+ * AnnualSummary summary2025 = series.getAnnualSummary(2025);
+ * }</pre>
+ *
+ * @param <T> the snapshot type, must extend MonthlySnapshot
+ *
+ * @see MonthlySnapshot
+ * @see AnnualSummary
+ */
+public final class TimeSeries<T extends MonthlySnapshot> implements Iterable<T> {
+
+    private static final int SCALE = 2;
+    private static final int PERCENT_SCALE = 4;
+    private static final RoundingMode ROUNDING = RoundingMode.HALF_UP;
+
+    private final NavigableMap<YearMonth, T> snapshotsByMonth;
+    private final List<T> snapshotsInOrder;
+
+    /**
+     * Private constructor - use {@link #builder()} to create instances.
+     *
+     * @param snapshots the snapshots to store
+     */
+    private TimeSeries(List<T> snapshots) {
+        NavigableMap<YearMonth, T> map = new TreeMap<>();
+        for (T snapshot : snapshots) {
+            if (map.containsKey(snapshot.month())) {
+                throw new ValidationException(
+                        "Duplicate snapshot for month: " + snapshot.month(), "month");
+            }
+            map.put(snapshot.month(), snapshot);
+        }
+        this.snapshotsByMonth = Collections.unmodifiableNavigableMap(map);
+        this.snapshotsInOrder = Collections.unmodifiableList(new ArrayList<>(map.values()));
+    }
+
+    // ─── Monthly Access ────────────────────────────────────────────────────────
+
+    /**
+     * Gets the snapshot for a specific month.
+     *
+     * @param month the year-month to query
+     * @return the snapshot, or empty if not found
+     */
+    public Optional<T> getSnapshot(YearMonth month) {
+        return Optional.ofNullable(snapshotsByMonth.get(month));
+    }
+
+    /**
+     * Gets snapshots within a date range (inclusive).
+     *
+     * @param start the start month (inclusive)
+     * @param end the end month (inclusive)
+     * @return unmodifiable list of snapshots in the range
+     */
+    public List<T> getRange(YearMonth start, YearMonth end) {
+        if (start.isAfter(end)) {
+            throw InvalidDateRangeException.dateMustBeBefore("start", "end");
+        }
+        return Collections.unmodifiableList(
+                new ArrayList<>(snapshotsByMonth.subMap(start, true, end, true).values())
+        );
+    }
+
+    /**
+     * Gets the first (earliest) snapshot.
+     *
+     * @return the first snapshot, or empty if series is empty
+     */
+    public Optional<T> getFirst() {
+        return snapshotsInOrder.isEmpty()
+                ? Optional.empty()
+                : Optional.of(snapshotsInOrder.getFirst());
+    }
+
+    /**
+     * Gets the last (latest) snapshot.
+     *
+     * @return the last snapshot, or empty if series is empty
+     */
+    public Optional<T> getLast() {
+        return snapshotsInOrder.isEmpty()
+                ? Optional.empty()
+                : Optional.of(snapshotsInOrder.getLast());
+    }
+
+    /**
+     * Returns the number of snapshots in the series.
+     *
+     * @return the snapshot count
+     */
+    public int size() {
+        return snapshotsInOrder.size();
+    }
+
+    /**
+     * Checks if the series is empty.
+     *
+     * @return true if no snapshots
+     */
+    public boolean isEmpty() {
+        return snapshotsInOrder.isEmpty();
+    }
+
+    /**
+     * Gets all snapshots for a specific year.
+     *
+     * @param year the calendar year
+     * @return unmodifiable list of snapshots for that year
+     */
+    public List<T> getSnapshotsForYear(int year) {
+        YearMonth start = YearMonth.of(year, 1);
+        YearMonth end = YearMonth.of(year, 12);
+        return getRange(start, end);
+    }
+
+    // ─── Annual Aggregation ────────────────────────────────────────────────────
+
+    /**
+     * Computes an annual summary for a specific year.
+     *
+     * <p>The summary aggregates all monthly data within the year.
+     *
+     * @param year the calendar year
+     * @return the annual summary, or empty if no data for that year
+     */
+    public Optional<AnnualSummary> getAnnualSummary(int year) {
+        List<T> yearSnapshots = getSnapshotsForYear(year);
+        if (yearSnapshots.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(computeAnnualSummary(year, yearSnapshots));
+    }
+
+    /**
+     * Computes annual summaries for all years in the series.
+     *
+     * @return unmodifiable list of annual summaries, ordered by year
+     */
+    public List<AnnualSummary> getAllAnnualSummaries() {
+        if (isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Map<Integer, List<T>> byYear = snapshotsInOrder.stream()
+                .collect(Collectors.groupingBy(s -> s.month().getYear()));
+
+        return byYear.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(entry -> computeAnnualSummary(entry.getKey(), entry.getValue()))
+                .toList();
+    }
+
+    /**
+     * Gets all distinct years present in the series.
+     *
+     * @return unmodifiable list of years, sorted ascending
+     */
+    public List<Integer> getYears() {
+        return snapshotsInOrder.stream()
+                .map(s -> s.month().getYear())
+                .distinct()
+                .sorted()
+                .toList();
+    }
+
+    // ─── Iteration ─────────────────────────────────────────────────────────────
+
+    /**
+     * Returns a stream of all snapshots in chronological order.
+     *
+     * @return stream of snapshots
+     */
+    public Stream<T> stream() {
+        return snapshotsInOrder.stream();
+    }
+
+    /**
+     * Returns an iterator over snapshots in chronological order.
+     *
+     * @return iterator over snapshots
+     */
+    @Override
+    public Iterator<T> iterator() {
+        return snapshotsInOrder.iterator();
+    }
+
+    /**
+     * Returns all snapshots as an unmodifiable list.
+     *
+     * @return unmodifiable list of all snapshots in chronological order
+     */
+    public List<T> toList() {
+        return snapshotsInOrder;
+    }
+
+    // ─── Private Helpers ───────────────────────────────────────────────────────
+
+    private AnnualSummary computeAnnualSummary(int year, List<T> yearSnapshots) {
+        T first = yearSnapshots.getFirst();
+        T last = yearSnapshots.getLast();
+
+        BigDecimal startingBalance = first.totalPortfolioBalance()
+                .subtract(first.totalContributions())
+                .add(first.totalWithdrawals())
+                .subtract(first.totalReturns());
+
+        BigDecimal endingBalance = last.totalPortfolioBalance();
+
+        BigDecimal totalContributions = yearSnapshots.stream()
+                .map(MonthlySnapshot::totalContributions)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        BigDecimal totalWithdrawals = yearSnapshots.stream()
+                .map(MonthlySnapshot::totalWithdrawals)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        BigDecimal totalIncome = yearSnapshots.stream()
+                .map(MonthlySnapshot::totalIncome)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        BigDecimal totalExpenses = yearSnapshots.stream()
+                .map(MonthlySnapshot::totalExpenses)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        BigDecimal totalTaxesPaid = yearSnapshots.stream()
+                .map(s -> s.taxes().totalTaxLiability())
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        BigDecimal annualReturn = yearSnapshots.stream()
+                .map(MonthlySnapshot::totalReturns)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        // Calculate return percentage based on average balance
+        BigDecimal avgBalance = startingBalance.add(endingBalance)
+                .divide(BigDecimal.valueOf(2), SCALE, ROUNDING);
+        BigDecimal annualReturnPercent = avgBalance.compareTo(BigDecimal.ZERO) == 0
+                ? BigDecimal.ZERO
+                : annualReturn.divide(avgBalance, PERCENT_SCALE, ROUNDING);
+
+        List<String> events = yearSnapshots.stream()
+                .flatMap(s -> s.eventsTriggered().stream())
+                .distinct()
+                .toList();
+
+        return AnnualSummary.builder(year)
+                .startingBalance(startingBalance.setScale(SCALE, ROUNDING))
+                .endingBalance(endingBalance.setScale(SCALE, ROUNDING))
+                .totalContributions(totalContributions.setScale(SCALE, ROUNDING))
+                .totalWithdrawals(totalWithdrawals.setScale(SCALE, ROUNDING))
+                .totalIncome(totalIncome.setScale(SCALE, ROUNDING))
+                .totalExpenses(totalExpenses.setScale(SCALE, ROUNDING))
+                .totalTaxesPaid(totalTaxesPaid.setScale(SCALE, ROUNDING))
+                .annualReturn(annualReturn.setScale(SCALE, ROUNDING))
+                .annualReturnPercent(annualReturnPercent)
+                .significantEvents(events)
+                .build();
+    }
+
+    // ─── Builder ───────────────────────────────────────────────────────────────
+
+    /**
+     * Creates a builder for constructing TimeSeries instances.
+     *
+     * @param <T> the snapshot type
+     * @return a new builder
+     */
+    public static <T extends MonthlySnapshot> Builder<T> builder() {
+        return new Builder<>();
+    }
+
+    /**
+     * Builder for TimeSeries.
+     *
+     * @param <T> the snapshot type
+     */
+    public static final class Builder<T extends MonthlySnapshot> {
+        private final List<T> snapshots = new ArrayList<>();
+
+        private Builder() {
+        }
+
+        /**
+         * Adds a snapshot to the series.
+         *
+         * @param snapshot the snapshot to add
+         * @return this builder
+         * @throws MissingRequiredFieldException if snapshot is null
+         */
+        public Builder<T> add(T snapshot) {
+            if (snapshot == null) {
+                throw new MissingRequiredFieldException("snapshot");
+            }
+            snapshots.add(snapshot);
+            return this;
+        }
+
+        /**
+         * Adds multiple snapshots to the series.
+         *
+         * @param snapshots the snapshots to add
+         * @return this builder
+         */
+        public Builder<T> addAll(List<T> snapshots) {
+            if (snapshots != null) {
+                for (T snapshot : snapshots) {
+                    add(snapshot);
+                }
+            }
+            return this;
+        }
+
+        /**
+         * Builds the TimeSeries.
+         *
+         * <p>Snapshots are automatically sorted by month during construction.
+         *
+         * @return the constructed TimeSeries
+         */
+        public TimeSeries<T> build() {
+            return new TimeSeries<>(snapshots);
+        }
+    }
+}

--- a/src/test/java/io/github/xmljim/retirement/simulation/result/AnnualSummaryTest.java
+++ b/src/test/java/io/github/xmljim/retirement/simulation/result/AnnualSummaryTest.java
@@ -1,0 +1,253 @@
+package io.github.xmljim.retirement.simulation.result;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("AnnualSummary")
+class AnnualSummaryTest {
+
+    @Nested
+    @DisplayName("Construction")
+    class Construction {
+
+        @Test
+        @DisplayName("should create with valid year")
+        void shouldCreateWithValidYear() {
+            AnnualSummary summary = AnnualSummary.builder(2025).build();
+
+            assertEquals(2025, summary.year());
+        }
+
+        @Test
+        @DisplayName("should reject year before 1900")
+        void shouldRejectYearBefore1900() {
+            assertThrows(IllegalArgumentException.class, () ->
+                    AnnualSummary.builder(1899).build());
+        }
+
+        @Test
+        @DisplayName("should reject year after 2200")
+        void shouldRejectYearAfter2200() {
+            assertThrows(IllegalArgumentException.class, () ->
+                    AnnualSummary.builder(2201).build());
+        }
+
+        @Test
+        @DisplayName("should default null values to zero")
+        void shouldDefaultNullValues() {
+            AnnualSummary summary = new AnnualSummary(
+                    2025, null, null, null, null, null, null, null, null, null, null);
+
+            assertEquals(BigDecimal.ZERO, summary.startingBalance());
+            assertEquals(BigDecimal.ZERO, summary.endingBalance());
+            assertEquals(BigDecimal.ZERO, summary.totalContributions());
+            assertEquals(BigDecimal.ZERO, summary.totalWithdrawals());
+            assertEquals(BigDecimal.ZERO, summary.totalIncome());
+            assertEquals(BigDecimal.ZERO, summary.totalExpenses());
+            assertEquals(BigDecimal.ZERO, summary.totalTaxesPaid());
+            assertEquals(BigDecimal.ZERO, summary.annualReturn());
+            assertEquals(BigDecimal.ZERO, summary.annualReturnPercent());
+            assertTrue(summary.significantEvents().isEmpty());
+        }
+
+        @Test
+        @DisplayName("should create immutable events list")
+        void shouldCreateImmutableEventsList() {
+            AnnualSummary summary = AnnualSummary.builder(2025)
+                    .significantEvents(List.of("Retirement", "SS Start"))
+                    .build();
+
+            assertThrows(UnsupportedOperationException.class, () ->
+                    summary.significantEvents().add("Event3"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Builder")
+    class BuilderTests {
+
+        @Test
+        @DisplayName("should build with all values")
+        void shouldBuildWithAllValues() {
+            AnnualSummary summary = AnnualSummary.builder(2025)
+                    .startingBalance(new BigDecimal("500000"))
+                    .endingBalance(new BigDecimal("550000"))
+                    .totalContributions(new BigDecimal("24000"))
+                    .totalWithdrawals(BigDecimal.ZERO)
+                    .totalIncome(new BigDecimal("100000"))
+                    .totalExpenses(new BigDecimal("75000"))
+                    .totalTaxesPaid(new BigDecimal("15000"))
+                    .annualReturn(new BigDecimal("26000"))
+                    .annualReturnPercent(new BigDecimal("0.0495"))
+                    .significantEvents(List.of("MaxContribution"))
+                    .build();
+
+            assertEquals(2025, summary.year());
+            assertEquals(new BigDecimal("500000"), summary.startingBalance());
+            assertEquals(new BigDecimal("550000"), summary.endingBalance());
+            assertEquals(new BigDecimal("24000"), summary.totalContributions());
+            assertEquals(BigDecimal.ZERO, summary.totalWithdrawals());
+            assertEquals(new BigDecimal("100000"), summary.totalIncome());
+            assertEquals(new BigDecimal("75000"), summary.totalExpenses());
+            assertEquals(new BigDecimal("15000"), summary.totalTaxesPaid());
+            assertEquals(new BigDecimal("26000"), summary.annualReturn());
+            assertEquals(new BigDecimal("0.0495"), summary.annualReturnPercent());
+            assertEquals(List.of("MaxContribution"), summary.significantEvents());
+        }
+    }
+
+    @Nested
+    @DisplayName("Computed Metrics")
+    class ComputedMetrics {
+
+        @Test
+        @DisplayName("netBalanceChange should be ending minus starting")
+        void netBalanceChange() {
+            AnnualSummary summary = AnnualSummary.builder(2025)
+                    .startingBalance(new BigDecimal("500000"))
+                    .endingBalance(new BigDecimal("550000"))
+                    .build();
+
+            assertEquals(new BigDecimal("50000.00"), summary.netBalanceChange());
+        }
+
+        @Test
+        @DisplayName("netContributions should be contributions minus withdrawals")
+        void netContributions() {
+            AnnualSummary summary = AnnualSummary.builder(2025)
+                    .totalContributions(new BigDecimal("24000"))
+                    .totalWithdrawals(new BigDecimal("5000"))
+                    .build();
+
+            assertEquals(new BigDecimal("19000.00"), summary.netContributions());
+        }
+
+        @Test
+        @DisplayName("netSavings should be income minus expenses")
+        void netSavings() {
+            AnnualSummary summary = AnnualSummary.builder(2025)
+                    .totalIncome(new BigDecimal("100000"))
+                    .totalExpenses(new BigDecimal("75000"))
+                    .build();
+
+            assertEquals(new BigDecimal("25000.00"), summary.netSavings());
+        }
+
+        @Test
+        @DisplayName("effectiveTaxRate should be taxes divided by income")
+        void effectiveTaxRate() {
+            AnnualSummary summary = AnnualSummary.builder(2025)
+                    .totalIncome(new BigDecimal("100000"))
+                    .totalTaxesPaid(new BigDecimal("22000"))
+                    .build();
+
+            assertEquals(new BigDecimal("0.2200"), summary.effectiveTaxRate());
+        }
+
+        @Test
+        @DisplayName("effectiveTaxRate should return zero when no income")
+        void effectiveTaxRateNoIncome() {
+            AnnualSummary summary = AnnualSummary.builder(2025).build();
+
+            assertEquals(BigDecimal.ZERO, summary.effectiveTaxRate());
+        }
+    }
+
+    @Nested
+    @DisplayName("Status Checks")
+    class StatusChecks {
+
+        @Test
+        @DisplayName("hadSignificantEvents should return true when events exist")
+        void hadSignificantEventsTrue() {
+            AnnualSummary summary = AnnualSummary.builder(2025)
+                    .significantEvents(List.of("Retirement"))
+                    .build();
+
+            assertTrue(summary.hadSignificantEvents());
+        }
+
+        @Test
+        @DisplayName("hadSignificantEvents should return false when no events")
+        void hadSignificantEventsFalse() {
+            AnnualSummary summary = AnnualSummary.builder(2025).build();
+
+            assertFalse(summary.hadSignificantEvents());
+        }
+
+        @Test
+        @DisplayName("hadGrowth should return true when ending > starting")
+        void hadGrowthTrue() {
+            AnnualSummary summary = AnnualSummary.builder(2025)
+                    .startingBalance(new BigDecimal("500000"))
+                    .endingBalance(new BigDecimal("550000"))
+                    .build();
+
+            assertTrue(summary.hadGrowth());
+        }
+
+        @Test
+        @DisplayName("hadGrowth should return false when ending <= starting")
+        void hadGrowthFalse() {
+            AnnualSummary summary = AnnualSummary.builder(2025)
+                    .startingBalance(new BigDecimal("500000"))
+                    .endingBalance(new BigDecimal("450000"))
+                    .build();
+
+            assertFalse(summary.hadGrowth());
+        }
+
+        @Test
+        @DisplayName("isAccumulating should return true when contributions > withdrawals")
+        void isAccumulatingTrue() {
+            AnnualSummary summary = AnnualSummary.builder(2025)
+                    .totalContributions(new BigDecimal("24000"))
+                    .totalWithdrawals(BigDecimal.ZERO)
+                    .build();
+
+            assertTrue(summary.isAccumulating());
+        }
+
+        @Test
+        @DisplayName("isAccumulating should return false when contributions <= withdrawals")
+        void isAccumulatingFalse() {
+            AnnualSummary summary = AnnualSummary.builder(2025)
+                    .totalContributions(BigDecimal.ZERO)
+                    .totalWithdrawals(new BigDecimal("50000"))
+                    .build();
+
+            assertFalse(summary.isAccumulating());
+        }
+
+        @Test
+        @DisplayName("isDistributing should return true when withdrawals > contributions")
+        void isDistributingTrue() {
+            AnnualSummary summary = AnnualSummary.builder(2025)
+                    .totalContributions(BigDecimal.ZERO)
+                    .totalWithdrawals(new BigDecimal("50000"))
+                    .build();
+
+            assertTrue(summary.isDistributing());
+        }
+
+        @Test
+        @DisplayName("isDistributing should return false when withdrawals <= contributions")
+        void isDistributingFalse() {
+            AnnualSummary summary = AnnualSummary.builder(2025)
+                    .totalContributions(new BigDecimal("24000"))
+                    .totalWithdrawals(BigDecimal.ZERO)
+                    .build();
+
+            assertFalse(summary.isDistributing());
+        }
+    }
+}

--- a/src/test/java/io/github/xmljim/retirement/simulation/result/TimeSeriesTest.java
+++ b/src/test/java/io/github/xmljim/retirement/simulation/result/TimeSeriesTest.java
@@ -1,0 +1,214 @@
+package io.github.xmljim.retirement.simulation.result;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.time.YearMonth;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.github.xmljim.retirement.domain.exception.InvalidDateRangeException;
+import io.github.xmljim.retirement.domain.exception.MissingRequiredFieldException;
+import io.github.xmljim.retirement.domain.exception.ValidationException;
+
+@DisplayName("TimeSeries")
+class TimeSeriesTest {
+
+    private MonthlySnapshot jan2025;
+    private MonthlySnapshot feb2025;
+    private MonthlySnapshot mar2025;
+    private MonthlySnapshot jan2026;
+
+    @BeforeEach
+    void setUp() {
+        jan2025 = MonthlySnapshot.builder(YearMonth.of(2025, 1))
+                .salaryIncome(new BigDecimal("8000"))
+                .totalExpenses(new BigDecimal("5000"))
+                .eventsTriggered(List.of("NewYear"))
+                .build();
+        feb2025 = MonthlySnapshot.builder(YearMonth.of(2025, 2))
+                .salaryIncome(new BigDecimal("8000"))
+                .totalExpenses(new BigDecimal("5000"))
+                .build();
+        mar2025 = MonthlySnapshot.builder(YearMonth.of(2025, 3))
+                .salaryIncome(new BigDecimal("8000"))
+                .totalExpenses(new BigDecimal("5000"))
+                .eventsTriggered(List.of("Bonus"))
+                .build();
+        jan2026 = MonthlySnapshot.builder(YearMonth.of(2026, 1))
+                .salaryIncome(new BigDecimal("8500"))
+                .totalExpenses(new BigDecimal("5200"))
+                .eventsTriggered(List.of("Raise"))
+                .build();
+    }
+
+    @Nested
+    @DisplayName("Construction")
+    class Construction {
+
+        @Test
+        @DisplayName("should create empty series")
+        void shouldCreateEmptySeries() {
+            TimeSeries<MonthlySnapshot> series = TimeSeries.<MonthlySnapshot>builder().build();
+            assertTrue(series.isEmpty());
+            assertEquals(0, series.size());
+        }
+
+        @Test
+        @DisplayName("should reject null snapshot")
+        void shouldRejectNullSnapshot() {
+            assertThrows(MissingRequiredFieldException.class, () ->
+                    TimeSeries.<MonthlySnapshot>builder().add(null));
+        }
+
+        @Test
+        @DisplayName("should reject duplicate months")
+        void shouldRejectDuplicateMonths() {
+            MonthlySnapshot dup = MonthlySnapshot.builder(YearMonth.of(2025, 1)).build();
+            assertThrows(ValidationException.class, () ->
+                    TimeSeries.<MonthlySnapshot>builder().add(jan2025).add(dup).build());
+        }
+
+        @Test
+        @DisplayName("should sort snapshots chronologically")
+        void shouldSortSnapshots() {
+            TimeSeries<MonthlySnapshot> series = TimeSeries.<MonthlySnapshot>builder()
+                    .add(mar2025).add(jan2025).add(feb2025).build();
+            assertEquals(jan2025, series.getFirst().orElseThrow());
+            assertEquals(mar2025, series.getLast().orElseThrow());
+        }
+    }
+
+    @Nested
+    @DisplayName("Monthly Access")
+    class MonthlyAccess {
+
+        @Test
+        @DisplayName("getSnapshot should return snapshot for month")
+        void getSnapshotFound() {
+            TimeSeries<MonthlySnapshot> series = TimeSeries.<MonthlySnapshot>builder()
+                    .add(jan2025).add(feb2025).build();
+            assertEquals(jan2025, series.getSnapshot(YearMonth.of(2025, 1)).orElseThrow());
+        }
+
+        @Test
+        @DisplayName("getSnapshot should return empty for missing month")
+        void getSnapshotNotFound() {
+            TimeSeries<MonthlySnapshot> series = TimeSeries.<MonthlySnapshot>builder()
+                    .add(jan2025).build();
+            assertTrue(series.getSnapshot(YearMonth.of(2025, 12)).isEmpty());
+        }
+
+        @Test
+        @DisplayName("getRange should return snapshots in range")
+        void getRange() {
+            TimeSeries<MonthlySnapshot> series = TimeSeries.<MonthlySnapshot>builder()
+                    .add(jan2025).add(feb2025).add(mar2025).build();
+            List<MonthlySnapshot> range = series.getRange(
+                    YearMonth.of(2025, 1), YearMonth.of(2025, 2));
+            assertEquals(2, range.size());
+        }
+
+        @Test
+        @DisplayName("getRange should reject invalid range")
+        void getRangeInvalid() {
+            TimeSeries<MonthlySnapshot> series = TimeSeries.<MonthlySnapshot>builder()
+                    .add(jan2025).build();
+            assertThrows(InvalidDateRangeException.class, () ->
+                    series.getRange(YearMonth.of(2025, 3), YearMonth.of(2025, 1)));
+        }
+    }
+
+    @Nested
+    @DisplayName("Annual Aggregation")
+    class AnnualAggregation {
+
+        @Test
+        @DisplayName("getAnnualSummary should aggregate year data")
+        void getAnnualSummary() {
+            TimeSeries<MonthlySnapshot> series = TimeSeries.<MonthlySnapshot>builder()
+                    .add(jan2025).add(feb2025).add(mar2025).build();
+            AnnualSummary summary = series.getAnnualSummary(2025).orElseThrow();
+            assertEquals(2025, summary.year());
+            assertEquals(new BigDecimal("24000.00"), summary.totalIncome());
+            assertEquals(new BigDecimal("15000.00"), summary.totalExpenses());
+        }
+
+        @Test
+        @DisplayName("getAnnualSummary should return empty for missing year")
+        void getAnnualSummaryMissing() {
+            TimeSeries<MonthlySnapshot> series = TimeSeries.<MonthlySnapshot>builder()
+                    .add(jan2025).build();
+            assertTrue(series.getAnnualSummary(2030).isEmpty());
+        }
+
+        @Test
+        @DisplayName("getAllAnnualSummaries should return all years")
+        void getAllAnnualSummaries() {
+            TimeSeries<MonthlySnapshot> series = TimeSeries.<MonthlySnapshot>builder()
+                    .add(jan2025).add(feb2025).add(jan2026).build();
+            List<AnnualSummary> summaries = series.getAllAnnualSummaries();
+            assertEquals(2, summaries.size());
+            assertEquals(2025, summaries.get(0).year());
+            assertEquals(2026, summaries.get(1).year());
+        }
+
+        @Test
+        @DisplayName("getYears should return distinct years")
+        void getYears() {
+            TimeSeries<MonthlySnapshot> series = TimeSeries.<MonthlySnapshot>builder()
+                    .add(jan2025).add(feb2025).add(jan2026).build();
+            assertEquals(List.of(2025, 2026), series.getYears());
+        }
+
+        @Test
+        @DisplayName("annual summary should collect events")
+        void annualSummaryEvents() {
+            TimeSeries<MonthlySnapshot> series = TimeSeries.<MonthlySnapshot>builder()
+                    .add(jan2025).add(mar2025).build();
+            AnnualSummary summary = series.getAnnualSummary(2025).orElseThrow();
+            assertTrue(summary.significantEvents().contains("NewYear"));
+            assertTrue(summary.significantEvents().contains("Bonus"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Iteration")
+    class Iteration {
+
+        @Test
+        @DisplayName("stream should return all snapshots")
+        void stream() {
+            TimeSeries<MonthlySnapshot> series = TimeSeries.<MonthlySnapshot>builder()
+                    .add(jan2025).add(feb2025).build();
+            assertEquals(2, series.stream().count());
+        }
+
+        @Test
+        @DisplayName("iterator should work in for-each")
+        void iterator() {
+            TimeSeries<MonthlySnapshot> series = TimeSeries.<MonthlySnapshot>builder()
+                    .add(jan2025).add(feb2025).build();
+            int count = 0;
+            for (MonthlySnapshot s : series) {
+                count++;
+            }
+            assertEquals(2, count);
+        }
+
+        @Test
+        @DisplayName("toList should return unmodifiable list")
+        void toList() {
+            TimeSeries<MonthlySnapshot> series = TimeSeries.<MonthlySnapshot>builder()
+                    .add(jan2025).build();
+            assertThrows(UnsupportedOperationException.class, () ->
+                    series.toList().add(feb2025));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Create `TimeSeries<T extends MonthlySnapshot>` generic container for monthly snapshots
- Create `AnnualSummary` record for year-over-year aggregation
- Implement efficient monthly access, range queries, and annual aggregation

## Implementation Details

### TimeSeries Class
- **Monthly access**: `getSnapshot(YearMonth)`, `getFirst()`, `getLast()`
- **Range queries**: `getRange(start, end)`, `getSnapshotsForYear(year)`
- **Annual aggregation**: `getAnnualSummary(year)`, `getAllAnnualSummaries()`
- **Iteration**: `stream()`, `iterator()`, `toList()`
- Backed by NavigableMap for efficient date-based lookups
- Immutable after construction via Builder pattern

### AnnualSummary Record
- Aggregates: startingBalance, endingBalance, contributions, withdrawals, income, expenses, taxes, returns
- Computed metrics: `netBalanceChange()`, `netContributions()`, `netSavings()`, `effectiveTaxRate()`
- Status checks: `hadGrowth()`, `isAccumulating()`, `isDistributing()`
- Collects significant events from all months in the year

## Test plan
- [x] AnnualSummaryTest (19 tests) - construction, builder, computed metrics, status checks
- [x] TimeSeriesTest (16 tests) - construction, monthly access, range queries, annual aggregation, iteration
- [x] Build passes with checkstyle and SpotBugs

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)