### PR TITLE
feat(#275): Integrate ContributionRouter for accumulation phase

### DIFF
--- a/src/main/java/io/github/xmljim/retirement/simulation/config/PersonFinancialConfig.java
+++ b/src/main/java/io/github/xmljim/retirement/simulation/config/PersonFinancialConfig.java
@@ -1,0 +1,125 @@
+package io.github.xmljim.retirement.simulation.config;
+
+import io.github.xmljim.retirement.domain.value.ContributionConfig;
+import io.github.xmljim.retirement.domain.value.RoutingConfiguration;
+
+/**
+ * Bundles per-person financial configuration for the simulation.
+ *
+ * <p>Each person in the simulation can have their own contribution
+ * and routing settings. This record groups those settings together.
+ *
+ * <p>Example usage:
+ * <pre>{@code
+ * PersonFinancialConfig config = PersonFinancialConfig.builder()
+ *     .contributionConfig(ContributionConfig.builder()
+ *         .contributionType(ContributionType.PERSONAL)
+ *         .contributionRate(0.10)  // 10% of salary
+ *         .incrementRate(0.01)     // +1% per year
+ *         .matchingPolicy(MatchingPolicy.simple(0.50, 0.06))
+ *         .build())
+ *     .routingConfig(RoutingConfiguration.builder()
+ *         .addRule("trad-401k", 0.70, 1)
+ *         .addRule("roth-401k", 0.30, 2)
+ *         .build())
+ *     .build();
+ * }</pre>
+ *
+ * @param contributionConfig the contribution settings (rate, increment, employer match)
+ * @param routingConfig      how contributions are routed across accounts
+ */
+public record PersonFinancialConfig(
+    ContributionConfig contributionConfig,
+    RoutingConfiguration routingConfig
+) {
+
+    /**
+     * Creates a PersonFinancialConfig with only contribution config.
+     *
+     * <p>Use this when routing is handled separately or defaults to single account.
+     *
+     * @param contributionConfig the contribution configuration
+     * @return a new PersonFinancialConfig
+     */
+    public static PersonFinancialConfig ofContribution(ContributionConfig contributionConfig) {
+        return new PersonFinancialConfig(contributionConfig, null);
+    }
+
+    /**
+     * Creates a PersonFinancialConfig with only routing config.
+     *
+     * <p>Use this when contribution amounts are calculated externally.
+     *
+     * @param routingConfig the routing configuration
+     * @return a new PersonFinancialConfig
+     */
+    public static PersonFinancialConfig ofRouting(RoutingConfiguration routingConfig) {
+        return new PersonFinancialConfig(null, routingConfig);
+    }
+
+    /**
+     * Returns true if contribution config is present.
+     *
+     * @return true if contributionConfig is not null
+     */
+    public boolean hasContributionConfig() {
+        return contributionConfig != null;
+    }
+
+    /**
+     * Returns true if routing config is present.
+     *
+     * @return true if routingConfig is not null
+     */
+    public boolean hasRoutingConfig() {
+        return routingConfig != null;
+    }
+
+    /**
+     * Creates a new builder for PersonFinancialConfig.
+     *
+     * @return a builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for PersonFinancialConfig.
+     */
+    public static class Builder {
+        private ContributionConfig contributionConfig;
+        private RoutingConfiguration routingConfig;
+
+        /**
+         * Sets the contribution configuration.
+         *
+         * @param config the contribution config
+         * @return this builder
+         */
+        public Builder contributionConfig(ContributionConfig config) {
+            this.contributionConfig = config;
+            return this;
+        }
+
+        /**
+         * Sets the routing configuration.
+         *
+         * @param config the routing config
+         * @return this builder
+         */
+        public Builder routingConfig(RoutingConfiguration config) {
+            this.routingConfig = config;
+            return this;
+        }
+
+        /**
+         * Builds the PersonFinancialConfig.
+         *
+         * @return a new PersonFinancialConfig
+         */
+        public PersonFinancialConfig build() {
+            return new PersonFinancialConfig(contributionConfig, routingConfig);
+        }
+    }
+}

--- a/src/test/java/io/github/xmljim/retirement/simulation/engine/ContributionRoutingIntegrationTest.java
+++ b/src/test/java/io/github/xmljim/retirement/simulation/engine/ContributionRoutingIntegrationTest.java
@@ -1,0 +1,167 @@
+package io.github.xmljim.retirement.simulation.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.github.xmljim.retirement.domain.enums.AccountType;
+import io.github.xmljim.retirement.domain.model.InvestmentAccount;
+import io.github.xmljim.retirement.domain.model.PersonProfile;
+import io.github.xmljim.retirement.domain.model.Portfolio;
+import io.github.xmljim.retirement.domain.value.RoutingConfiguration;
+import io.github.xmljim.retirement.simulation.config.PersonFinancialConfig;
+
+/**
+ * Tests for SimulationConfig with PersonFinancialConfig integration.
+ */
+@DisplayName("Contribution Routing Integration")
+class ContributionRoutingIntegrationTest {
+
+    private PersonProfile createPerson(String name) {
+        return PersonProfile.builder()
+            .name(name)
+            .dateOfBirth(LocalDate.of(1970, 6, 15))
+            .retirementDate(LocalDate.of(2035, 1, 1))
+            .lifeExpectancy(90)
+            .build();
+    }
+
+    private InvestmentAccount createAccount(String name, AccountType type) {
+        return InvestmentAccount.builder()
+            .id(UUID.randomUUID().toString())
+            .name(name)
+            .accountType(type)
+            .balance(new BigDecimal("100000"))
+            .preRetirementReturnRate(new BigDecimal("0.07"))
+            .postRetirementReturnRate(new BigDecimal("0.05"))
+            .build();
+    }
+
+    @Nested
+    @DisplayName("SimulationConfig with PersonFinancialConfig")
+    class SimulationConfigFinancialTests {
+
+        @Test
+        @DisplayName("should allow empty financial configs")
+        void shouldAllowEmptyFinancialConfigs() {
+            PersonProfile person = createPerson("Test Person");
+            InvestmentAccount account = createAccount("401k", AccountType.TRADITIONAL_401K);
+            Portfolio portfolio = Portfolio.builder().owner(person).addAccount(account).build();
+
+            SimulationConfig config = SimulationConfig.builder()
+                .portfolio(portfolio)
+                .startMonth(YearMonth.of(2025, 1))
+                .endMonth(YearMonth.of(2025, 12))
+                .build();
+
+            assertTrue(config.getFinancialConfig(person).isEmpty());
+        }
+
+        @Test
+        @DisplayName("should return financial config when set")
+        void shouldReturnFinancialConfigWhenSet() {
+            PersonProfile person = createPerson("Test Person");
+            InvestmentAccount account = createAccount("401k", AccountType.TRADITIONAL_401K);
+            Portfolio portfolio = Portfolio.builder().owner(person).addAccount(account).build();
+
+            RoutingConfiguration routingConfig = RoutingConfiguration.singleAccount(account.getId());
+            PersonFinancialConfig financialConfig = PersonFinancialConfig.builder()
+                .routingConfig(routingConfig)
+                .build();
+
+            SimulationConfig config = SimulationConfig.builder()
+                .portfolio(portfolio)
+                .startMonth(YearMonth.of(2025, 1))
+                .endMonth(YearMonth.of(2025, 12))
+                .addFinancialConfig(person, financialConfig)
+                .build();
+
+            assertTrue(config.getFinancialConfig(person).isPresent());
+            assertEquals(financialConfig, config.getFinancialConfig(person).orElseThrow());
+        }
+
+        @Test
+        @DisplayName("should support multiple persons with different configs")
+        void shouldSupportMultiplePersonsWithDifferentConfigs() {
+            PersonProfile person = createPerson("Test Person");
+            PersonProfile spouse = createPerson("Spouse");
+
+            InvestmentAccount account1 = createAccount("401k", AccountType.TRADITIONAL_401K);
+            InvestmentAccount account2 = createAccount("Spouse 401k", AccountType.TRADITIONAL_401K);
+
+            Portfolio portfolio1 = Portfolio.builder().owner(person).addAccount(account1).build();
+            Portfolio portfolio2 = Portfolio.builder().owner(spouse).addAccount(account2).build();
+
+            RoutingConfiguration routingConfig1 = RoutingConfiguration.singleAccount(account1.getId());
+            RoutingConfiguration routingConfig2 = RoutingConfiguration.singleAccount(account2.getId());
+
+            PersonFinancialConfig config1 = PersonFinancialConfig.builder()
+                .routingConfig(routingConfig1)
+                .build();
+            PersonFinancialConfig config2 = PersonFinancialConfig.builder()
+                .routingConfig(routingConfig2)
+                .build();
+
+            SimulationConfig config = SimulationConfig.builder()
+                .portfolios(List.of(portfolio1, portfolio2))
+                .startMonth(YearMonth.of(2025, 1))
+                .endMonth(YearMonth.of(2025, 12))
+                .addFinancialConfig(person, config1)
+                .addFinancialConfig(spouse, config2)
+                .build();
+
+            assertTrue(config.getFinancialConfig(person).isPresent());
+            assertTrue(config.getFinancialConfig(spouse).isPresent());
+            assertEquals(routingConfig1, config.getFinancialConfig(person).orElseThrow().routingConfig());
+            assertEquals(routingConfig2, config.getFinancialConfig(spouse).orElseThrow().routingConfig());
+        }
+
+        @Test
+        @DisplayName("should return empty for unknown person")
+        void shouldReturnEmptyForUnknownPerson() {
+            PersonProfile person = createPerson("Test Person");
+            PersonProfile unknown = createPerson("Unknown");
+
+            InvestmentAccount account = createAccount("401k", AccountType.TRADITIONAL_401K);
+            Portfolio portfolio = Portfolio.builder().owner(person).addAccount(account).build();
+
+            SimulationConfig config = SimulationConfig.builder()
+                .portfolio(portfolio)
+                .startMonth(YearMonth.of(2025, 1))
+                .endMonth(YearMonth.of(2025, 12))
+                .build();
+
+            assertTrue(config.getFinancialConfig(unknown).isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("PersonFinancialConfig")
+    class PersonFinancialConfigTests {
+
+        @Test
+        @DisplayName("should report hasRoutingConfig correctly")
+        void shouldReportHasRoutingConfig() {
+            InvestmentAccount account = createAccount("401k", AccountType.TRADITIONAL_401K);
+            RoutingConfiguration routingConfig = RoutingConfiguration.singleAccount(account.getId());
+
+            PersonFinancialConfig withRouting = PersonFinancialConfig.builder()
+                .routingConfig(routingConfig)
+                .build();
+
+            PersonFinancialConfig withoutRouting = PersonFinancialConfig.builder().build();
+
+            assertTrue(withRouting.hasRoutingConfig());
+            assertTrue(!withoutRouting.hasRoutingConfig());
+        }
+    }
+}

--- a/src/test/java/io/github/xmljim/retirement/simulation/state/SimulationStateTest.java
+++ b/src/test/java/io/github/xmljim/retirement/simulation/state/SimulationStateTest.java
@@ -566,4 +566,36 @@ class SimulationStateTest {
             assertEquals(new BigDecimal("200000.00"), account1Snapshot.balance());
         }
     }
+
+    @Nested
+    @DisplayName("Contribution Tracking")
+    class ContributionTrackingTests {
+
+        @Test
+        @DisplayName("depositToAccount should not affect cumulative contributions")
+        void depositToAccountShouldNotAffectCumulativeContributions() {
+            SimulationState state = new SimulationState(testAccounts);
+
+            state.depositToAccount(account1Id, new BigDecimal("1000"));
+
+            // depositToAccount is low-level and doesn't track cumulative contributions
+            assertEquals(BigDecimal.ZERO, state.getCumulativeContributions());
+        }
+
+        @Test
+        @DisplayName("getCumulativeContributions should start at zero")
+        void getCumulativeContributionsShouldStartAtZero() {
+            SimulationState state = new SimulationState(testAccounts);
+
+            assertEquals(BigDecimal.ZERO, state.getCumulativeContributions());
+        }
+
+        @Test
+        @DisplayName("getContributionTracker should return null when not initialized")
+        void getContributionTrackerShouldReturnNullWhenNotInitialized() {
+            SimulationState state = new SimulationState(testAccounts);
+
+            assertEquals(null, state.getContributionTracker());
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Creates `PersonFinancialConfig` record to bundle per-person `ContributionConfig` and `RoutingConfiguration`
- Refactors `SimulationConfig` to store per-person financial configs via `Map<String, PersonFinancialConfig>`
- Implements `executeContributions()` in `SimulationEngine` to route contributions during ACCUMULATION phase
- Adds `YTDContributionTracker` integration to `SimulationState` for IRS limit enforcement

## Changes
### New Files
- `PersonFinancialConfig.java` - Bundles per-person contribution and routing settings

### Modified Files
- `SimulationConfig.java` - Added `financialConfigs` map with `getFinancialConfig()` accessors
- `SimulationEngine.java` - Implemented `executeContributions()` using `ContributionRouter`
- `SimulationState.java` - Added YTD contribution tracking and cumulative contributions

### Test Files
- `ContributionRoutingIntegrationTest.java` - Tests for PersonFinancialConfig and SimulationConfig integration

## Note
Full `ContributionCalculator` integration for salary-based contribution calculation is pending `IncomeProcessor` providing gross salary amounts. Currently uses income as a placeholder.

## Test plan
- [x] Run ContributionRoutingIntegrationTest (5 tests pass)
- [x] Run SimulationConfigTest (15 tests pass)
- [x] Run SimulationEngineTest (14 tests pass)
- [x] Run SimulationStateTest (41 tests pass)
- [x] Checkstyle passes

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)