### PR TITLE
feat(#271): Create SimulationLevers configuration records

### DIFF
--- a/src/main/java/io/github/xmljim/retirement/simulation/config/EconomicLevers.java
+++ b/src/main/java/io/github/xmljim/retirement/simulation/config/EconomicLevers.java
@@ -1,0 +1,133 @@
+package io.github.xmljim.retirement.simulation.config;
+
+import java.math.BigDecimal;
+
+/**
+ * Economic assumptions that drive simulation calculations.
+ *
+ * <p>These rates affect income growth, purchasing power, and
+ * present value calculations throughout the simulation.
+ *
+ * @param generalInflationRate annual CPI inflation rate (e.g., 0.025 for 2.5%)
+ * @param wageGrowthRate annual salary/wage growth rate (e.g., 0.03 for 3%)
+ * @param interestRate risk-free rate for discounting (e.g., 0.04 for 4%)
+ *
+ * @see SimulationLevers
+ */
+public record EconomicLevers(
+        BigDecimal generalInflationRate,
+        BigDecimal wageGrowthRate,
+        BigDecimal interestRate
+) {
+
+    /** Default general inflation rate: 2.5%. */
+    public static final BigDecimal DEFAULT_INFLATION_RATE = new BigDecimal("0.025");
+
+    /** Default wage growth rate: 3.0%. */
+    public static final BigDecimal DEFAULT_WAGE_GROWTH_RATE = new BigDecimal("0.03");
+
+    /** Default risk-free interest rate: 4.0%. */
+    public static final BigDecimal DEFAULT_INTEREST_RATE = new BigDecimal("0.04");
+
+    /**
+     * Compact constructor with null-safe defaults.
+     */
+    public EconomicLevers {
+        if (generalInflationRate == null) {
+            generalInflationRate = DEFAULT_INFLATION_RATE;
+        }
+        if (wageGrowthRate == null) {
+            wageGrowthRate = DEFAULT_WAGE_GROWTH_RATE;
+        }
+        if (interestRate == null) {
+            interestRate = DEFAULT_INTEREST_RATE;
+        }
+    }
+
+    /**
+     * Creates economic levers with default assumptions.
+     *
+     * <p>Default values:
+     * <ul>
+     *   <li>General inflation: 2.5%</li>
+     *   <li>Wage growth: 3.0%</li>
+     *   <li>Interest rate: 4.0%</li>
+     * </ul>
+     *
+     * @return levers with default values
+     */
+    public static EconomicLevers withDefaults() {
+        return new EconomicLevers(
+                DEFAULT_INFLATION_RATE,
+                DEFAULT_WAGE_GROWTH_RATE,
+                DEFAULT_INTEREST_RATE
+        );
+    }
+
+    /**
+     * Creates a builder for constructing EconomicLevers.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for EconomicLevers.
+     */
+    public static final class Builder {
+        private BigDecimal generalInflationRate = DEFAULT_INFLATION_RATE;
+        private BigDecimal wageGrowthRate = DEFAULT_WAGE_GROWTH_RATE;
+        private BigDecimal interestRate = DEFAULT_INTEREST_RATE;
+
+        private Builder() {
+        }
+
+        /**
+         * Sets the general inflation rate.
+         *
+         * @param rate the inflation rate as decimal
+         * @return this builder
+         */
+        public Builder generalInflationRate(BigDecimal rate) {
+            this.generalInflationRate = rate;
+            return this;
+        }
+
+        /**
+         * Sets the wage growth rate.
+         *
+         * @param rate the wage growth rate as decimal
+         * @return this builder
+         */
+        public Builder wageGrowthRate(BigDecimal rate) {
+            this.wageGrowthRate = rate;
+            return this;
+        }
+
+        /**
+         * Sets the interest rate.
+         *
+         * @param rate the interest rate as decimal
+         * @return this builder
+         */
+        public Builder interestRate(BigDecimal rate) {
+            this.interestRate = rate;
+            return this;
+        }
+
+        /**
+         * Builds the EconomicLevers.
+         *
+         * @return the constructed EconomicLevers
+         */
+        public EconomicLevers build() {
+            return new EconomicLevers(
+                    generalInflationRate,
+                    wageGrowthRate,
+                    interestRate
+            );
+        }
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/simulation/config/ExpenseLevers.java
+++ b/src/main/java/io/github/xmljim/retirement/simulation/config/ExpenseLevers.java
@@ -1,0 +1,246 @@
+package io.github.xmljim.retirement.simulation.config;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.github.xmljim.retirement.domain.calculator.ExpenseModifier;
+import io.github.xmljim.retirement.domain.enums.ExpenseCategory.InflationType;
+
+/**
+ * Expense-related assumptions for simulation.
+ *
+ * <p>Controls how expenses evolve over time through:
+ * <ul>
+ *   <li>Category-specific inflation rates</li>
+ *   <li>Healthcare cost trends</li>
+ *   <li>Modifiers for spending phases and survivor scenarios</li>
+ * </ul>
+ *
+ * @param inflationRates inflation rates by category type
+ * @param healthcareTrend additional healthcare cost increase above inflation
+ * @param discretionaryModifier modifier for discretionary spending
+ * @param essentialsModifier modifier for essential spending
+ * @param healthcareModifier modifier for healthcare spending
+ * @param survivorModifier modifier applied in survivor scenarios
+ *
+ * @see ExpenseModifier
+ * @see InflationType
+ * @see SimulationLevers
+ */
+@SuppressFBWarnings(
+        value = "EI_EXPOSE_REP",
+        justification = "Map is made unmodifiable in compact constructor"
+)
+public record ExpenseLevers(
+        Map<InflationType, BigDecimal> inflationRates,
+        BigDecimal healthcareTrend,
+        ExpenseModifier discretionaryModifier,
+        ExpenseModifier essentialsModifier,
+        ExpenseModifier healthcareModifier,
+        ExpenseModifier survivorModifier
+) {
+
+    /** Default general inflation: 2.5%. */
+    public static final BigDecimal DEFAULT_GENERAL_INFLATION = new BigDecimal("0.025");
+
+    /** Default healthcare inflation: 5.5%. */
+    public static final BigDecimal DEFAULT_HEALTHCARE_INFLATION = new BigDecimal("0.055");
+
+    /** Default housing inflation: 3.0%. */
+    public static final BigDecimal DEFAULT_HOUSING_INFLATION = new BigDecimal("0.03");
+
+    /** Default LTC inflation: 4.0%. */
+    public static final BigDecimal DEFAULT_LTC_INFLATION = new BigDecimal("0.04");
+
+    /** Default healthcare trend above inflation: 2.0%. */
+    public static final BigDecimal DEFAULT_HEALTHCARE_TREND = new BigDecimal("0.02");
+
+    /**
+     * Compact constructor with null-safe defaults and defensive copying.
+     */
+    public ExpenseLevers {
+        if (inflationRates == null || inflationRates.isEmpty()) {
+            inflationRates = defaultInflationRates();
+        } else {
+            inflationRates = Collections.unmodifiableMap(new EnumMap<>(inflationRates));
+        }
+        if (healthcareTrend == null) {
+            healthcareTrend = DEFAULT_HEALTHCARE_TREND;
+        }
+        if (discretionaryModifier == null) {
+            discretionaryModifier = ExpenseModifier.identity();
+        }
+        if (essentialsModifier == null) {
+            essentialsModifier = ExpenseModifier.identity();
+        }
+        if (healthcareModifier == null) {
+            healthcareModifier = ExpenseModifier.identity();
+        }
+        if (survivorModifier == null) {
+            survivorModifier = ExpenseModifier.identity();
+        }
+    }
+
+    /**
+     * Creates expense levers with default assumptions.
+     *
+     * @return levers with default values
+     */
+    public static ExpenseLevers withDefaults() {
+        return new ExpenseLevers(
+                defaultInflationRates(),
+                DEFAULT_HEALTHCARE_TREND,
+                ExpenseModifier.identity(),
+                ExpenseModifier.identity(),
+                ExpenseModifier.identity(),
+                ExpenseModifier.identity()
+        );
+    }
+
+    /**
+     * Gets the inflation rate for a specific category type.
+     *
+     * @param type the inflation type
+     * @return the inflation rate, or ZERO for NONE type
+     */
+    public BigDecimal getInflationRate(InflationType type) {
+        if (type == InflationType.NONE) {
+            return BigDecimal.ZERO;
+        }
+        return inflationRates.getOrDefault(type, DEFAULT_GENERAL_INFLATION);
+    }
+
+    /**
+     * Creates a builder for constructing ExpenseLevers.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private static Map<InflationType, BigDecimal> defaultInflationRates() {
+        EnumMap<InflationType, BigDecimal> rates = new EnumMap<>(InflationType.class);
+        rates.put(InflationType.GENERAL, DEFAULT_GENERAL_INFLATION);
+        rates.put(InflationType.HEALTHCARE, DEFAULT_HEALTHCARE_INFLATION);
+        rates.put(InflationType.HOUSING, DEFAULT_HOUSING_INFLATION);
+        rates.put(InflationType.LTC, DEFAULT_LTC_INFLATION);
+        rates.put(InflationType.NONE, BigDecimal.ZERO);
+        return Collections.unmodifiableMap(rates);
+    }
+
+    /**
+     * Builder for ExpenseLevers.
+     */
+    public static final class Builder {
+        private Map<InflationType, BigDecimal> inflationRates;
+        private BigDecimal healthcareTrend = DEFAULT_HEALTHCARE_TREND;
+        private ExpenseModifier discretionaryModifier = ExpenseModifier.identity();
+        private ExpenseModifier essentialsModifier = ExpenseModifier.identity();
+        private ExpenseModifier healthcareModifier = ExpenseModifier.identity();
+        private ExpenseModifier survivorModifier = ExpenseModifier.identity();
+
+        private Builder() {
+            this.inflationRates = new EnumMap<>(InflationType.class);
+            this.inflationRates.putAll(defaultInflationRates());
+        }
+
+        /**
+         * Sets all inflation rates.
+         *
+         * @param rates the inflation rates map
+         * @return this builder
+         */
+        public Builder inflationRates(Map<InflationType, BigDecimal> rates) {
+            this.inflationRates = new EnumMap<>(InflationType.class);
+            this.inflationRates.putAll(rates);
+            return this;
+        }
+
+        /**
+         * Sets a specific inflation rate.
+         *
+         * @param type the inflation type
+         * @param rate the rate
+         * @return this builder
+         */
+        public Builder inflationRate(InflationType type, BigDecimal rate) {
+            this.inflationRates.put(type, rate);
+            return this;
+        }
+
+        /**
+         * Sets the healthcare trend.
+         *
+         * @param trend the healthcare trend rate
+         * @return this builder
+         */
+        public Builder healthcareTrend(BigDecimal trend) {
+            this.healthcareTrend = trend;
+            return this;
+        }
+
+        /**
+         * Sets the discretionary spending modifier.
+         *
+         * @param modifier the modifier
+         * @return this builder
+         */
+        public Builder discretionaryModifier(ExpenseModifier modifier) {
+            this.discretionaryModifier = modifier;
+            return this;
+        }
+
+        /**
+         * Sets the essentials spending modifier.
+         *
+         * @param modifier the modifier
+         * @return this builder
+         */
+        public Builder essentialsModifier(ExpenseModifier modifier) {
+            this.essentialsModifier = modifier;
+            return this;
+        }
+
+        /**
+         * Sets the healthcare spending modifier.
+         *
+         * @param modifier the modifier
+         * @return this builder
+         */
+        public Builder healthcareModifier(ExpenseModifier modifier) {
+            this.healthcareModifier = modifier;
+            return this;
+        }
+
+        /**
+         * Sets the survivor modifier.
+         *
+         * @param modifier the modifier
+         * @return this builder
+         */
+        public Builder survivorModifier(ExpenseModifier modifier) {
+            this.survivorModifier = modifier;
+            return this;
+        }
+
+        /**
+         * Builds the ExpenseLevers.
+         *
+         * @return the constructed ExpenseLevers
+         */
+        public ExpenseLevers build() {
+            return new ExpenseLevers(
+                    inflationRates,
+                    healthcareTrend,
+                    discretionaryModifier,
+                    essentialsModifier,
+                    healthcareModifier,
+                    survivorModifier
+            );
+        }
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/simulation/config/MarketLevers.java
+++ b/src/main/java/io/github/xmljim/retirement/simulation/config/MarketLevers.java
@@ -1,0 +1,144 @@
+package io.github.xmljim.retirement.simulation.config;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.github.xmljim.retirement.domain.exception.ValidationException;
+
+/**
+ * Market return assumptions for simulation.
+ *
+ * <p>Configures how investment returns are calculated based on the
+ * selected {@link SimulationMode}:
+ * <ul>
+ *   <li>Deterministic - uses {@code expectedReturn}</li>
+ *   <li>Monte Carlo - uses {@code expectedReturn} and {@code returnStdDev}</li>
+ *   <li>Historical - uses {@code historicalReturns} sequence</li>
+ * </ul>
+ *
+ * @param mode the simulation mode determining return calculation
+ * @param expectedReturn expected annual return (used by deterministic and Monte Carlo)
+ * @param returnStdDev standard deviation of returns (used by Monte Carlo)
+ * @param historicalReturns sequence of historical returns (used by historical mode)
+ *
+ * @see SimulationMode
+ * @see SimulationLevers
+ */
+@SuppressFBWarnings(
+        value = "EI_EXPOSE_REP",
+        justification = "List is made unmodifiable in compact constructor"
+)
+public record MarketLevers(
+        SimulationMode mode,
+        BigDecimal expectedReturn,
+        BigDecimal returnStdDev,
+        List<BigDecimal> historicalReturns
+) {
+
+    /** Default expected return: 7.0%. */
+    public static final BigDecimal DEFAULT_EXPECTED_RETURN = new BigDecimal("0.07");
+
+    /** Default return standard deviation: 15.0%. */
+    public static final BigDecimal DEFAULT_RETURN_STD_DEV = new BigDecimal("0.15");
+
+    /**
+     * Compact constructor with validation and defensive copying.
+     */
+    public MarketLevers {
+        if (mode == null) {
+            mode = SimulationMode.DETERMINISTIC;
+        }
+        if (expectedReturn == null) {
+            expectedReturn = DEFAULT_EXPECTED_RETURN;
+        }
+        if (returnStdDev == null) {
+            returnStdDev = DEFAULT_RETURN_STD_DEV;
+        }
+        historicalReturns = historicalReturns == null
+                ? Collections.emptyList()
+                : Collections.unmodifiableList(new ArrayList<>(historicalReturns));
+
+        // Validate mode-specific requirements
+        if (mode == SimulationMode.HISTORICAL && historicalReturns.isEmpty()) {
+            throw new ValidationException(
+                    "Historical mode requires non-empty historicalReturns", "historicalReturns");
+        }
+    }
+
+    /**
+     * Creates deterministic market levers with a fixed return rate.
+     *
+     * @param rate the fixed annual return rate
+     * @return market levers for deterministic simulation
+     */
+    public static MarketLevers deterministic(BigDecimal rate) {
+        return new MarketLevers(
+                SimulationMode.DETERMINISTIC,
+                rate,
+                BigDecimal.ZERO,
+                Collections.emptyList()
+        );
+    }
+
+    /**
+     * Creates Monte Carlo market levers with mean and standard deviation.
+     *
+     * @param mean the expected return (mean of distribution)
+     * @param stdDev the standard deviation of returns
+     * @return market levers for Monte Carlo simulation
+     */
+    public static MarketLevers monteCarlo(BigDecimal mean, BigDecimal stdDev) {
+        return new MarketLevers(
+                SimulationMode.MONTE_CARLO,
+                mean,
+                stdDev,
+                Collections.emptyList()
+        );
+    }
+
+    /**
+     * Creates historical market levers with actual return sequence.
+     *
+     * @param returns the historical returns sequence
+     * @return market levers for historical backtesting
+     * @throws ValidationException if returns list is empty
+     */
+    public static MarketLevers historical(List<BigDecimal> returns) {
+        return new MarketLevers(
+                SimulationMode.HISTORICAL,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                returns
+        );
+    }
+
+    /**
+     * Creates market levers with default assumptions (deterministic 7%).
+     *
+     * @return levers with default values
+     */
+    public static MarketLevers withDefaults() {
+        return deterministic(DEFAULT_EXPECTED_RETURN);
+    }
+
+    /**
+     * Indicates whether this configuration uses stochastic returns.
+     *
+     * @return true if Monte Carlo mode
+     */
+    public boolean isStochastic() {
+        return mode.isStochastic();
+    }
+
+    /**
+     * Indicates whether this configuration uses historical data.
+     *
+     * @return true if historical mode
+     */
+    public boolean usesHistoricalData() {
+        return mode.usesHistoricalData();
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/simulation/config/SimulationLevers.java
+++ b/src/main/java/io/github/xmljim/retirement/simulation/config/SimulationLevers.java
@@ -1,0 +1,158 @@
+package io.github.xmljim.retirement.simulation.config;
+
+/**
+ * Top-level configuration controlling simulation behavior.
+ *
+ * <p>SimulationLevers aggregates all configuration parameters that affect
+ * how a retirement simulation runs. These values are immutable and set
+ * at simulation start.
+ *
+ * <p>Levers are organized into three categories:
+ * <ul>
+ *   <li>{@link EconomicLevers} - Inflation, wage growth, interest rates</li>
+ *   <li>{@link MarketLevers} - Investment return assumptions and mode</li>
+ *   <li>{@link ExpenseLevers} - Expense inflation and modifiers</li>
+ * </ul>
+ *
+ * <p>Example usage:
+ * <pre>{@code
+ * SimulationLevers levers = SimulationLevers.builder()
+ *     .economic(EconomicLevers.builder()
+ *         .generalInflationRate(new BigDecimal("0.03"))
+ *         .build())
+ *     .market(MarketLevers.monteCarlo(
+ *         new BigDecimal("0.07"),
+ *         new BigDecimal("0.15")))
+ *     .build();
+ * }</pre>
+ *
+ * @param economic economic assumptions (inflation, wage growth, interest)
+ * @param market market return assumptions and simulation mode
+ * @param expense expense inflation and modifiers
+ *
+ * @see EconomicLevers
+ * @see MarketLevers
+ * @see ExpenseLevers
+ */
+public record SimulationLevers(
+        EconomicLevers economic,
+        MarketLevers market,
+        ExpenseLevers expense
+) {
+
+    /**
+     * Compact constructor with null-safe defaults.
+     */
+    public SimulationLevers {
+        if (economic == null) {
+            economic = EconomicLevers.withDefaults();
+        }
+        if (market == null) {
+            market = MarketLevers.withDefaults();
+        }
+        if (expense == null) {
+            expense = ExpenseLevers.withDefaults();
+        }
+    }
+
+    /**
+     * Creates simulation levers with all default assumptions.
+     *
+     * <p>Defaults provide a reasonable baseline for initial projections:
+     * <ul>
+     *   <li>Economic: 2.5% inflation, 3% wage growth, 4% interest</li>
+     *   <li>Market: Deterministic 7% return</li>
+     *   <li>Expense: Standard inflation rates, no modifiers</li>
+     * </ul>
+     *
+     * @return levers with default values
+     */
+    public static SimulationLevers withDefaults() {
+        return new SimulationLevers(
+                EconomicLevers.withDefaults(),
+                MarketLevers.withDefaults(),
+                ExpenseLevers.withDefaults()
+        );
+    }
+
+    /**
+     * Creates a builder for constructing SimulationLevers.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Indicates whether this configuration uses stochastic returns.
+     *
+     * @return true if Monte Carlo mode
+     */
+    public boolean isStochastic() {
+        return market.isStochastic();
+    }
+
+    /**
+     * Gets the simulation mode from market levers.
+     *
+     * @return the simulation mode
+     */
+    public SimulationMode mode() {
+        return market.mode();
+    }
+
+    /**
+     * Builder for SimulationLevers.
+     */
+    public static final class Builder {
+        private EconomicLevers economic = EconomicLevers.withDefaults();
+        private MarketLevers market = MarketLevers.withDefaults();
+        private ExpenseLevers expense = ExpenseLevers.withDefaults();
+
+        private Builder() {
+        }
+
+        /**
+         * Sets the economic levers.
+         *
+         * @param economic the economic levers
+         * @return this builder
+         */
+        public Builder economic(EconomicLevers economic) {
+            this.economic = economic;
+            return this;
+        }
+
+        /**
+         * Sets the market levers.
+         *
+         * @param market the market levers
+         * @return this builder
+         */
+        public Builder market(MarketLevers market) {
+            this.market = market;
+            return this;
+        }
+
+        /**
+         * Sets the expense levers.
+         *
+         * @param expense the expense levers
+         * @return this builder
+         */
+        public Builder expense(ExpenseLevers expense) {
+            this.expense = expense;
+            return this;
+        }
+
+        /**
+         * Builds the SimulationLevers.
+         *
+         * @return the constructed SimulationLevers
+         */
+        public SimulationLevers build() {
+            return new SimulationLevers(economic, market, expense);
+        }
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/simulation/config/SimulationMode.java
+++ b/src/main/java/io/github/xmljim/retirement/simulation/config/SimulationMode.java
@@ -1,0 +1,93 @@
+package io.github.xmljim.retirement.simulation.config;
+
+/**
+ * Defines how investment returns are calculated during simulation.
+ *
+ * <p>The simulation mode determines the source of return data:
+ * <ul>
+ *   <li>{@link #DETERMINISTIC} - Uses a fixed rate for all periods</li>
+ *   <li>{@link #MONTE_CARLO} - Draws random returns from a distribution</li>
+ *   <li>{@link #HISTORICAL} - Uses actual historical market sequences</li>
+ * </ul>
+ *
+ * @see MarketLevers
+ */
+public enum SimulationMode {
+
+    /**
+     * Fixed rate applied to all periods.
+     *
+     * <p>Use for baseline projections and sensitivity analysis.
+     * The same return rate is applied every month/year.
+     */
+    DETERMINISTIC("Deterministic", "Fixed rate applied consistently"),
+
+    /**
+     * Random returns drawn from a normal distribution.
+     *
+     * <p>Use for probability analysis and stress testing.
+     * Each period samples from N(mean, stdDev) distribution.
+     */
+    MONTE_CARLO("Monte Carlo", "Random draws from distribution"),
+
+    /**
+     * Actual historical market sequences.
+     *
+     * <p>Use for backtesting against real market conditions.
+     * Applies actual historical returns in sequence.
+     */
+    HISTORICAL("Historical", "Actual market sequences");
+
+    private final String displayName;
+    private final String description;
+
+    SimulationMode(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+
+    /**
+     * Returns the human-readable display name.
+     *
+     * @return the display name
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * Returns a brief description of this mode.
+     *
+     * @return the description
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Indicates whether this mode requires random number generation.
+     *
+     * @return true if stochastic
+     */
+    public boolean isStochastic() {
+        return this == MONTE_CARLO;
+    }
+
+    /**
+     * Indicates whether this mode uses a fixed rate.
+     *
+     * @return true if deterministic
+     */
+    public boolean isFixed() {
+        return this == DETERMINISTIC;
+    }
+
+    /**
+     * Indicates whether this mode uses historical data.
+     *
+     * @return true if historical
+     */
+    public boolean usesHistoricalData() {
+        return this == HISTORICAL;
+    }
+}

--- a/src/test/java/io/github/xmljim/retirement/simulation/config/EconomicLeversTest.java
+++ b/src/test/java/io/github/xmljim/retirement/simulation/config/EconomicLeversTest.java
@@ -1,0 +1,72 @@
+package io.github.xmljim.retirement.simulation.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("EconomicLevers")
+class EconomicLeversTest {
+
+    @Nested
+    @DisplayName("Default Factory")
+    class DefaultFactory {
+
+        @Test
+        @DisplayName("withDefaults should use standard assumptions")
+        void withDefaultsShouldUseStandardAssumptions() {
+            EconomicLevers levers = EconomicLevers.withDefaults();
+
+            assertEquals(new BigDecimal("0.025"), levers.generalInflationRate());
+            assertEquals(new BigDecimal("0.03"), levers.wageGrowthRate());
+            assertEquals(new BigDecimal("0.04"), levers.interestRate());
+        }
+    }
+
+    @Nested
+    @DisplayName("Null Handling")
+    class NullHandling {
+
+        @Test
+        @DisplayName("should default null values")
+        void shouldDefaultNullValues() {
+            EconomicLevers levers = new EconomicLevers(null, null, null);
+
+            assertEquals(EconomicLevers.DEFAULT_INFLATION_RATE, levers.generalInflationRate());
+            assertEquals(EconomicLevers.DEFAULT_WAGE_GROWTH_RATE, levers.wageGrowthRate());
+            assertEquals(EconomicLevers.DEFAULT_INTEREST_RATE, levers.interestRate());
+        }
+    }
+
+    @Nested
+    @DisplayName("Builder")
+    class BuilderTests {
+
+        @Test
+        @DisplayName("should build with custom values")
+        void shouldBuildWithCustomValues() {
+            EconomicLevers levers = EconomicLevers.builder()
+                    .generalInflationRate(new BigDecimal("0.03"))
+                    .wageGrowthRate(new BigDecimal("0.04"))
+                    .interestRate(new BigDecimal("0.05"))
+                    .build();
+
+            assertEquals(new BigDecimal("0.03"), levers.generalInflationRate());
+            assertEquals(new BigDecimal("0.04"), levers.wageGrowthRate());
+            assertEquals(new BigDecimal("0.05"), levers.interestRate());
+        }
+
+        @Test
+        @DisplayName("builder should use defaults when not set")
+        void builderShouldUseDefaults() {
+            EconomicLevers levers = EconomicLevers.builder().build();
+
+            assertEquals(EconomicLevers.DEFAULT_INFLATION_RATE, levers.generalInflationRate());
+            assertEquals(EconomicLevers.DEFAULT_WAGE_GROWTH_RATE, levers.wageGrowthRate());
+            assertEquals(EconomicLevers.DEFAULT_INTEREST_RATE, levers.interestRate());
+        }
+    }
+}

--- a/src/test/java/io/github/xmljim/retirement/simulation/config/ExpenseLeversTest.java
+++ b/src/test/java/io/github/xmljim/retirement/simulation/config/ExpenseLeversTest.java
@@ -1,0 +1,136 @@
+package io.github.xmljim.retirement.simulation.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.github.xmljim.retirement.domain.enums.ExpenseCategory.InflationType;
+
+@DisplayName("ExpenseLevers")
+class ExpenseLeversTest {
+
+    @Nested
+    @DisplayName("Default Factory")
+    class DefaultFactory {
+
+        @Test
+        @DisplayName("withDefaults should use standard assumptions")
+        void withDefaultsShouldUseStandardAssumptions() {
+            ExpenseLevers levers = ExpenseLevers.withDefaults();
+
+            assertEquals(ExpenseLevers.DEFAULT_GENERAL_INFLATION,
+                    levers.getInflationRate(InflationType.GENERAL));
+            assertEquals(ExpenseLevers.DEFAULT_HEALTHCARE_INFLATION,
+                    levers.getInflationRate(InflationType.HEALTHCARE));
+            assertEquals(ExpenseLevers.DEFAULT_HOUSING_INFLATION,
+                    levers.getInflationRate(InflationType.HOUSING));
+            assertEquals(ExpenseLevers.DEFAULT_LTC_INFLATION,
+                    levers.getInflationRate(InflationType.LTC));
+            assertEquals(BigDecimal.ZERO,
+                    levers.getInflationRate(InflationType.NONE));
+            assertEquals(ExpenseLevers.DEFAULT_HEALTHCARE_TREND,
+                    levers.healthcareTrend());
+        }
+
+        @Test
+        @DisplayName("withDefaults should provide identity modifiers")
+        void withDefaultsShouldProvideIdentityModifiers() {
+            ExpenseLevers levers = ExpenseLevers.withDefaults();
+
+            assertNotNull(levers.discretionaryModifier());
+            assertNotNull(levers.essentialsModifier());
+            assertNotNull(levers.healthcareModifier());
+            assertNotNull(levers.survivorModifier());
+        }
+    }
+
+    @Nested
+    @DisplayName("Inflation Rates")
+    class InflationRates {
+
+        @Test
+        @DisplayName("getInflationRate should return ZERO for NONE type")
+        void getInflationRateShouldReturnZeroForNone() {
+            ExpenseLevers levers = ExpenseLevers.withDefaults();
+
+            assertEquals(BigDecimal.ZERO, levers.getInflationRate(InflationType.NONE));
+        }
+
+        @Test
+        @DisplayName("getInflationRate should return default for unknown type")
+        void getInflationRateShouldReturnDefaultForUnknown() {
+            ExpenseLevers levers = ExpenseLevers.builder()
+                    .inflationRates(Map.of())
+                    .build();
+
+            // Should fall back to default general inflation
+            assertEquals(ExpenseLevers.DEFAULT_GENERAL_INFLATION,
+                    levers.getInflationRate(InflationType.GENERAL));
+        }
+    }
+
+    @Nested
+    @DisplayName("Builder")
+    class BuilderTests {
+
+        @Test
+        @DisplayName("should build with custom inflation rates")
+        void shouldBuildWithCustomInflationRates() {
+            ExpenseLevers levers = ExpenseLevers.builder()
+                    .inflationRate(InflationType.GENERAL, new BigDecimal("0.03"))
+                    .inflationRate(InflationType.HEALTHCARE, new BigDecimal("0.06"))
+                    .build();
+
+            assertEquals(new BigDecimal("0.03"),
+                    levers.getInflationRate(InflationType.GENERAL));
+            assertEquals(new BigDecimal("0.06"),
+                    levers.getInflationRate(InflationType.HEALTHCARE));
+        }
+
+        @Test
+        @DisplayName("should build with custom healthcare trend")
+        void shouldBuildWithCustomHealthcareTrend() {
+            ExpenseLevers levers = ExpenseLevers.builder()
+                    .healthcareTrend(new BigDecimal("0.03"))
+                    .build();
+
+            assertEquals(new BigDecimal("0.03"), levers.healthcareTrend());
+        }
+    }
+
+    @Nested
+    @DisplayName("Immutability")
+    class Immutability {
+
+        @Test
+        @DisplayName("inflationRates map should be unmodifiable")
+        void inflationRatesMapShouldBeUnmodifiable() {
+            ExpenseLevers levers = ExpenseLevers.withDefaults();
+
+            assertThrows(UnsupportedOperationException.class, () ->
+                    levers.inflationRates().put(InflationType.GENERAL, BigDecimal.ONE));
+        }
+    }
+
+    @Nested
+    @DisplayName("Null Handling")
+    class NullHandling {
+
+        @Test
+        @DisplayName("should default null inflation rates")
+        void shouldDefaultNullInflationRates() {
+            ExpenseLevers levers = new ExpenseLevers(null, null, null, null, null, null);
+
+            assertNotNull(levers.inflationRates());
+            assertEquals(ExpenseLevers.DEFAULT_HEALTHCARE_TREND, levers.healthcareTrend());
+            assertNotNull(levers.discretionaryModifier());
+        }
+    }
+}

--- a/src/test/java/io/github/xmljim/retirement/simulation/config/MarketLeversTest.java
+++ b/src/test/java/io/github/xmljim/retirement/simulation/config/MarketLeversTest.java
@@ -1,0 +1,111 @@
+package io.github.xmljim.retirement.simulation.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.github.xmljim.retirement.domain.exception.ValidationException;
+
+@DisplayName("MarketLevers")
+class MarketLeversTest {
+
+    @Nested
+    @DisplayName("Factory Methods")
+    class FactoryMethods {
+
+        @Test
+        @DisplayName("deterministic should create fixed rate levers")
+        void deterministicShouldCreateFixedRateLevers() {
+            MarketLevers levers = MarketLevers.deterministic(new BigDecimal("0.06"));
+
+            assertEquals(SimulationMode.DETERMINISTIC, levers.mode());
+            assertEquals(new BigDecimal("0.06"), levers.expectedReturn());
+            assertTrue(levers.mode().isFixed());
+            assertFalse(levers.isStochastic());
+        }
+
+        @Test
+        @DisplayName("monteCarlo should create stochastic levers")
+        void monteCarloShouldCreateStochasticLevers() {
+            MarketLevers levers = MarketLevers.monteCarlo(
+                    new BigDecimal("0.07"),
+                    new BigDecimal("0.15"));
+
+            assertEquals(SimulationMode.MONTE_CARLO, levers.mode());
+            assertEquals(new BigDecimal("0.07"), levers.expectedReturn());
+            assertEquals(new BigDecimal("0.15"), levers.returnStdDev());
+            assertTrue(levers.isStochastic());
+        }
+
+        @Test
+        @DisplayName("historical should create historical levers")
+        void historicalShouldCreateHistoricalLevers() {
+            List<BigDecimal> returns = List.of(
+                    new BigDecimal("0.10"),
+                    new BigDecimal("-0.05"),
+                    new BigDecimal("0.15"));
+
+            MarketLevers levers = MarketLevers.historical(returns);
+
+            assertEquals(SimulationMode.HISTORICAL, levers.mode());
+            assertEquals(returns, levers.historicalReturns());
+            assertTrue(levers.usesHistoricalData());
+        }
+
+        @Test
+        @DisplayName("historical should reject empty returns")
+        void historicalShouldRejectEmptyReturns() {
+            assertThrows(ValidationException.class, () ->
+                    MarketLevers.historical(Collections.emptyList()));
+        }
+
+        @Test
+        @DisplayName("withDefaults should create deterministic 7%")
+        void withDefaultsShouldCreateDeterministicSeven() {
+            MarketLevers levers = MarketLevers.withDefaults();
+
+            assertEquals(SimulationMode.DETERMINISTIC, levers.mode());
+            assertEquals(new BigDecimal("0.07"), levers.expectedReturn());
+        }
+    }
+
+    @Nested
+    @DisplayName("Immutability")
+    class Immutability {
+
+        @Test
+        @DisplayName("historicalReturns should be unmodifiable")
+        void historicalReturnsShouldBeUnmodifiable() {
+            List<BigDecimal> returns = List.of(new BigDecimal("0.10"));
+            MarketLevers levers = MarketLevers.historical(returns);
+
+            assertThrows(UnsupportedOperationException.class, () ->
+                    levers.historicalReturns().add(new BigDecimal("0.05")));
+        }
+    }
+
+    @Nested
+    @DisplayName("Null Handling")
+    class NullHandling {
+
+        @Test
+        @DisplayName("should default null mode to DETERMINISTIC")
+        void shouldDefaultNullMode() {
+            MarketLevers levers = new MarketLevers(null, null, null, null);
+
+            assertEquals(SimulationMode.DETERMINISTIC, levers.mode());
+            assertEquals(MarketLevers.DEFAULT_EXPECTED_RETURN, levers.expectedReturn());
+            assertEquals(MarketLevers.DEFAULT_RETURN_STD_DEV, levers.returnStdDev());
+            assertTrue(levers.historicalReturns().isEmpty());
+        }
+    }
+}

--- a/src/test/java/io/github/xmljim/retirement/simulation/config/SimulationLeversTest.java
+++ b/src/test/java/io/github/xmljim/retirement/simulation/config/SimulationLeversTest.java
@@ -1,0 +1,155 @@
+package io.github.xmljim.retirement.simulation.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("SimulationLevers")
+class SimulationLeversTest {
+
+    @Nested
+    @DisplayName("Default Factory")
+    class DefaultFactory {
+
+        @Test
+        @DisplayName("withDefaults should create all default levers")
+        void withDefaultsShouldCreateAllDefaultLevers() {
+            SimulationLevers levers = SimulationLevers.withDefaults();
+
+            assertNotNull(levers.economic());
+            assertNotNull(levers.market());
+            assertNotNull(levers.expense());
+        }
+
+        @Test
+        @DisplayName("withDefaults should use deterministic mode")
+        void withDefaultsShouldUseDeterministicMode() {
+            SimulationLevers levers = SimulationLevers.withDefaults();
+
+            assertEquals(SimulationMode.DETERMINISTIC, levers.mode());
+            assertFalse(levers.isStochastic());
+        }
+    }
+
+    @Nested
+    @DisplayName("Null Handling")
+    class NullHandling {
+
+        @Test
+        @DisplayName("should default null component levers")
+        void shouldDefaultNullComponentLevers() {
+            SimulationLevers levers = new SimulationLevers(null, null, null);
+
+            assertNotNull(levers.economic());
+            assertNotNull(levers.market());
+            assertNotNull(levers.expense());
+        }
+    }
+
+    @Nested
+    @DisplayName("Builder")
+    class BuilderTests {
+
+        @Test
+        @DisplayName("should build with custom economic levers")
+        void shouldBuildWithCustomEconomicLevers() {
+            EconomicLevers custom = EconomicLevers.builder()
+                    .generalInflationRate(new BigDecimal("0.03"))
+                    .build();
+
+            SimulationLevers levers = SimulationLevers.builder()
+                    .economic(custom)
+                    .build();
+
+            assertEquals(new BigDecimal("0.03"),
+                    levers.economic().generalInflationRate());
+        }
+
+        @Test
+        @DisplayName("should build with custom market levers")
+        void shouldBuildWithCustomMarketLevers() {
+            MarketLevers custom = MarketLevers.monteCarlo(
+                    new BigDecimal("0.08"),
+                    new BigDecimal("0.20"));
+
+            SimulationLevers levers = SimulationLevers.builder()
+                    .market(custom)
+                    .build();
+
+            assertEquals(SimulationMode.MONTE_CARLO, levers.mode());
+            assertTrue(levers.isStochastic());
+            assertEquals(new BigDecimal("0.08"),
+                    levers.market().expectedReturn());
+        }
+
+        @Test
+        @DisplayName("should build with custom expense levers")
+        void shouldBuildWithCustomExpenseLevers() {
+            ExpenseLevers custom = ExpenseLevers.builder()
+                    .healthcareTrend(new BigDecimal("0.03"))
+                    .build();
+
+            SimulationLevers levers = SimulationLevers.builder()
+                    .expense(custom)
+                    .build();
+
+            assertEquals(new BigDecimal("0.03"),
+                    levers.expense().healthcareTrend());
+        }
+
+        @Test
+        @DisplayName("builder defaults should match withDefaults")
+        void builderDefaultsShouldMatchWithDefaults() {
+            SimulationLevers fromBuilder = SimulationLevers.builder().build();
+            SimulationLevers fromFactory = SimulationLevers.withDefaults();
+
+            assertEquals(fromFactory.economic().generalInflationRate(),
+                    fromBuilder.economic().generalInflationRate());
+            assertEquals(fromFactory.market().expectedReturn(),
+                    fromBuilder.market().expectedReturn());
+            assertEquals(fromFactory.expense().healthcareTrend(),
+                    fromBuilder.expense().healthcareTrend());
+        }
+    }
+
+    @Nested
+    @DisplayName("Convenience Methods")
+    class ConvenienceMethods {
+
+        @Test
+        @DisplayName("mode should delegate to market levers")
+        void modeShouldDelegateToMarketLevers() {
+            SimulationLevers levers = SimulationLevers.builder()
+                    .market(MarketLevers.monteCarlo(
+                            new BigDecimal("0.07"),
+                            new BigDecimal("0.15")))
+                    .build();
+
+            assertEquals(SimulationMode.MONTE_CARLO, levers.mode());
+        }
+
+        @Test
+        @DisplayName("isStochastic should delegate to market levers")
+        void isStochasticShouldDelegateToMarketLevers() {
+            SimulationLevers deterministic = SimulationLevers.builder()
+                    .market(MarketLevers.deterministic(new BigDecimal("0.07")))
+                    .build();
+
+            SimulationLevers monteCarlo = SimulationLevers.builder()
+                    .market(MarketLevers.monteCarlo(
+                            new BigDecimal("0.07"),
+                            new BigDecimal("0.15")))
+                    .build();
+
+            assertFalse(deterministic.isStochastic());
+            assertTrue(monteCarlo.isStochastic());
+        }
+    }
+}

--- a/src/test/java/io/github/xmljim/retirement/simulation/config/SimulationModeTest.java
+++ b/src/test/java/io/github/xmljim/retirement/simulation/config/SimulationModeTest.java
@@ -1,0 +1,72 @@
+package io.github.xmljim.retirement.simulation.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+@DisplayName("SimulationMode")
+class SimulationModeTest {
+
+    @Nested
+    @DisplayName("Enum Values")
+    class EnumValues {
+
+        @Test
+        @DisplayName("should have exactly 3 modes")
+        void shouldHaveThreeModes() {
+            assertEquals(3, SimulationMode.values().length);
+        }
+
+        @ParameterizedTest
+        @EnumSource(SimulationMode.class)
+        @DisplayName("all modes should have display names")
+        void allModesShouldHaveDisplayNames(SimulationMode mode) {
+            assertNotNull(mode.getDisplayName());
+            assertFalse(mode.getDisplayName().isBlank());
+        }
+
+        @ParameterizedTest
+        @EnumSource(SimulationMode.class)
+        @DisplayName("all modes should have descriptions")
+        void allModesShouldHaveDescriptions(SimulationMode mode) {
+            assertNotNull(mode.getDescription());
+            assertFalse(mode.getDescription().isBlank());
+        }
+    }
+
+    @Nested
+    @DisplayName("Mode Properties")
+    class ModeProperties {
+
+        @Test
+        @DisplayName("DETERMINISTIC should be fixed")
+        void deterministicShouldBeFixed() {
+            assertTrue(SimulationMode.DETERMINISTIC.isFixed());
+            assertFalse(SimulationMode.DETERMINISTIC.isStochastic());
+            assertFalse(SimulationMode.DETERMINISTIC.usesHistoricalData());
+        }
+
+        @Test
+        @DisplayName("MONTE_CARLO should be stochastic")
+        void monteCarloShouldBeStochastic() {
+            assertFalse(SimulationMode.MONTE_CARLO.isFixed());
+            assertTrue(SimulationMode.MONTE_CARLO.isStochastic());
+            assertFalse(SimulationMode.MONTE_CARLO.usesHistoricalData());
+        }
+
+        @Test
+        @DisplayName("HISTORICAL should use historical data")
+        void historicalShouldUseHistoricalData() {
+            assertFalse(SimulationMode.HISTORICAL.isFixed());
+            assertFalse(SimulationMode.HISTORICAL.isStochastic());
+            assertTrue(SimulationMode.HISTORICAL.usesHistoricalData());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements configuration records that control simulation behavior (#271):

- **SimulationMode** enum: DETERMINISTIC, MONTE_CARLO, HISTORICAL with behavior methods
- **EconomicLevers** record: inflation (2.5%), wage growth (3%), interest rates (4%)
- **MarketLevers** record: return assumptions with factory methods for each mode
- **ExpenseLevers** record: category-specific inflation rates and expense modifiers
- **SimulationLevers** record: top-level aggregation of all levers

### Key Design Decisions

| Decision | Rationale |
|----------|-----------|
| Immutable records | Thread-safe configuration objects |
| Factory methods | Clean API for creating mode-specific configurations |
| Builder pattern | Flexible construction with sensible defaults |
| EnumMap for inflation | Type-safe mapping of InflationType to rates |
| Validation | Historical mode requires non-empty returns list |

### Files Added

- `simulation/config/SimulationMode.java` - Enum for simulation modes
- `simulation/config/EconomicLevers.java` - Economic assumptions
- `simulation/config/MarketLevers.java` - Market return configuration
- `simulation/config/ExpenseLevers.java` - Expense category configuration
- `simulation/config/SimulationLevers.java` - Top-level configuration
- Unit tests for all 5 classes (38 tests total)

## Test plan

- [x] All 38 new tests pass
- [x] Build succeeds with no Checkstyle errors
- [x] Records properly handle null inputs with defaults
- [x] Collections are immutable (defensive copies)
- [x] ValidationException thrown for invalid historical mode

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)