### PR TITLE
feat(#273): Create SimulationEngine skeleton with 7-step loop

### DIFF
--- a/src/main/java/io/github/xmljim/retirement/simulation/engine/SimulationConfig.java
+++ b/src/main/java/io/github/xmljim/retirement/simulation/engine/SimulationConfig.java
@@ -1,0 +1,239 @@
+package io.github.xmljim.retirement.simulation.engine;
+
+import java.time.YearMonth;
+import java.util.Collections;
+import java.util.List;
+
+import io.github.xmljim.retirement.domain.calculator.SpendingStrategy;
+import io.github.xmljim.retirement.domain.exception.MissingRequiredFieldException;
+import io.github.xmljim.retirement.domain.exception.ValidationException;
+import io.github.xmljim.retirement.domain.model.PersonProfile;
+import io.github.xmljim.retirement.domain.model.Portfolio;
+import io.github.xmljim.retirement.domain.value.Budget;
+import io.github.xmljim.retirement.simulation.config.SimulationLevers;
+
+/**
+ * Configuration for running a retirement simulation.
+ *
+ * <p>SimulationConfig contains all inputs required to run a simulation:
+ * <ul>
+ *   <li>Person profiles (one or two for couple simulations)</li>
+ *   <li>Portfolio with investment accounts</li>
+ *   <li>Budget defining income and expenses</li>
+ *   <li>Simulation levers controlling economic assumptions</li>
+ *   <li>Time period (start and end months)</li>
+ *   <li>Spending strategy for distribution phase</li>
+ * </ul>
+ *
+ * <p>Use the builder for construction:
+ * <pre>{@code
+ * SimulationConfig config = SimulationConfig.builder()
+ *     .persons(List.of(primaryPerson, spouse))
+ *     .portfolio(portfolio)
+ *     .budget(budget)
+ *     .levers(SimulationLevers.withDefaults())
+ *     .startMonth(YearMonth.of(2025, 1))
+ *     .endMonth(YearMonth.of(2055, 12))
+ *     .strategy(spendingStrategy)
+ *     .build();
+ * }</pre>
+ *
+ * @param persons    the person profiles (1 for single, 2 for couple)
+ * @param portfolio  the investment portfolio
+ * @param budget     the income and expense budget
+ * @param levers     the simulation levers (economic assumptions)
+ * @param startMonth the simulation start month
+ * @param endMonth   the simulation end month
+ * @param strategy   the spending strategy for withdrawals
+ */
+public record SimulationConfig(
+    List<PersonProfile> persons,
+    Portfolio portfolio,
+    Budget budget,
+    SimulationLevers levers,
+    YearMonth startMonth,
+    YearMonth endMonth,
+    SpendingStrategy strategy
+) {
+
+    /**
+     * Compact constructor with validation and defensive copying.
+     */
+    public SimulationConfig {
+        MissingRequiredFieldException.requireNonNull(persons, "persons");
+        MissingRequiredFieldException.requireNonNull(portfolio, "portfolio");
+        MissingRequiredFieldException.requireNonNull(startMonth, "startMonth");
+        MissingRequiredFieldException.requireNonNull(endMonth, "endMonth");
+
+        ValidationException.validate("persons", persons, p -> !p.isEmpty(),
+            "At least one person profile is required");
+
+        persons = Collections.unmodifiableList(persons);
+        levers = levers != null ? levers : SimulationLevers.withDefaults();
+    }
+
+    /**
+     * Returns the primary person (first in list).
+     *
+     * @return the primary person profile
+     */
+    public PersonProfile primaryPerson() {
+        return persons.get(0);
+    }
+
+    /**
+     * Returns the spouse (second person) if present.
+     *
+     * @return the spouse profile, or null if single simulation
+     */
+    public PersonProfile spouse() {
+        return persons.size() > 1 ? persons.get(1) : null;
+    }
+
+    /**
+     * Indicates whether this is a couple simulation.
+     *
+     * @return true if two persons are configured
+     */
+    public boolean isCoupleSimulation() {
+        return persons.size() > 1;
+    }
+
+    /**
+     * Calculates the total number of months in the simulation.
+     *
+     * @return the month count
+     */
+    public int monthCount() {
+        int years = endMonth.getYear() - startMonth.getYear();
+        int months = endMonth.getMonthValue() - startMonth.getMonthValue();
+        return years * 12 + months + 1;
+    }
+
+    /**
+     * Creates a new builder.
+     *
+     * @return a builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for SimulationConfig.
+     */
+    public static class Builder {
+        private List<PersonProfile> persons;
+        private Portfolio portfolio;
+        private Budget budget;
+        private SimulationLevers levers;
+        private YearMonth startMonth;
+        private YearMonth endMonth;
+        private SpendingStrategy strategy;
+
+        /**
+         * Sets the person profiles.
+         *
+         * @param persons the profiles (1 or 2)
+         * @return this builder
+         */
+        public Builder persons(List<PersonProfile> persons) {
+            this.persons = persons;
+            return this;
+        }
+
+        /**
+         * Sets a single person (convenience method).
+         *
+         * @param person the person profile
+         * @return this builder
+         */
+        public Builder person(PersonProfile person) {
+            this.persons = List.of(person);
+            return this;
+        }
+
+        /**
+         * Sets the portfolio.
+         *
+         * @param portfolio the investment portfolio
+         * @return this builder
+         */
+        public Builder portfolio(Portfolio portfolio) {
+            this.portfolio = portfolio;
+            return this;
+        }
+
+        /**
+         * Sets the budget.
+         *
+         * @param budget the income/expense budget
+         * @return this builder
+         */
+        public Builder budget(Budget budget) {
+            this.budget = budget;
+            return this;
+        }
+
+        /**
+         * Sets the simulation levers.
+         *
+         * @param levers the economic assumptions
+         * @return this builder
+         */
+        public Builder levers(SimulationLevers levers) {
+            this.levers = levers;
+            return this;
+        }
+
+        /**
+         * Sets the simulation start month.
+         *
+         * @param startMonth the start month
+         * @return this builder
+         */
+        public Builder startMonth(YearMonth startMonth) {
+            this.startMonth = startMonth;
+            return this;
+        }
+
+        /**
+         * Sets the simulation end month.
+         *
+         * @param endMonth the end month
+         * @return this builder
+         */
+        public Builder endMonth(YearMonth endMonth) {
+            this.endMonth = endMonth;
+            return this;
+        }
+
+        /**
+         * Sets the spending strategy.
+         *
+         * @param strategy the strategy for withdrawals
+         * @return this builder
+         */
+        public Builder strategy(SpendingStrategy strategy) {
+            this.strategy = strategy;
+            return this;
+        }
+
+        /**
+         * Builds the SimulationConfig.
+         *
+         * @return a new SimulationConfig
+         */
+        public SimulationConfig build() {
+            return new SimulationConfig(
+                persons,
+                portfolio,
+                budget,
+                levers,
+                startMonth,
+                endMonth,
+                strategy
+            );
+        }
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/simulation/engine/SimulationConfig.java
+++ b/src/main/java/io/github/xmljim/retirement/simulation/engine/SimulationConfig.java
@@ -4,6 +4,7 @@ import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import io.github.xmljim.retirement.domain.calculator.SpendingStrategy;
 import io.github.xmljim.retirement.domain.exception.MissingRequiredFieldException;
@@ -87,17 +88,19 @@ public record SimulationConfig(
      * @return the primary person profile
      */
     public PersonProfile primaryPerson() {
-        return portfolios.get(0).getOwner();
+        return portfolios.getFirst().getOwner();
     }
 
     /**
      * Returns the spouse (second distinct person) if present.
      *
-     * @return the spouse profile, or null if single simulation
+     * @return optional containing the spouse profile, or empty if single simulation
      */
-    public PersonProfile spouse() {
+    public Optional<PersonProfile> spouse() {
         List<PersonProfile> allPersons = persons();
-        return allPersons.size() > 1 ? allPersons.get(1) : null;
+        return allPersons.size() > 1
+            ? Optional.of(allPersons.getLast())
+            : Optional.empty();
     }
 
     /**
@@ -126,7 +129,7 @@ public record SimulationConfig(
      * @return the primary portfolio
      */
     public Portfolio primaryPortfolio() {
-        return portfolios.get(0);
+        return portfolios.getFirst();
     }
 
     /**

--- a/src/main/java/io/github/xmljim/retirement/simulation/engine/SimulationEngine.java
+++ b/src/main/java/io/github/xmljim/retirement/simulation/engine/SimulationEngine.java
@@ -1,0 +1,383 @@
+package io.github.xmljim.retirement.simulation.engine;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import io.github.xmljim.retirement.domain.calculator.ContributionRouter;
+import io.github.xmljim.retirement.domain.calculator.SpendingOrchestrator;
+import io.github.xmljim.retirement.domain.enums.SimulationPhase;
+import io.github.xmljim.retirement.domain.exception.MissingRequiredFieldException;
+import io.github.xmljim.retirement.domain.model.PersonProfile;
+import io.github.xmljim.retirement.simulation.result.AccountMonthlyFlow;
+import io.github.xmljim.retirement.simulation.result.MonthlySnapshot;
+import io.github.xmljim.retirement.simulation.result.TimeSeries;
+import io.github.xmljim.retirement.simulation.state.SimulationState;
+
+/**
+ * Core simulation engine that runs the retirement projection.
+ *
+ * <p>The SimulationEngine executes a month-by-month simulation from
+ * the start date through the end date. Each month follows a 7-step
+ * process:
+ * <ol>
+ *   <li><strong>Determine Phase</strong> - Identify simulation phase for each person</li>
+ *   <li><strong>Process Income</strong> - Calculate monthly income sources</li>
+ *   <li><strong>Process Events</strong> - Handle triggered events (retirement, death, etc.)</li>
+ *   <li><strong>Calculate Expenses</strong> - Compute monthly expenses</li>
+ *   <li><strong>Execute Financials</strong> - Process contributions or withdrawals</li>
+ *   <li><strong>Apply Returns</strong> - Apply monthly investment returns</li>
+ *   <li><strong>Record Snapshot</strong> - Capture month-end state</li>
+ * </ol>
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * SimulationEngine engine = SimulationEngine.builder()
+ *     .spendingOrchestrator(orchestrator)
+ *     .contributionRouter(router)
+ *     .build();
+ *
+ * TimeSeries<MonthlySnapshot> results = engine.run(config);
+ * }</pre>
+ *
+ * @see SimulationConfig
+ * @see MonthlySnapshot
+ * @see TimeSeries
+ */
+public class SimulationEngine {
+
+    private static final int SCALE = 6;
+    private static final MathContext MATH_CONTEXT = new MathContext(10, RoundingMode.HALF_UP);
+    private static final int MONTHS_PER_YEAR = 12;
+
+    private final SpendingOrchestrator spendingOrchestrator;
+    private final ContributionRouter contributionRouter;
+
+    private SimulationState state;
+
+    /**
+     * Creates a SimulationEngine with required components.
+     *
+     * @param spendingOrchestrator the orchestrator for withdrawal operations
+     * @param contributionRouter the router for contribution operations
+     */
+    public SimulationEngine(
+            SpendingOrchestrator spendingOrchestrator,
+            ContributionRouter contributionRouter) {
+        this.spendingOrchestrator = spendingOrchestrator;
+        this.contributionRouter = contributionRouter;
+    }
+
+    /**
+     * Runs the simulation with the given configuration.
+     *
+     * @param config the simulation configuration
+     * @return the time series of monthly snapshots
+     */
+    public TimeSeries<MonthlySnapshot> run(SimulationConfig config) {
+        MissingRequiredFieldException.requireNonNull(config, "config");
+
+        // Initialize state from portfolio accounts
+        this.state = new SimulationState(config.portfolio().getAccounts());
+
+        TimeSeries.Builder<MonthlySnapshot> builder = TimeSeries.builder();
+
+        // Generate list of months to simulate
+        List<YearMonth> months = generateMonths(config.startMonth(), config.endMonth());
+
+        for (YearMonth month : months) {
+            MonthlySnapshot snapshot = processMonth(month, config);
+            builder.add(snapshot);
+            state.recordHistory(snapshot);
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Processes a single month of the simulation.
+     *
+     * <p>Executes the 7-step monthly loop.
+     *
+     * @param month the month to process
+     * @param config the simulation configuration
+     * @return the monthly snapshot
+     */
+    private MonthlySnapshot processMonth(YearMonth month, SimulationConfig config) {
+        // Step 1: Determine phase
+        SimulationPhase phase = determinePhase(config.primaryPerson(), month);
+
+        // Step 2: Process income
+        BigDecimal income = processIncome(month, phase, config);
+
+        // Step 3: Process events
+        List<String> triggeredEvents = processEvents(month, config);
+
+        // Step 4: Calculate expenses
+        BigDecimal expenses = calculateExpenses(month, phase, config);
+
+        // Step 5: Execute contributions OR withdrawals
+        Map<UUID, AccountMonthlyFlow> flows = executeFinancials(
+            phase, income, expenses, month, config);
+
+        // Step 6: Apply monthly returns
+        BigDecimal returnRate = calculateMonthlyReturn(config);
+        applyMonthlyReturns(flows, returnRate);
+
+        // Step 7: Record snapshot
+        return buildSnapshot(month, flows, income, expenses, phase, triggeredEvents);
+    }
+
+    // ─── Step 1: Phase Determination ────────────────────────────────────────────
+
+    /**
+     * Determines the simulation phase for a person at the given month.
+     *
+     * @param person the person profile
+     * @param month the current month
+     * @return the simulation phase
+     */
+    SimulationPhase determinePhase(PersonProfile person, YearMonth month) {
+        LocalDate monthStart = month.atDay(1);
+
+        // Check survivor mode first
+        if (state.isSurvivorMode()) {
+            return SimulationPhase.SURVIVOR;
+        }
+
+        // Check if before retirement
+        if (monthStart.isBefore(person.getRetirementDate())) {
+            return SimulationPhase.ACCUMULATION;
+        }
+
+        // In distribution phase (after retirement)
+        return SimulationPhase.DISTRIBUTION;
+    }
+
+    // ─── Step 2: Process Income ─────────────────────────────────────────────────
+
+    /**
+     * Processes income for the month.
+     *
+     * <p>Stub implementation - to be enhanced in later milestones.
+     *
+     * @param month the current month
+     * @param phase the simulation phase
+     * @param config the configuration
+     * @return the total monthly income
+     */
+    BigDecimal processIncome(YearMonth month, SimulationPhase phase, SimulationConfig config) {
+        // Stub: Return zero for now
+        // Will be implemented to handle salary, Social Security, pensions, etc.
+        return BigDecimal.ZERO;
+    }
+
+    // ─── Step 3: Process Events ─────────────────────────────────────────────────
+
+    /**
+     * Processes events triggered in the month.
+     *
+     * <p>Stub implementation - to be enhanced in later milestones.
+     *
+     * @param month the current month
+     * @param config the configuration
+     * @return list of triggered event names
+     */
+    List<String> processEvents(YearMonth month, SimulationConfig config) {
+        // Stub: Return empty list for now
+        // Will be implemented to handle retirement events, death events, etc.
+        return Collections.emptyList();
+    }
+
+    // ─── Step 4: Calculate Expenses ─────────────────────────────────────────────
+
+    /**
+     * Calculates expenses for the month.
+     *
+     * <p>Stub implementation - to be enhanced in later milestones.
+     *
+     * @param month the current month
+     * @param phase the simulation phase
+     * @param config the configuration
+     * @return the total monthly expenses
+     */
+    BigDecimal calculateExpenses(YearMonth month, SimulationPhase phase, SimulationConfig config) {
+        // Stub: Return zero for now
+        // Will be implemented to calculate category-based expenses with inflation
+        return BigDecimal.ZERO;
+    }
+
+    // ─── Step 5: Execute Financials ─────────────────────────────────────────────
+
+    /**
+     * Executes financial operations for the month.
+     *
+     * <p>During accumulation: process contributions.
+     * <p>During distribution/survivor: process withdrawals.
+     *
+     * <p>Stub implementation - to be enhanced in later milestones.
+     *
+     * @param phase the simulation phase
+     * @param income the monthly income
+     * @param expenses the monthly expenses
+     * @param month the current month
+     * @param config the configuration
+     * @return map of account flows
+     */
+    Map<UUID, AccountMonthlyFlow> executeFinancials(
+            SimulationPhase phase,
+            BigDecimal income,
+            BigDecimal expenses,
+            YearMonth month,
+            SimulationConfig config) {
+        // Stub: Return empty map for now
+        // Will be implemented to route contributions or execute withdrawals
+        return Collections.emptyMap();
+    }
+
+    // ─── Step 6: Apply Returns ──────────────────────────────────────────────────
+
+    /**
+     * Calculates the monthly return rate from the annual rate.
+     *
+     * <p>Uses monthly compounding: (1 + annual)^(1/12) - 1
+     *
+     * @param config the configuration containing levers
+     * @return the monthly return rate
+     */
+    BigDecimal calculateMonthlyReturn(SimulationConfig config) {
+        BigDecimal annualReturn = config.levers().market().expectedReturn();
+
+        // Monthly multiplier = (1 + annual)^(1/12)
+        double annualDouble = annualReturn.doubleValue();
+        double monthlyMultiplier = Math.pow(1.0 + annualDouble, 1.0 / MONTHS_PER_YEAR);
+        double monthlyRate = monthlyMultiplier - 1.0;
+
+        return BigDecimal.valueOf(monthlyRate).setScale(SCALE, RoundingMode.HALF_UP);
+    }
+
+    /**
+     * Applies monthly returns to all accounts.
+     *
+     * @param flows the account flows for the month (to be updated with returns)
+     * @param monthlyRate the monthly return rate
+     */
+    void applyMonthlyReturns(Map<UUID, AccountMonthlyFlow> flows, BigDecimal monthlyRate) {
+        // Apply returns to all accounts in state
+        state.applyReturns(monthlyRate);
+    }
+
+    // ─── Step 7: Build Snapshot ─────────────────────────────────────────────────
+
+    /**
+     * Builds the monthly snapshot from processed data.
+     *
+     * @param month the month
+     * @param flows the account flows
+     * @param income the monthly income
+     * @param expenses the monthly expenses
+     * @param phase the simulation phase
+     * @param triggeredEvents list of triggered event names
+     * @return the monthly snapshot
+     */
+    MonthlySnapshot buildSnapshot(
+            YearMonth month,
+            Map<UUID, AccountMonthlyFlow> flows,
+            BigDecimal income,
+            BigDecimal expenses,
+            SimulationPhase phase,
+            List<String> triggeredEvents) {
+
+        return MonthlySnapshot.builder(month)
+            .accountFlows(flows)
+            .phase(phase)
+            .build();
+    }
+
+    // ─── Utility Methods ────────────────────────────────────────────────────────
+
+    /**
+     * Generates a list of months from start to end (inclusive).
+     *
+     * @param start the start month
+     * @param end the end month
+     * @return list of months
+     */
+    List<YearMonth> generateMonths(YearMonth start, YearMonth end) {
+        List<YearMonth> months = new ArrayList<>();
+        YearMonth current = start;
+
+        while (!current.isAfter(end)) {
+            months.add(current);
+            current = current.plusMonths(1);
+        }
+
+        return months;
+    }
+
+    /**
+     * Returns the current simulation state.
+     *
+     * <p>Primarily for testing purposes.
+     *
+     * @return the state, or null if no simulation has been run
+     */
+    SimulationState getState() {
+        return state;
+    }
+
+    /**
+     * Creates a new builder for SimulationEngine.
+     *
+     * @return a builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for SimulationEngine.
+     */
+    public static class Builder {
+        private SpendingOrchestrator spendingOrchestrator;
+        private ContributionRouter contributionRouter;
+
+        /**
+         * Sets the spending orchestrator.
+         *
+         * @param orchestrator the orchestrator
+         * @return this builder
+         */
+        public Builder spendingOrchestrator(SpendingOrchestrator orchestrator) {
+            this.spendingOrchestrator = orchestrator;
+            return this;
+        }
+
+        /**
+         * Sets the contribution router.
+         *
+         * @param router the router
+         * @return this builder
+         */
+        public Builder contributionRouter(ContributionRouter router) {
+            this.contributionRouter = router;
+            return this;
+        }
+
+        /**
+         * Builds the SimulationEngine.
+         *
+         * @return a new SimulationEngine
+         */
+        public SimulationEngine build() {
+            return new SimulationEngine(spendingOrchestrator, contributionRouter);
+        }
+    }
+}

--- a/src/main/java/io/github/xmljim/retirement/simulation/engine/SimulationEngine.java
+++ b/src/main/java/io/github/xmljim/retirement/simulation/engine/SimulationEngine.java
@@ -84,8 +84,8 @@ public class SimulationEngine {
     public TimeSeries<MonthlySnapshot> run(SimulationConfig config) {
         MissingRequiredFieldException.requireNonNull(config, "config");
 
-        // Initialize state from portfolio accounts
-        this.state = new SimulationState(config.portfolio().getAccounts());
+        // Initialize state from all portfolio accounts
+        this.state = new SimulationState(config.getAllAccounts());
 
         TimeSeries.Builder<MonthlySnapshot> builder = TimeSeries.builder();
 

--- a/src/test/java/io/github/xmljim/retirement/simulation/engine/SimulationConfigTest.java
+++ b/src/test/java/io/github/xmljim/retirement/simulation/engine/SimulationConfigTest.java
@@ -83,8 +83,7 @@ class SimulationConfigTest {
 
             assertEquals(2, config.persons().size());
             assertEquals(primaryPerson, config.primaryPerson());
-            assertTrue(config.spouse().isPresent());
-            assertEquals(spouse, config.spouse().get());
+            assertEquals(spouse, config.spouse().orElseThrow());
         }
 
         @Test
@@ -183,8 +182,7 @@ class SimulationConfigTest {
 
             assertTrue(config.isCoupleSimulation());
             assertEquals(primaryPerson, config.primaryPerson());
-            assertTrue(config.spouse().isPresent());
-            assertEquals(spouse, config.spouse().get());
+            assertEquals(spouse, config.spouse().orElseThrow());
         }
 
         @Test

--- a/src/test/java/io/github/xmljim/retirement/simulation/engine/SimulationConfigTest.java
+++ b/src/test/java/io/github/xmljim/retirement/simulation/engine/SimulationConfigTest.java
@@ -142,12 +142,24 @@ class SimulationConfigTest {
         }
 
         @Test
-        @DisplayName("should reject null portfolio")
-        void shouldRejectNullPortfolio() {
+        @DisplayName("should reject null portfolios")
+        void shouldRejectNullPortfolios() {
             assertThrows(MissingRequiredFieldException.class, () ->
                 SimulationConfig.builder()
                     .person(primaryPerson)
-                    .portfolio(null)
+                    .portfolios(null)
+                    .startMonth(YearMonth.of(2025, 1))
+                    .endMonth(YearMonth.of(2055, 12))
+                    .build());
+        }
+
+        @Test
+        @DisplayName("should reject empty portfolios list")
+        void shouldRejectEmptyPortfolios() {
+            assertThrows(ValidationException.class, () ->
+                SimulationConfig.builder()
+                    .person(primaryPerson)
+                    .portfolios(List.of())
                     .startMonth(YearMonth.of(2025, 1))
                     .endMonth(YearMonth.of(2055, 12))
                     .build());

--- a/src/test/java/io/github/xmljim/retirement/simulation/engine/SimulationConfigTest.java
+++ b/src/test/java/io/github/xmljim/retirement/simulation/engine/SimulationConfigTest.java
@@ -3,7 +3,6 @@ package io.github.xmljim.retirement.simulation.engine;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -84,7 +83,8 @@ class SimulationConfigTest {
 
             assertEquals(2, config.persons().size());
             assertEquals(primaryPerson, config.primaryPerson());
-            assertEquals(spouse, config.spouse());
+            assertTrue(config.spouse().isPresent());
+            assertEquals(spouse, config.spouse().get());
         }
 
         @Test
@@ -183,7 +183,8 @@ class SimulationConfigTest {
 
             assertTrue(config.isCoupleSimulation());
             assertEquals(primaryPerson, config.primaryPerson());
-            assertEquals(spouse, config.spouse());
+            assertTrue(config.spouse().isPresent());
+            assertEquals(spouse, config.spouse().get());
         }
 
         @Test
@@ -197,7 +198,7 @@ class SimulationConfigTest {
 
             assertFalse(config.isCoupleSimulation());
             assertEquals(primaryPerson, config.primaryPerson());
-            assertNull(config.spouse());
+            assertTrue(config.spouse().isEmpty());
         }
 
         @Test
@@ -216,7 +217,7 @@ class SimulationConfigTest {
             assertFalse(config.isCoupleSimulation());
             assertEquals(1, config.persons().size());
             assertEquals(primaryPerson, config.primaryPerson());
-            assertNull(config.spouse());
+            assertTrue(config.spouse().isEmpty());
         }
     }
 

--- a/src/test/java/io/github/xmljim/retirement/simulation/engine/SimulationConfigTest.java
+++ b/src/test/java/io/github/xmljim/retirement/simulation/engine/SimulationConfigTest.java
@@ -1,0 +1,279 @@
+package io.github.xmljim.retirement.simulation.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.github.xmljim.retirement.domain.exception.MissingRequiredFieldException;
+import io.github.xmljim.retirement.domain.exception.ValidationException;
+import io.github.xmljim.retirement.domain.model.PersonProfile;
+import io.github.xmljim.retirement.domain.model.Portfolio;
+import io.github.xmljim.retirement.simulation.config.SimulationLevers;
+
+@DisplayName("SimulationConfig")
+class SimulationConfigTest {
+
+    private PersonProfile primaryPerson;
+    private PersonProfile spouse;
+    private Portfolio portfolio;
+
+    @BeforeEach
+    void setUp() {
+        primaryPerson = PersonProfile.builder()
+            .name("John Doe")
+            .dateOfBirth(LocalDate.of(1970, 1, 1))
+            .retirementDate(LocalDate.of(2035, 1, 1))
+            .lifeExpectancy(90)
+            .build();
+
+        spouse = PersonProfile.builder()
+            .name("Jane Doe")
+            .dateOfBirth(LocalDate.of(1972, 6, 15))
+            .retirementDate(LocalDate.of(2037, 6, 1))
+            .lifeExpectancy(92)
+            .build();
+
+        portfolio = Portfolio.builder()
+            .owner(primaryPerson)
+            .build();
+    }
+
+    @Nested
+    @DisplayName("Builder")
+    class BuilderTests {
+
+        @Test
+        @DisplayName("should build with all required fields")
+        void shouldBuildWithRequiredFields() {
+            SimulationConfig config = SimulationConfig.builder()
+                .persons(List.of(primaryPerson))
+                .portfolio(portfolio)
+                .startMonth(YearMonth.of(2025, 1))
+                .endMonth(YearMonth.of(2055, 12))
+                .build();
+
+            assertNotNull(config);
+            assertEquals(1, config.persons().size());
+            assertNotNull(config.levers()); // Should default
+        }
+
+        @Test
+        @DisplayName("should build with single person convenience method")
+        void shouldBuildWithSinglePerson() {
+            SimulationConfig config = SimulationConfig.builder()
+                .person(primaryPerson)
+                .portfolio(portfolio)
+                .startMonth(YearMonth.of(2025, 1))
+                .endMonth(YearMonth.of(2055, 12))
+                .build();
+
+            assertEquals(1, config.persons().size());
+            assertEquals(primaryPerson, config.primaryPerson());
+        }
+
+        @Test
+        @DisplayName("should default levers when not provided")
+        void shouldDefaultLevers() {
+            SimulationConfig config = SimulationConfig.builder()
+                .person(primaryPerson)
+                .portfolio(portfolio)
+                .startMonth(YearMonth.of(2025, 1))
+                .endMonth(YearMonth.of(2055, 12))
+                .build();
+
+            assertNotNull(config.levers());
+        }
+
+        @Test
+        @DisplayName("should use custom levers when provided")
+        void shouldUseCustomLevers() {
+            SimulationLevers customLevers = SimulationLevers.withDefaults();
+
+            SimulationConfig config = SimulationConfig.builder()
+                .person(primaryPerson)
+                .portfolio(portfolio)
+                .levers(customLevers)
+                .startMonth(YearMonth.of(2025, 1))
+                .endMonth(YearMonth.of(2055, 12))
+                .build();
+
+            assertEquals(customLevers, config.levers());
+        }
+    }
+
+    @Nested
+    @DisplayName("Validation")
+    class Validation {
+
+        @Test
+        @DisplayName("should reject null persons")
+        void shouldRejectNullPersons() {
+            assertThrows(MissingRequiredFieldException.class, () ->
+                SimulationConfig.builder()
+                    .persons(null)
+                    .portfolio(portfolio)
+                    .startMonth(YearMonth.of(2025, 1))
+                    .endMonth(YearMonth.of(2055, 12))
+                    .build());
+        }
+
+        @Test
+        @DisplayName("should reject empty persons list")
+        void shouldRejectEmptyPersons() {
+            assertThrows(ValidationException.class, () ->
+                SimulationConfig.builder()
+                    .persons(List.of())
+                    .portfolio(portfolio)
+                    .startMonth(YearMonth.of(2025, 1))
+                    .endMonth(YearMonth.of(2055, 12))
+                    .build());
+        }
+
+        @Test
+        @DisplayName("should reject null portfolio")
+        void shouldRejectNullPortfolio() {
+            assertThrows(MissingRequiredFieldException.class, () ->
+                SimulationConfig.builder()
+                    .person(primaryPerson)
+                    .portfolio(null)
+                    .startMonth(YearMonth.of(2025, 1))
+                    .endMonth(YearMonth.of(2055, 12))
+                    .build());
+        }
+
+        @Test
+        @DisplayName("should reject null startMonth")
+        void shouldRejectNullStartMonth() {
+            assertThrows(MissingRequiredFieldException.class, () ->
+                SimulationConfig.builder()
+                    .person(primaryPerson)
+                    .portfolio(portfolio)
+                    .startMonth(null)
+                    .endMonth(YearMonth.of(2055, 12))
+                    .build());
+        }
+
+        @Test
+        @DisplayName("should reject null endMonth")
+        void shouldRejectNullEndMonth() {
+            assertThrows(MissingRequiredFieldException.class, () ->
+                SimulationConfig.builder()
+                    .person(primaryPerson)
+                    .portfolio(portfolio)
+                    .startMonth(YearMonth.of(2025, 1))
+                    .endMonth(null)
+                    .build());
+        }
+    }
+
+    @Nested
+    @DisplayName("Couple Simulation")
+    class CoupleSimulation {
+
+        @Test
+        @DisplayName("should identify couple simulation")
+        void shouldIdentifyCoupleSimulation() {
+            SimulationConfig config = SimulationConfig.builder()
+                .persons(List.of(primaryPerson, spouse))
+                .portfolio(portfolio)
+                .startMonth(YearMonth.of(2025, 1))
+                .endMonth(YearMonth.of(2055, 12))
+                .build();
+
+            assertTrue(config.isCoupleSimulation());
+            assertEquals(primaryPerson, config.primaryPerson());
+            assertEquals(spouse, config.spouse());
+        }
+
+        @Test
+        @DisplayName("should identify single simulation")
+        void shouldIdentifySingleSimulation() {
+            SimulationConfig config = SimulationConfig.builder()
+                .person(primaryPerson)
+                .portfolio(portfolio)
+                .startMonth(YearMonth.of(2025, 1))
+                .endMonth(YearMonth.of(2055, 12))
+                .build();
+
+            assertFalse(config.isCoupleSimulation());
+            assertEquals(primaryPerson, config.primaryPerson());
+            assertNull(config.spouse());
+        }
+    }
+
+    @Nested
+    @DisplayName("Month Calculation")
+    class MonthCalculation {
+
+        @Test
+        @DisplayName("should calculate month count for full years")
+        void shouldCalculateMonthCountForFullYears() {
+            SimulationConfig config = SimulationConfig.builder()
+                .person(primaryPerson)
+                .portfolio(portfolio)
+                .startMonth(YearMonth.of(2025, 1))
+                .endMonth(YearMonth.of(2025, 12))
+                .build();
+
+            assertEquals(12, config.monthCount());
+        }
+
+        @Test
+        @DisplayName("should calculate month count spanning years")
+        void shouldCalculateMonthCountSpanningYears() {
+            SimulationConfig config = SimulationConfig.builder()
+                .person(primaryPerson)
+                .portfolio(portfolio)
+                .startMonth(YearMonth.of(2025, 1))
+                .endMonth(YearMonth.of(2055, 12))
+                .build();
+
+            // 31 years = 372 months
+            assertEquals(372, config.monthCount());
+        }
+
+        @Test
+        @DisplayName("should calculate month count for single month")
+        void shouldCalculateMonthCountForSingleMonth() {
+            SimulationConfig config = SimulationConfig.builder()
+                .person(primaryPerson)
+                .portfolio(portfolio)
+                .startMonth(YearMonth.of(2025, 6))
+                .endMonth(YearMonth.of(2025, 6))
+                .build();
+
+            assertEquals(1, config.monthCount());
+        }
+    }
+
+    @Nested
+    @DisplayName("Immutability")
+    class Immutability {
+
+        @Test
+        @DisplayName("persons list should be unmodifiable")
+        void personsListShouldBeUnmodifiable() {
+            SimulationConfig config = SimulationConfig.builder()
+                .persons(List.of(primaryPerson))
+                .portfolio(portfolio)
+                .startMonth(YearMonth.of(2025, 1))
+                .endMonth(YearMonth.of(2055, 12))
+                .build();
+
+            assertThrows(UnsupportedOperationException.class, () ->
+                config.persons().add(spouse));
+        }
+    }
+}

--- a/src/test/java/io/github/xmljim/retirement/simulation/engine/SimulationEngineTest.java
+++ b/src/test/java/io/github/xmljim/retirement/simulation/engine/SimulationEngineTest.java
@@ -102,7 +102,6 @@ class SimulationEngineTest {
         @DisplayName("should calculate monthly return from 7% annual")
         void shouldCalculateMonthlyReturnFromSevenPercent() {
             SimulationConfig config = SimulationConfig.builder()
-                .person(person)
                 .portfolio(portfolio)
                 .levers(SimulationLevers.builder()
                     .market(MarketLevers.deterministic(new BigDecimal("0.07")))
@@ -122,7 +121,6 @@ class SimulationEngineTest {
         @DisplayName("should calculate zero return for zero annual rate")
         void shouldCalculateZeroReturnForZeroRate() {
             SimulationConfig config = SimulationConfig.builder()
-                .person(person)
                 .portfolio(portfolio)
                 .levers(SimulationLevers.builder()
                     .market(MarketLevers.deterministic(BigDecimal.ZERO))
@@ -261,7 +259,6 @@ class SimulationEngineTest {
 
     private SimulationConfig createConfig(YearMonth start, YearMonth end) {
         return SimulationConfig.builder()
-            .person(person)
             .portfolio(portfolio)
             .startMonth(start)
             .endMonth(end)

--- a/src/test/java/io/github/xmljim/retirement/simulation/engine/SimulationEngineTest.java
+++ b/src/test/java/io/github/xmljim/retirement/simulation/engine/SimulationEngineTest.java
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import io.github.xmljim.retirement.domain.calculator.ReturnCalculator;
+import io.github.xmljim.retirement.domain.calculator.impl.DefaultReturnCalculator;
 import io.github.xmljim.retirement.domain.enums.SimulationPhase;
 import io.github.xmljim.retirement.domain.exception.MissingRequiredFieldException;
 import io.github.xmljim.retirement.domain.model.PersonProfile;
@@ -30,10 +32,14 @@ class SimulationEngineTest {
     private SimulationEngine engine;
     private PersonProfile person;
     private Portfolio portfolio;
+    private ReturnCalculator returnCalculator;
 
     @BeforeEach
     void setUp() {
-        engine = SimulationEngine.builder().build();
+        returnCalculator = new DefaultReturnCalculator();
+        engine = SimulationEngine.builder()
+            .returnCalculator(returnCalculator)
+            .build();
 
         person = PersonProfile.builder()
             .name("Test Person")

--- a/src/test/java/io/github/xmljim/retirement/simulation/engine/SimulationEngineTest.java
+++ b/src/test/java/io/github/xmljim/retirement/simulation/engine/SimulationEngineTest.java
@@ -1,0 +1,270 @@
+package io.github.xmljim.retirement.simulation.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.github.xmljim.retirement.domain.enums.SimulationPhase;
+import io.github.xmljim.retirement.domain.exception.MissingRequiredFieldException;
+import io.github.xmljim.retirement.domain.model.PersonProfile;
+import io.github.xmljim.retirement.domain.model.Portfolio;
+import io.github.xmljim.retirement.simulation.config.MarketLevers;
+import io.github.xmljim.retirement.simulation.config.SimulationLevers;
+import io.github.xmljim.retirement.simulation.result.MonthlySnapshot;
+import io.github.xmljim.retirement.simulation.result.TimeSeries;
+
+@DisplayName("SimulationEngine")
+class SimulationEngineTest {
+
+    private SimulationEngine engine;
+    private PersonProfile person;
+    private Portfolio portfolio;
+
+    @BeforeEach
+    void setUp() {
+        engine = SimulationEngine.builder().build();
+
+        person = PersonProfile.builder()
+            .name("Test Person")
+            .dateOfBirth(LocalDate.of(1970, 1, 1))
+            .retirementDate(LocalDate.of(2035, 1, 1))
+            .lifeExpectancy(90)
+            .build();
+
+        portfolio = Portfolio.builder()
+            .owner(person)
+            .build();
+    }
+
+    @Nested
+    @DisplayName("Phase Determination")
+    class PhaseDetermination {
+
+        @Test
+        @DisplayName("should return ACCUMULATION before retirement date")
+        void shouldReturnAccumulationBeforeRetirement() {
+            SimulationConfig config = createConfig(
+                YearMonth.of(2025, 1),
+                YearMonth.of(2025, 12));
+
+            engine.run(config);
+
+            // Person retires 2035, so 2025 is accumulation
+            SimulationPhase phase = engine.determinePhase(person, YearMonth.of(2025, 6));
+            assertEquals(SimulationPhase.ACCUMULATION, phase);
+        }
+
+        @Test
+        @DisplayName("should return DISTRIBUTION after retirement date")
+        void shouldReturnDistributionAfterRetirement() {
+            SimulationConfig config = createConfig(
+                YearMonth.of(2025, 1),
+                YearMonth.of(2025, 12));
+
+            engine.run(config);
+
+            // Person retires 2035, so 2040 is distribution
+            SimulationPhase phase = engine.determinePhase(person, YearMonth.of(2040, 6));
+            assertEquals(SimulationPhase.DISTRIBUTION, phase);
+        }
+
+        @Test
+        @DisplayName("should return DISTRIBUTION on retirement month")
+        void shouldReturnDistributionOnRetirementMonth() {
+            SimulationConfig config = createConfig(
+                YearMonth.of(2025, 1),
+                YearMonth.of(2025, 12));
+
+            engine.run(config);
+
+            // Person retires 2035-01-01
+            SimulationPhase phase = engine.determinePhase(person, YearMonth.of(2035, 1));
+            assertEquals(SimulationPhase.DISTRIBUTION, phase);
+        }
+    }
+
+    @Nested
+    @DisplayName("Monthly Return Calculation")
+    class MonthlyReturnCalculation {
+
+        @Test
+        @DisplayName("should calculate monthly return from 7% annual")
+        void shouldCalculateMonthlyReturnFromSevenPercent() {
+            SimulationConfig config = SimulationConfig.builder()
+                .person(person)
+                .portfolio(portfolio)
+                .levers(SimulationLevers.builder()
+                    .market(MarketLevers.deterministic(new BigDecimal("0.07")))
+                    .build())
+                .startMonth(YearMonth.of(2025, 1))
+                .endMonth(YearMonth.of(2025, 12))
+                .build();
+
+            BigDecimal monthlyRate = engine.calculateMonthlyReturn(config);
+
+            // (1.07)^(1/12) - 1 ≈ 0.005654
+            assertTrue(monthlyRate.compareTo(new BigDecimal("0.005")) > 0);
+            assertTrue(monthlyRate.compareTo(new BigDecimal("0.006")) < 0);
+        }
+
+        @Test
+        @DisplayName("should calculate zero return for zero annual rate")
+        void shouldCalculateZeroReturnForZeroRate() {
+            SimulationConfig config = SimulationConfig.builder()
+                .person(person)
+                .portfolio(portfolio)
+                .levers(SimulationLevers.builder()
+                    .market(MarketLevers.deterministic(BigDecimal.ZERO))
+                    .build())
+                .startMonth(YearMonth.of(2025, 1))
+                .endMonth(YearMonth.of(2025, 12))
+                .build();
+
+            BigDecimal monthlyRate = engine.calculateMonthlyReturn(config);
+
+            assertEquals(0, BigDecimal.ZERO.compareTo(monthlyRate));
+        }
+    }
+
+    @Nested
+    @DisplayName("Month Generation")
+    class MonthGeneration {
+
+        @Test
+        @DisplayName("should generate correct number of months")
+        void shouldGenerateCorrectNumberOfMonths() {
+            List<YearMonth> months = engine.generateMonths(
+                YearMonth.of(2025, 1),
+                YearMonth.of(2025, 12));
+
+            assertEquals(12, months.size());
+            assertEquals(YearMonth.of(2025, 1), months.get(0));
+            assertEquals(YearMonth.of(2025, 12), months.get(11));
+        }
+
+        @Test
+        @DisplayName("should generate single month")
+        void shouldGenerateSingleMonth() {
+            List<YearMonth> months = engine.generateMonths(
+                YearMonth.of(2025, 6),
+                YearMonth.of(2025, 6));
+
+            assertEquals(1, months.size());
+            assertEquals(YearMonth.of(2025, 6), months.get(0));
+        }
+
+        @Test
+        @DisplayName("should generate months spanning years")
+        void shouldGenerateMonthsSpanningYears() {
+            List<YearMonth> months = engine.generateMonths(
+                YearMonth.of(2024, 11),
+                YearMonth.of(2025, 2));
+
+            assertEquals(4, months.size());
+            assertEquals(YearMonth.of(2024, 11), months.get(0));
+            assertEquals(YearMonth.of(2024, 12), months.get(1));
+            assertEquals(YearMonth.of(2025, 1), months.get(2));
+            assertEquals(YearMonth.of(2025, 2), months.get(3));
+        }
+    }
+
+    @Nested
+    @DisplayName("Simulation Run")
+    class SimulationRun {
+
+        @Test
+        @DisplayName("should run empty simulation with no accounts")
+        void shouldRunEmptySimulation() {
+            SimulationConfig config = createConfig(
+                YearMonth.of(2025, 1),
+                YearMonth.of(2025, 12));
+
+            TimeSeries<MonthlySnapshot> results = engine.run(config);
+
+            assertNotNull(results);
+            assertEquals(12, results.size());
+        }
+
+        @Test
+        @DisplayName("should iterate correct number of months")
+        void shouldIterateCorrectMonths() {
+            SimulationConfig config = createConfig(
+                YearMonth.of(2025, 1),
+                YearMonth.of(2027, 12));
+
+            TimeSeries<MonthlySnapshot> results = engine.run(config);
+
+            // 3 years = 36 months
+            assertEquals(36, results.size());
+        }
+
+        @Test
+        @DisplayName("should create state on run")
+        void shouldCreateStateOnRun() {
+            SimulationConfig config = createConfig(
+                YearMonth.of(2025, 1),
+                YearMonth.of(2025, 12));
+
+            engine.run(config);
+
+            assertNotNull(engine.getState());
+        }
+
+        @Test
+        @DisplayName("should reject null config")
+        void shouldRejectNullConfig() {
+            assertThrows(MissingRequiredFieldException.class, () ->
+                engine.run(null));
+        }
+
+        @Test
+        @DisplayName("should record snapshots with correct phases")
+        void shouldRecordSnapshotsWithCorrectPhases() {
+            // Person retires 2035, test months in 2034 (accumulation)
+            SimulationConfig config = createConfig(
+                YearMonth.of(2034, 1),
+                YearMonth.of(2034, 6));
+
+            TimeSeries<MonthlySnapshot> results = engine.run(config);
+
+            // All months should be ACCUMULATION
+            results.stream().forEach(snapshot ->
+                assertEquals(SimulationPhase.ACCUMULATION, snapshot.phase()));
+        }
+    }
+
+    @Nested
+    @DisplayName("Builder")
+    class BuilderTests {
+
+        @Test
+        @DisplayName("should build without components")
+        void shouldBuildWithoutComponents() {
+            SimulationEngine built = SimulationEngine.builder().build();
+
+            assertNotNull(built);
+        }
+    }
+
+    // ─── Helper Methods ─────────────────────────────────────────────────────────
+
+    private SimulationConfig createConfig(YearMonth start, YearMonth end) {
+        return SimulationConfig.builder()
+            .person(person)
+            .portfolio(portfolio)
+            .startMonth(start)
+            .endMonth(end)
+            .build();
+    }
+}


### PR DESCRIPTION
## Summary
- Implements `SimulationConfig` record with builder for simulation configuration
- Implements `SimulationEngine` with 7-step monthly processing loop (stubs for most steps)
- Implements phase determination logic (ACCUMULATION/DISTRIBUTION/SURVIVOR)
- Implements monthly return calculation from annual rate
- Supports single and couple simulations with multiple portfolios

## Changes
- `SimulationConfig`: Configuration record containing persons, portfolios, budget, levers, time period, and spending strategy
- `SimulationEngine`: Core engine with injectable SpendingOrchestrator and ContributionRouter
- 7-step monthly loop: determine phase → process income → process events → calculate expenses → execute financials → apply returns → record snapshot
- Helper methods: `generateMonths()`, `calculateMonthlyReturn()`, `determinePhase()`

## Design Decisions
- Changed from single `Portfolio` to `List<Portfolio>` to support multi-portfolio simulations (e.g., couple scenarios)
- Added `getAllAccounts()` method to aggregate accounts across all portfolios
- Defensive copies in builder methods to prevent external mutation (SpotBugs compliance)

## Test Plan
- [x] SimulationConfig builder creates valid configurations
- [x] Validation rejects null/empty required fields
- [x] Couple vs single simulation detection works correctly
- [x] Month count calculation is accurate
- [x] Phase determination handles pre-retirement, post-retirement, and retirement month
- [x] Monthly return calculation converts annual rate correctly
- [x] Month generation produces correct sequences
- [x] Simulation run produces correct number of snapshots
- [x] All 30 tests pass
- [x] Checkstyle and SpotBugs pass

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)